### PR TITLE
fix: tx history issues by reducing RPC calls (rpc-lite mode)

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistoryDisclaimer.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistoryDisclaimer.tsx
@@ -1,11 +1,14 @@
 import { useMemo } from 'react';
 import { useAccount } from 'wagmi';
 
+import { FETCH_SELECTED_NETWORK_TX_HISTORY_ONLY } from '../../constants';
 import { useAccountType } from '../../hooks/useAccountType';
 import { useBalance } from '../../hooks/useBalance';
 import { useLifiTransactionHistory } from '../../hooks/useLifiTransactionHistory';
+import { useNetworks } from '../../hooks/useNetworks';
 import { ChainId } from '../../types/ChainId';
 import { CommonAddress } from '../../util/CommonAddressUtils';
+import { getBridgeUiConfigForChain } from '../../util/bridgeUiConfig';
 import { ExternalLink } from '../common/ExternalLink';
 
 export const highlightTransactionHistoryDisclaimer = () => {
@@ -23,6 +26,7 @@ export const highlightTransactionHistoryDisclaimer = () => {
 export function TransactionHistoryDisclaimer() {
   const { address: walletAddress } = useAccount();
   const { accountType } = useAccountType();
+  const [networks] = useNetworks();
   const { data: lifiTransactions } = useLifiTransactionHistory({
     walletAddress,
   });
@@ -54,76 +58,95 @@ export function TransactionHistoryDisclaimer() {
   const showLifiDisclaimer =
     accountType === 'smart-contract-wallet' || (lifiTransactions && lifiTransactions.length > 0);
 
-  if (!showOftDisclaimer && !showLifiDisclaimer) {
+  const showSelectedNetworkWarning = FETCH_SELECTED_NETWORK_TX_HISTORY_ONLY;
+  const sourceNetworkName = getBridgeUiConfigForChain(networks.sourceChain.id).network.name;
+  const destinationNetworkName = getBridgeUiConfigForChain(networks.destinationChain.id).network
+    .name;
+
+  if (!showOftDisclaimer && !showLifiDisclaimer && !showSelectedNetworkWarning) {
     return null;
   }
 
   return (
     <div
-      className="flex flex-col gap-2 rounded-md bg-blue/20 p-2 text-sm text-white"
+      className={'flex flex-col gap-2 rounded-md bg-blue/20 p-2 text-sm text-white'}
       id="tx-history-disclaimer"
     >
-      <span className="font-bold">Don&apos;t see your transaction?</span>
-      <ul className="list-disc pl-4">
-        {showLifiDisclaimer &&
-          (lifiTransactions && lifiTransactions.length > 0 ? (
-            <li>
-              LiFi transactions can be found on{' '}
-              <ExternalLink
-                href={
-                  walletAddress
-                    ? `https://scan.li.fi/wallet/${walletAddress}`
-                    : 'https://scan.li.fi'
-                }
-                className="arb-hover inline-flex underline"
-              >
-                LifiScanner
-              </ExternalLink>
-              .
-            </li>
-          ) : (
-            <li>
-              LiFi transactions inititated by Smart-contract wallets can be found on{' '}
-              <ExternalLink
-                href={
-                  walletAddress
-                    ? `https://arbiscan.io/address/${walletAddress}`
-                    : 'https://arbiscan.io'
-                }
-                className="arb-hover inline-flex underline"
-              >
-                Arbiscan
-              </ExternalLink>
-              .
-            </li>
-          ))}
-        {showOftDisclaimer && (
-          <li>
-            LayerZero USDT transfers initiated by Smart-contract wallets can be found on{' '}
-            <ExternalLink
-              href={
-                walletAddress
-                  ? `https://etherscan.io/address/${walletAddress}`
-                  : 'https://etherscan.io'
-              }
-            >
-              Etherscan
-            </ExternalLink>{' '}
-            and{' '}
-            <ExternalLink
-              href={
-                walletAddress
-                  ? `https://arbiscan.io/address/${walletAddress}`
-                  : 'https://arbiscan.io'
-              }
-            >
-              Arbiscan
-            </ExternalLink>
-            .
-          </li>
-        )}
-      </ul>
-      <span className="pl-4">Full integration of transactions history is coming soon.</span>
+      {showSelectedNetworkWarning && (
+        <p>
+          Due to increased load, transaction history is only being shown for the network pair that
+          you&apos;ve selected in the Bridge tab. ie.{' '}
+          <span className="font-bold">{sourceNetworkName}</span> and{' '}
+          <span className="font-bold">{destinationNetworkName}</span>. Please select other networks
+          to view their transactions while our team works on a solution.
+        </p>
+      )}
+
+      {!showSelectedNetworkWarning && (
+        <>
+          <span className="font-bold">Don&apos;t see your transaction?</span>
+          <ul className="list-disc pl-4">
+            {showLifiDisclaimer &&
+              (lifiTransactions && lifiTransactions.length > 0 ? (
+                <li>
+                  LiFi transactions can be found on{' '}
+                  <ExternalLink
+                    href={
+                      walletAddress
+                        ? `https://scan.li.fi/wallet/${walletAddress}`
+                        : 'https://scan.li.fi'
+                    }
+                    className="arb-hover inline-flex underline"
+                  >
+                    LifiScanner
+                  </ExternalLink>
+                  .
+                </li>
+              ) : (
+                <li>
+                  LiFi transactions inititated by Smart-contract wallets can be found on{' '}
+                  <ExternalLink
+                    href={
+                      walletAddress
+                        ? `https://arbiscan.io/address/${walletAddress}`
+                        : 'https://arbiscan.io'
+                    }
+                    className="arb-hover inline-flex underline"
+                  >
+                    Arbiscan
+                  </ExternalLink>
+                  .
+                </li>
+              ))}
+            {showOftDisclaimer && (
+              <li>
+                LayerZero USDT transfers initiated by Smart-contract wallets can be found on{' '}
+                <ExternalLink
+                  href={
+                    walletAddress
+                      ? `https://etherscan.io/address/${walletAddress}`
+                      : 'https://etherscan.io'
+                  }
+                >
+                  Etherscan
+                </ExternalLink>{' '}
+                and{' '}
+                <ExternalLink
+                  href={
+                    walletAddress
+                      ? `https://arbiscan.io/address/${walletAddress}`
+                      : 'https://arbiscan.io'
+                  }
+                >
+                  Arbiscan
+                </ExternalLink>
+                .
+              </li>
+            )}
+          </ul>
+          <span className="pl-4">Full integration of transactions history is coming soon.</span>
+        </>
+      )}
     </div>
   );
 }

--- a/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
@@ -1,6 +1,6 @@
 import {
   ChevronDownIcon,
-  ExclamationCircleIcon,
+  // ExclamationCircleIcon,
   ShieldExclamationIcon,
 } from '@heroicons/react/24/outline';
 import { useDebounce } from '@uidotdev/usehooks';
@@ -16,11 +16,11 @@ import { DisabledFeatures, useArbQueryParams } from '../../hooks/useArbQueryPara
 import { useDisabledFeatures } from '../../hooks/useDisabledFeatures';
 import { useIsTestnetMode } from '../../hooks/useIsTestnetMode';
 import { useMode } from '../../hooks/useMode';
-import { useNativeCurrencyBalanceForChainId } from '../../hooks/useNativeCurrencyBalanceForChainId';
+// import { useNativeCurrencyBalanceForChainId } from '../../hooks/useNativeCurrencyBalanceForChainId';
 import { useNetworks } from '../../hooks/useNetworks';
 import { useSelectedToken } from '../../hooks/useSelectedToken';
 import { ChainId } from '../../types/ChainId';
-import { formatAmount } from '../../util/NumberUtils';
+// import { formatAmount } from '../../util/NumberUtils';
 import { getBridgeUiConfigForChain } from '../../util/bridgeUiConfig';
 import { getNetworkName, isNetwork } from '../../util/networks';
 import { getWagmiChain } from '../../util/wagmi/getWagmiChain';
@@ -34,7 +34,8 @@ import { SearchPanel } from './SearchPanel/SearchPanel';
 import { SearchPanelTable } from './SearchPanel/SearchPanelTable';
 import { TestnetToggle } from './TestnetToggle';
 import { Tooltip } from './Tooltip';
-import { Loader } from './atoms/Loader';
+
+// import { Loader } from './atoms/Loader';
 
 type NetworkType = 'core' | 'more' | 'orbit';
 
@@ -175,11 +176,11 @@ function NetworkRow({
   const { network, nativeTokenData } = getBridgeUiConfigForChain(chainId);
   const chain = getWagmiChain(chainId);
   const { address: walletAddress } = useAccount();
-  const {
-    data: balanceState,
-    isLoading: isLoadingBalance,
-    error: balanceError,
-  } = useNativeCurrencyBalanceForChainId(chainId, walletAddress);
+  // const {
+  //   data: balanceState,
+  //   isLoading: isLoadingBalance,
+  //   error: balanceError,
+  // } = useNativeCurrencyBalanceForChainId(chainId, walletAddress);
 
   function handleClick() {
     onClick(chain);
@@ -209,7 +210,7 @@ function NetworkRow({
             </Tooltip>
           )}
 
-          {isLoadingBalance && <Loader size="small" />}
+          {/* {isLoadingBalance && <Loader size="small" />}
 
           {!isLoadingBalance && balanceError && (
             <Tooltip content="Error fetching balance">
@@ -227,7 +228,7 @@ function NetworkRow({
                 symbol: balanceState.symbol,
               })}
             </Tooltip>
-          )}
+          )} */}
         </p>
       </div>
     </button>

--- a/packages/arb-token-bridge-ui/src/constants.ts
+++ b/packages/arb-token-bridge-ui/src/constants.ts
@@ -31,3 +31,6 @@ export const ETHER_TOKEN_LOGO = '/images/EthereumLogoRound.svg';
 export const ether = { name: 'Ether', symbol: 'ETH', decimals: 18 } as const;
 
 export const PORTAL_API_ENDPOINT = 'https://portal.arbitrum.io';
+
+// Transaction History Configuration
+export const FETCH_SELECTED_NETWORK_TX_HISTORY_ONLY = true;


### PR DESCRIPTION
-  Removes Balance fetches for all chains in Netwrok Selection Popup.
- Adds a flag based feature in tx history, where for the time being, only txns of the selected chain pair are fetched, reducing load on other alchemy chains