### PR TITLE
feat: control buy tab using query params

### DIFF
--- a/packages/app/src/utils/sanitizeAndRedirect.ts
+++ b/packages/app/src/utils/sanitizeAndRedirect.ts
@@ -125,10 +125,10 @@ export async function sanitizeAndRedirect(
       destinationChainId: sanitizedChainIds.destinationChainId,
     }),
     tab: sanitizeTabQueryParam(tab, {
-      disabledFeatures: DisabledFeaturesParam.decode(disabledFeatures)
+      disabledFeatures: DisabledFeaturesParam.decode(disabledFeatures),
     }),
-    disabledFeatures: DisabledFeaturesParam.decode(disabledFeatures)
-  }
+    disabledFeatures: DisabledFeaturesParam.decode(disabledFeatures),
+  };
 
   // if the sanitized query params are different from the initial values, redirect to the url with sanitized query params
   if (

--- a/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
+++ b/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
@@ -2,23 +2,22 @@ import { Tab } from '@headlessui/react';
 import { useLocalStorage } from '@uidotdev/usehooks';
 import { Fragment, useCallback } from 'react';
 
-import { TransferPanel } from '../TransferPanel/TransferPanel'
-import { ArbitrumStats, statsLocalStorageKey } from './ArbitrumStats'
-import { SettingsDialog } from '../common/SettingsDialog'
-import { TransactionHistory } from '../TransactionHistory/TransactionHistory'
-import { TopNavBar } from '../TopNavBar'
-import { useBalanceUpdater } from '../syncers/useBalanceUpdater'
-import { useArbQueryParams } from '../../hooks/useArbQueryParams'
-import { useMode } from '../../hooks/useMode'
-import { RecoverFunds } from '../RecoverFunds'
-import { BuyPanel } from '../BuyPanel'
-import { isBuyFeatureEnabled } from '../../util/queryParamUtils'
+import { useArbQueryParams } from '../../hooks/useArbQueryParams';
+import { useMode } from '../../hooks/useMode';
+import { isBuyFeatureEnabled } from '../../util/queryParamUtils';
+import { BuyPanel } from '../BuyPanel';
+import { RecoverFunds } from '../RecoverFunds';
+import { TopNavBar } from '../TopNavBar';
+import { TransactionHistory } from '../TransactionHistory/TransactionHistory';
+import { TransferPanel } from '../TransferPanel/TransferPanel';
+import { SettingsDialog } from '../common/SettingsDialog';
+import { useBalanceUpdater } from '../syncers/useBalanceUpdater';
+import { ArbitrumStats, statsLocalStorageKey } from './ArbitrumStats';
 
 export function MainContent() {
-  const [isArbitrumStatsVisible] =
-    useLocalStorage<boolean>(statsLocalStorageKey)
-  const [{ tab, disabledFeatures }, setQueryParams] = useArbQueryParams()
-  const showBuyPanel = isBuyFeatureEnabled({ disabledFeatures })
+  const [isArbitrumStatsVisible] = useLocalStorage<boolean>(statsLocalStorageKey);
+  const [{ tab, disabledFeatures }, setQueryParams] = useArbQueryParams();
+  const showBuyPanel = isBuyFeatureEnabled({ disabledFeatures });
 
   const setSelectedTab = useCallback(
     (index: number) => {

--- a/packages/arb-token-bridge-ui/src/components/TopNavBar.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TopNavBar.tsx
@@ -1,11 +1,12 @@
-import { Tab } from '@headlessui/react'
-import { PaperAirplaneIcon, WalletIcon } from '@heroicons/react/24/outline'
-import { PropsWithChildren } from 'react'
-import { twMerge } from 'tailwind-merge'
-import Image from 'next/image'
-import { useTransactionReminderInfo } from './TransactionHistory/useTransactionReminderInfo'
-import { useArbQueryParams } from '../hooks/useArbQueryParams'
-import { isBuyFeatureEnabled } from '../util/queryParamUtils'
+import { Tab } from '@headlessui/react';
+import { PaperAirplaneIcon, WalletIcon } from '@heroicons/react/24/outline';
+import Image from 'next/image';
+import { PropsWithChildren } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { useArbQueryParams } from '../hooks/useArbQueryParams';
+import { isBuyFeatureEnabled } from '../util/queryParamUtils';
+import { useTransactionReminderInfo } from './TransactionHistory/useTransactionReminderInfo';
 
 function StyledTab({ children, ...props }: PropsWithChildren) {
   return (
@@ -21,9 +22,9 @@ function StyledTab({ children, ...props }: PropsWithChildren) {
 StyledTab.displayName = 'StyledTab';
 
 export function TopNavBar() {
-  const { colorClassName } = useTransactionReminderInfo()
-  const [{ disabledFeatures }] = useArbQueryParams()
-  const showBuyPanel = isBuyFeatureEnabled({ disabledFeatures })
+  const { colorClassName } = useTransactionReminderInfo();
+  const [{ disabledFeatures }] = useArbQueryParams();
+  const showBuyPanel = isBuyFeatureEnabled({ disabledFeatures });
 
   return (
     <Tab.List

--- a/packages/arb-token-bridge-ui/src/components/Widget/WidgetModeDropdown.tsx
+++ b/packages/arb-token-bridge-ui/src/components/Widget/WidgetModeDropdown.tsx
@@ -8,14 +8,10 @@ import {
 import { useCallback } from 'react';
 import { twMerge } from 'tailwind-merge';
 
-import { Button } from '../common/Button'
-import { Transition } from '../common/Transition'
-import {
-  useArbQueryParams,
-  TabParamEnum,
-  indexToTab
-} from '../../hooks/useArbQueryParams'
-import { isBuyFeatureEnabled } from '../../util/queryParamUtils'
+import { TabParamEnum, indexToTab, useArbQueryParams } from '../../hooks/useArbQueryParams';
+import { isBuyFeatureEnabled } from '../../util/queryParamUtils';
+import { Button } from '../common/Button';
+import { Transition } from '../common/Transition';
 
 interface ModeOptionProps {
   icon: React.ReactNode;
@@ -40,8 +36,8 @@ const ModeOption = ({ icon, label, isSelected, onClick }: ModeOptionProps) => {
 };
 
 export const WidgetModeDropdown = () => {
-  const [{ tab, disabledFeatures }, setQueryParams] = useArbQueryParams()
-  const showBuyPanel = isBuyFeatureEnabled({ disabledFeatures })
+  const [{ tab, disabledFeatures }, setQueryParams] = useArbQueryParams();
+  const showBuyPanel = isBuyFeatureEnabled({ disabledFeatures });
 
   const currentTab = indexToTab[tab as keyof typeof indexToTab] || TabParamEnum.BRIDGE;
 

--- a/packages/arb-token-bridge-ui/src/components/Widget/WidgetTransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/Widget/WidgetTransferPanel.tsx
@@ -1,26 +1,19 @@
-import { useAccount } from 'wagmi'
-import { twMerge } from 'tailwind-merge'
-import {
-  DialogProps,
-  DialogWrapper,
-  OpenDialogFunction
-} from '../common/Dialog2'
-import { WidgetHeaderRow } from './WidgetHeaderRow'
-import { WidgetRoutes } from './WidgetRoutes'
-import { MoveFundsButton } from '../TransferPanel/MoveFundsButton'
-import { WidgetConnectWalletButton } from './WidgetConnectWalletButton'
-import { TransferPanelMain } from '../TransferPanel/TransferPanelMain'
-import { BuyPanel } from '../BuyPanel'
-import { TokenImportDialog } from '../TransferPanel/TokenImportDialog'
-import { ToSConfirmationCheckbox } from '../TransferPanel/ToSConfirmationCheckbox'
-import { UseDialogProps } from '../common/Dialog'
-import { ReceiveFundsHeader } from '../TransferPanel/ReceiveFundsHeader'
-import {
-  useArbQueryParams,
-  indexToTab,
-  TabParamEnum
-} from '../../hooks/useArbQueryParams'
-import { isBuyFeatureEnabled } from '../../util/queryParamUtils'
+import { twMerge } from 'tailwind-merge';
+import { useAccount } from 'wagmi';
+
+import { TabParamEnum, indexToTab, useArbQueryParams } from '../../hooks/useArbQueryParams';
+import { isBuyFeatureEnabled } from '../../util/queryParamUtils';
+import { BuyPanel } from '../BuyPanel';
+import { MoveFundsButton } from '../TransferPanel/MoveFundsButton';
+import { ReceiveFundsHeader } from '../TransferPanel/ReceiveFundsHeader';
+import { ToSConfirmationCheckbox } from '../TransferPanel/ToSConfirmationCheckbox';
+import { TokenImportDialog } from '../TransferPanel/TokenImportDialog';
+import { TransferPanelMain } from '../TransferPanel/TransferPanelMain';
+import { UseDialogProps } from '../common/Dialog';
+import { DialogProps, DialogWrapper, OpenDialogFunction } from '../common/Dialog2';
+import { WidgetConnectWalletButton } from './WidgetConnectWalletButton';
+import { WidgetHeaderRow } from './WidgetHeaderRow';
+import { WidgetRoutes } from './WidgetRoutes';
 
 type WidgetTransferPanelProps = {
   moveFundsButtonOnClick: () => void;
@@ -41,9 +34,9 @@ export function WidgetTransferPanel({
   tokenImportDialogProps,
   closeWithResetTokenImportDialog,
 }: WidgetTransferPanelProps) {
-  const { isConnected } = useAccount()
-  const [{ tab, disabledFeatures }] = useArbQueryParams()
-  const showBuyPanel = isBuyFeatureEnabled({ disabledFeatures })
+  const { isConnected } = useAccount();
+  const [{ tab, disabledFeatures }] = useArbQueryParams();
+  const showBuyPanel = isBuyFeatureEnabled({ disabledFeatures });
 
   const currentTab = indexToTab[tab as keyof typeof indexToTab] || TabParamEnum.BRIDGE;
   const isBuyMode = currentTab === TabParamEnum.BUY;

--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/useArbQueryParams.test.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/useArbQueryParams.test.ts
@@ -5,20 +5,21 @@ import { ChainId } from '../../types/ChainId';
 import { isOnrampEnabled } from '../../util/featureFlag';
 import { customChainLocalStorageKey } from '../../util/networks';
 import {
+  TabParam,
+  decodeTabQueryParam,
+  encodeTabQueryParam,
+  getTabMappings,
+  isBuyFeatureEnabled,
   sanitizeTabQueryParam,
   sanitizeTokenQueryParam,
-  isBuyFeatureEnabled,
-  getTabMappings,
-  encodeTabQueryParam,
-  decodeTabQueryParam
-} from '../../util/queryParamUtils'
+} from '../../util/queryParamUtils';
 import {
   AmountQueryParam,
   ChainParam,
   DisabledFeatures,
-  DisabledFeaturesParam
-} from '../useArbQueryParams'
-import { createMockOrbitChain } from './helpers'
+  DisabledFeaturesParam,
+} from '../useArbQueryParams';
+import { createMockOrbitChain } from './helpers';
 
 vi.mock('../../util/featureFlag', () => ({
   isOnrampEnabled: vi.fn(),
@@ -413,9 +414,9 @@ describe.sequential('sanitizeTabQueryParam', () => {
     });
 
     it('should be kept if it is a valid tab string value', () => {
-      const result1 = sanitizeTabQueryParam('buy')
-      const result2 = sanitizeTabQueryParam('bridge')
-      const result3 = sanitizeTabQueryParam('tx_history')
+      const result1 = sanitizeTabQueryParam('buy');
+      const result2 = sanitizeTabQueryParam('bridge');
+      const result3 = sanitizeTabQueryParam('tx_history');
 
       expect(result1).toEqual('buy');
       expect(result2).toEqual('bridge');
@@ -423,10 +424,10 @@ describe.sequential('sanitizeTabQueryParam', () => {
     });
 
     it('should be case insensitive', () => {
-      const result1 = sanitizeTabQueryParam('BUY')
-      const result2 = sanitizeTabQueryParam('Buy')
-      const result3 = sanitizeTabQueryParam('TX_history')
-      const result4 = sanitizeTabQueryParam('Tx_HiStoRy')
+      const result1 = sanitizeTabQueryParam('BUY');
+      const result2 = sanitizeTabQueryParam('Buy');
+      const result3 = sanitizeTabQueryParam('TX_history');
+      const result4 = sanitizeTabQueryParam('Tx_HiStoRy');
 
       expect(result1).toEqual('buy');
       expect(result2).toEqual('buy');
@@ -435,10 +436,10 @@ describe.sequential('sanitizeTabQueryParam', () => {
     });
 
     it('should default to bridge if the value is invalid', () => {
-      const result1 = sanitizeTabQueryParam('0')
-      const result2 = sanitizeTabQueryParam('1')
-      const result3 = sanitizeTabQueryParam('3')
-      const result4 = sanitizeTabQueryParam('tx_HISTORY_')
+      const result1 = sanitizeTabQueryParam('0');
+      const result2 = sanitizeTabQueryParam('1');
+      const result3 = sanitizeTabQueryParam('3');
+      const result4 = sanitizeTabQueryParam('tx_HISTORY_');
 
       expect(result1).toEqual('bridge');
       expect(result2).toEqual('bridge');
@@ -454,18 +455,18 @@ describe.sequential('sanitizeTabQueryParam', () => {
     });
 
     it('should be kept if it is a valid tab string value', () => {
-      const result1 = sanitizeTabQueryParam('bridge')
-      const result2 = sanitizeTabQueryParam('tx_history')
+      const result1 = sanitizeTabQueryParam('bridge');
+      const result2 = sanitizeTabQueryParam('tx_history');
 
       expect(result1).toEqual('bridge');
       expect(result2).toEqual('tx_history');
     });
 
     it('should be case insensitive', () => {
-      const result1 = sanitizeTabQueryParam('Bridge')
-      const result2 = sanitizeTabQueryParam('BriDge')
-      const result3 = sanitizeTabQueryParam('TX_history')
-      const result4 = sanitizeTabQueryParam('Tx_HiStoRy')
+      const result1 = sanitizeTabQueryParam('Bridge');
+      const result2 = sanitizeTabQueryParam('BriDge');
+      const result3 = sanitizeTabQueryParam('TX_history');
+      const result4 = sanitizeTabQueryParam('Tx_HiStoRy');
 
       expect(result1).toEqual('bridge');
       expect(result2).toEqual('bridge');
@@ -474,10 +475,10 @@ describe.sequential('sanitizeTabQueryParam', () => {
     });
 
     it('should default to bridge if the value is invalid', () => {
-      const result1 = sanitizeTabQueryParam('0')
-      const result2 = sanitizeTabQueryParam('1')
-      const result3 = sanitizeTabQueryParam('3')
-      const result4 = sanitizeTabQueryParam('tx_HISTORY_')
+      const result1 = sanitizeTabQueryParam('0');
+      const result2 = sanitizeTabQueryParam('1');
+      const result3 = sanitizeTabQueryParam('3');
+      const result4 = sanitizeTabQueryParam('tx_HISTORY_');
 
       expect(result1).toEqual('bridge');
       expect(result2).toEqual('bridge');
@@ -547,177 +548,139 @@ describe('DisabledFeaturesParam', () => {
     });
 
     it('should handle invalid URL values', () => {
-      expect(DisabledFeaturesParam.decode('disabledFeatures=')).toEqual([])
-      expect(DisabledFeaturesParam.decode('?disabledFeatures=')).toEqual([])
-      expect(DisabledFeaturesParam.decode('randomInvalidValue')).toEqual([])
-    })
-  })
-})
+      expect(DisabledFeaturesParam.decode('disabledFeatures=')).toEqual([]);
+      expect(DisabledFeaturesParam.decode('?disabledFeatures=')).toEqual([]);
+      expect(DisabledFeaturesParam.decode('randomInvalidValue')).toEqual([]);
+    });
+  });
+});
 
 describe.sequential('Buy Feature Disabled Tests', () => {
   afterAll(() => {
-    vi.clearAllMocks()
-    vi.unstubAllEnvs()
-  })
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
 
   describe('isBuyFeatureEnabled', () => {
     it('should return true when onramp is enabled and buy is not disabled', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(true)
-      expect(isBuyFeatureEnabled({ disabledFeatures: [] })).toBe(true)
-      expect(
-        isBuyFeatureEnabled({ disabledFeatures: ['batch-transfers'] })
-      ).toBe(true)
-    })
+      vi.mocked(isOnrampEnabled).mockReturnValue(true);
+      expect(isBuyFeatureEnabled({ disabledFeatures: [] })).toBe(true);
+      expect(isBuyFeatureEnabled({ disabledFeatures: ['batch-transfers'] })).toBe(true);
+    });
 
     it('should return false when onramp is disabled', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(false)
-      expect(isBuyFeatureEnabled({ disabledFeatures: [] })).toBe(false)
-      expect(isBuyFeatureEnabled({ disabledFeatures: ['buy'] })).toBe(false)
-    })
+      vi.mocked(isOnrampEnabled).mockReturnValue(false);
+      expect(isBuyFeatureEnabled({ disabledFeatures: [] })).toBe(false);
+      expect(isBuyFeatureEnabled({ disabledFeatures: ['buy'] })).toBe(false);
+    });
 
     it('should return false when buy is disabled via query param', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(true)
-      expect(isBuyFeatureEnabled({ disabledFeatures: ['buy'] })).toBe(false)
-      expect(
-        isBuyFeatureEnabled({ disabledFeatures: ['buy', 'batch-transfers'] })
-      ).toBe(false)
-    })
+      vi.mocked(isOnrampEnabled).mockReturnValue(true);
+      expect(isBuyFeatureEnabled({ disabledFeatures: ['buy'] })).toBe(false);
+      expect(isBuyFeatureEnabled({ disabledFeatures: ['buy', 'batch-transfers'] })).toBe(false);
+    });
 
     it('should work with default empty object', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(true)
-      expect(isBuyFeatureEnabled()).toBe(true)
-      expect(isBuyFeatureEnabled({})).toBe(true)
-    })
-  })
+      vi.mocked(isOnrampEnabled).mockReturnValue(true);
+      expect(isBuyFeatureEnabled()).toBe(true);
+      expect(isBuyFeatureEnabled({})).toBe(true);
+    });
+  });
 
   describe('getTabMappings with disabled features', () => {
     it('should return 3-tab mapping when onramp enabled and buy not disabled', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(true)
-      const mappings = getTabMappings({ disabledFeatures: [] })
+      vi.mocked(isOnrampEnabled).mockReturnValue(true);
+      const mappings = getTabMappings({ disabledFeatures: [] });
       expect(mappings.tabToIndex).toEqual({
         buy: 0,
         bridge: 1,
-        tx_history: 2
-      })
+        tx_history: 2,
+      });
       expect(mappings.indexToTab).toEqual({
         0: 'buy',
         1: 'bridge',
-        2: 'tx_history'
-      })
-    })
+        2: 'tx_history',
+      });
+    });
 
     it('should return 2-tab mapping when buy is disabled', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(true)
-      const mappings = getTabMappings({ disabledFeatures: ['buy'] })
+      vi.mocked(isOnrampEnabled).mockReturnValue(true);
+      const mappings = getTabMappings({ disabledFeatures: ['buy'] });
       expect(mappings.tabToIndex).toEqual({
         bridge: 0,
-        tx_history: 1
-      })
+        tx_history: 1,
+      });
       expect(mappings.indexToTab).toEqual({
         0: 'bridge',
-        1: 'tx_history'
-      })
-    })
+        1: 'tx_history',
+      });
+    });
 
     it('should return 2-tab mapping when onramp is disabled', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(false)
-      const mappings = getTabMappings({ disabledFeatures: [] })
+      vi.mocked(isOnrampEnabled).mockReturnValue(false);
+      const mappings = getTabMappings({ disabledFeatures: [] });
       expect(mappings.tabToIndex).toEqual({
         bridge: 0,
-        tx_history: 1
-      })
+        tx_history: 1,
+      });
       expect(mappings.indexToTab).toEqual({
         0: 'bridge',
-        1: 'tx_history'
-      })
-    })
-  })
+        1: 'tx_history',
+      });
+    });
+  });
 
   describe('encodeTabQueryParam with disabled features', () => {
     it('should encode buy tab when buy is not disabled', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(true)
-      expect(encodeTabQueryParam({ tabIndex: 0, disabledFeatures: [] })).toBe(
-        'buy'
-      )
-      expect(encodeTabQueryParam({ tabIndex: 1, disabledFeatures: [] })).toBe(
-        'bridge'
-      )
-      expect(encodeTabQueryParam({ tabIndex: 2, disabledFeatures: [] })).toBe(
-        'tx_history'
-      )
-    })
+      vi.mocked(isOnrampEnabled).mockReturnValue(true);
+      expect(encodeTabQueryParam({ tabIndex: 0, disabledFeatures: [] })).toBe('buy');
+      expect(encodeTabQueryParam({ tabIndex: 1, disabledFeatures: [] })).toBe('bridge');
+      expect(encodeTabQueryParam({ tabIndex: 2, disabledFeatures: [] })).toBe('tx_history');
+    });
 
     it('should not encode buy tab when buy is disabled', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(true)
-      expect(
-        encodeTabQueryParam({ tabIndex: 0, disabledFeatures: ['buy'] })
-      ).toBe('bridge')
-      expect(
-        encodeTabQueryParam({ tabIndex: 1, disabledFeatures: ['buy'] })
-      ).toBe('tx_history')
-    })
-  })
+      vi.mocked(isOnrampEnabled).mockReturnValue(true);
+      expect(encodeTabQueryParam({ tabIndex: 0, disabledFeatures: ['buy'] })).toBe('bridge');
+      expect(encodeTabQueryParam({ tabIndex: 1, disabledFeatures: ['buy'] })).toBe('tx_history');
+    });
+  });
 
   describe('decodeTabQueryParam with disabled features', () => {
     it('should decode buy tab when buy is not disabled', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(true)
-      expect(decodeTabQueryParam({ tab: 'buy', disabledFeatures: [] })).toBe(0)
-      expect(decodeTabQueryParam({ tab: 'bridge', disabledFeatures: [] })).toBe(
-        1
-      )
-      expect(
-        decodeTabQueryParam({ tab: 'tx_history', disabledFeatures: [] })
-      ).toBe(2)
-    })
+      vi.mocked(isOnrampEnabled).mockReturnValue(true);
+      expect(decodeTabQueryParam({ tab: 'buy', disabledFeatures: [] })).toBe(0);
+      expect(decodeTabQueryParam({ tab: 'bridge', disabledFeatures: [] })).toBe(1);
+      expect(decodeTabQueryParam({ tab: 'tx_history', disabledFeatures: [] })).toBe(2);
+    });
 
     it('should redirect buy tab to bridge when buy is disabled', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(true)
-      expect(
-        decodeTabQueryParam({ tab: 'buy', disabledFeatures: ['buy'] })
-      ).toBe(0) // bridge index
-      expect(
-        decodeTabQueryParam({ tab: 'bridge', disabledFeatures: ['buy'] })
-      ).toBe(0)
-      expect(
-        decodeTabQueryParam({ tab: 'tx_history', disabledFeatures: ['buy'] })
-      ).toBe(1)
-    })
+      vi.mocked(isOnrampEnabled).mockReturnValue(true);
+      expect(decodeTabQueryParam({ tab: 'buy', disabledFeatures: ['buy'] })).toBe(0); // bridge index
+      expect(decodeTabQueryParam({ tab: 'bridge', disabledFeatures: ['buy'] })).toBe(0);
+      expect(decodeTabQueryParam({ tab: 'tx_history', disabledFeatures: ['buy'] })).toBe(1);
+    });
 
     it('should redirect buy tab to bridge when onramp is disabled', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(false)
-      expect(decodeTabQueryParam({ tab: 'buy', disabledFeatures: [] })).toBe(0) // bridge index
-      expect(decodeTabQueryParam({ tab: 'bridge', disabledFeatures: [] })).toBe(
-        0
-      )
-      expect(
-        decodeTabQueryParam({ tab: 'tx_history', disabledFeatures: [] })
-      ).toBe(1)
-    })
-  })
+      vi.mocked(isOnrampEnabled).mockReturnValue(false);
+      expect(decodeTabQueryParam({ tab: 'buy', disabledFeatures: [] })).toBe(0); // bridge index
+      expect(decodeTabQueryParam({ tab: 'bridge', disabledFeatures: [] })).toBe(0);
+      expect(decodeTabQueryParam({ tab: 'tx_history', disabledFeatures: [] })).toBe(1);
+    });
+  });
 
   describe('sanitizeTabQueryParam with disabled features', () => {
     it('should keep buy tab when buy is not disabled', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(true)
-      expect(sanitizeTabQueryParam('buy', { disabledFeatures: [] })).toBe('buy')
-      expect(sanitizeTabQueryParam('bridge', { disabledFeatures: [] })).toBe(
-        'bridge'
-      )
-      expect(
-        sanitizeTabQueryParam('tx_history', { disabledFeatures: [] })
-      ).toBe('tx_history')
-    })
+      vi.mocked(isOnrampEnabled).mockReturnValue(true);
+      expect(sanitizeTabQueryParam('buy', { disabledFeatures: [] })).toBe('buy');
+      expect(sanitizeTabQueryParam('bridge', { disabledFeatures: [] })).toBe('bridge');
+      expect(sanitizeTabQueryParam('tx_history', { disabledFeatures: [] })).toBe('tx_history');
+    });
 
     it('should default buy tab to bridge when buy is disabled', () => {
-      vi.mocked(isOnrampEnabled).mockReturnValue(true)
-      expect(sanitizeTabQueryParam('buy', { disabledFeatures: ['buy'] })).toBe(
-        'bridge'
-      )
-      expect(
-        sanitizeTabQueryParam('bridge', { disabledFeatures: ['buy'] })
-      ).toBe('bridge')
-      expect(
-        sanitizeTabQueryParam('tx_history', { disabledFeatures: ['buy'] })
-      ).toBe('tx_history')
-    })
-  })
-})
+      vi.mocked(isOnrampEnabled).mockReturnValue(true);
+      expect(sanitizeTabQueryParam('buy', { disabledFeatures: ['buy'] })).toBe('bridge');
+      expect(sanitizeTabQueryParam('bridge', { disabledFeatures: ['buy'] })).toBe('bridge');
+      expect(sanitizeTabQueryParam('tx_history', { disabledFeatures: ['buy'] })).toBe('tx_history');
+    });
+  });
+});

