### PR TITLE
fix(bridge): double balances in network popup

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
@@ -251,7 +251,7 @@ function NetworkRow({
             </Tooltip>
           )}
 
-          {balanceState && (
+          {!isLoadingBalance && !balanceError && balanceState && (
             <Tooltip
               content={`${
                 nativeTokenData?.symbol ?? 'ETH'


### PR DESCRIPTION
The assumption was that the `balanceState` will be empty in case there's an error during fetch. But that doesn't seem to be the case.