--- a/packages/arb-token-bridge-ui/src/util/queryParamUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/queryParamUtils.ts
@@ -39,14 +39,12 @@ export enum DisabledFeatures {
   TX_HISTORY = 'tx-history',
   NETWORK_SELECTION = 'network-selection',
   TRANSFERS_TO_NON_ARBITRUM_CHAINS = 'transfers-to-non-arbitrum-chains',
-  BUY = 'buy'
+  BUY = 'buy',
 }
 
-function createTabMappings({
-  disabledFeatures = []
-}: { disabledFeatures?: string[] } = {}) {
-  const isBuyDisabled = disabledFeatures.includes(DisabledFeatures.BUY)
-  const showBuyTab = isOnrampEnabled() && !isBuyDisabled
+function createTabMappings({ disabledFeatures = [] }: { disabledFeatures?: string[] } = {}) {
+  const isBuyDisabled = disabledFeatures.includes(DisabledFeatures.BUY);
+  const showBuyTab = isOnrampEnabled() && !isBuyDisabled;
 
   if (showBuyTab) {
     return {
@@ -76,14 +74,12 @@ function createTabMappings({
 }
 
 // Default tab mappings (used when disabled features are not available)
-export const { tabToIndex, indexToTab } = createTabMappings()
+export const { tabToIndex, indexToTab } = createTabMappings();
 
 // Function to get tab mappings with disabled features
-export const getTabMappings = ({
-  disabledFeatures = []
-}: { disabledFeatures?: string[] } = {}) => {
-  return createTabMappings({ disabledFeatures })
-}
+export const getTabMappings = ({ disabledFeatures = [] }: { disabledFeatures?: string[] } = {}) => {
+  return createTabMappings({ disabledFeatures });
+};
 
 export const isValidDisabledFeature = (feature: string) => {
   return Object.values(DisabledFeatures).includes(feature.toLowerCase() as DisabledFeatures);
@@ -183,12 +179,12 @@ export function decodeChainQueryParam(
 
 export function encodeTabQueryParam({
   tabIndex,
-  disabledFeatures = []
+  disabledFeatures = [],
 }: {
-  tabIndex: number | null | undefined
-  disabledFeatures?: string[]
+  tabIndex: number | null | undefined;
+  disabledFeatures?: string[];
 }): string {
-  const { indexToTab: _indexToTab } = createTabMappings({ disabledFeatures })
+  const { indexToTab: _indexToTab } = createTabMappings({ disabledFeatures });
   if (typeof tabIndex === 'number' && tabIndex in _indexToTab) {
     const tabParam = _indexToTab[tabIndex as keyof typeof _indexToTab];
     if (tabParam !== undefined) {
@@ -200,16 +196,16 @@ export function encodeTabQueryParam({
 
 export function decodeTabQueryParam({
   tab,
-  disabledFeatures = []
+  disabledFeatures = [],
 }: {
-  tab: string | (string | null)[] | null | undefined
-  disabledFeatures?: string[]
+  tab: string | (string | null)[] | null | undefined;
+  disabledFeatures?: string[];
 }): number {
-  const { tabToIndex: _tabToIndex } = createTabMappings({ disabledFeatures })
+  const { tabToIndex: _tabToIndex } = createTabMappings({ disabledFeatures });
   if (typeof tab === 'string') {
-    const isBuyDisabled = disabledFeatures.includes(DisabledFeatures.BUY)
+    const isBuyDisabled = disabledFeatures.includes(DisabledFeatures.BUY);
     if (tab === TabParamEnum.BUY && (!isOnrampEnabled() || isBuyDisabled)) {
-      return _tabToIndex[TabParamEnum.BRIDGE]
+      return _tabToIndex[TabParamEnum.BRIDGE];
     }
 
     if (tab in _tabToIndex) {
@@ -348,18 +344,16 @@ export const ChainParam = {
 };
 
 export const TabParam = {
-  encode: (tabIndex: number | null | undefined) =>
-    encodeTabQueryParam({ tabIndex }),
-  decode: (tab: string | (string | null)[] | null | undefined) =>
-    decodeTabQueryParam({ tab })
-}
+  encode: (tabIndex: number | null | undefined) => encodeTabQueryParam({ tabIndex }),
+  decode: (tab: string | (string | null)[] | null | undefined) => decodeTabQueryParam({ tab }),
+};
 
 export const isBuyFeatureEnabled = ({
-  disabledFeatures = []
+  disabledFeatures = [],
 }: { disabledFeatures?: string[] } = {}) => {
   // Buy feature is enabled if onramp is enabled in .env, and buy is not disabled in the query params
-  return isOnrampEnabled() && !disabledFeatures.includes(DisabledFeatures.BUY)
-}
+  return isOnrampEnabled() && !disabledFeatures.includes(DisabledFeatures.BUY);
+};
 
 const cache: Record<
   string,
@@ -557,12 +551,12 @@ export const sanitizeTokenQueryParam = ({
 
 export const sanitizeTabQueryParam = (
   tab: string | string[] | null | undefined,
-  { disabledFeatures = [] }: { disabledFeatures?: string[] } = {}
+  { disabledFeatures = [] }: { disabledFeatures?: string[] } = {},
 ): string => {
   if (typeof tab === 'string') {
     const lowercasedTab = tab.toLowerCase();
 
-    const { tabToIndex: _tabToIndex } = createTabMappings({ disabledFeatures })
+    const { tabToIndex: _tabToIndex } = createTabMappings({ disabledFeatures });
 
     if (Object.keys(_tabToIndex).includes(lowercasedTab)) {
       return lowercasedTab;


### PR DESCRIPTION
- In addition to the onramp feature being controlled at the application level using `.env`, we also want to control it using the `disabledFeatures` query param so that it can be controlled in embed mode depending on client needs.