### PR TITLE
chore: re-enable monitoring

### DIFF
--- a/.github/workflows/retryable-monitor.yml
+++ b/.github/workflows/retryable-monitor.yml
@@ -3,7 +3,7 @@ name: Retryable Monitor
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */6 * * *' # Run every 6 hours
+    - cron: '3 8 * * *' # Run once a day at 08:03am GMT
 
 jobs:
   run-retryable-monitoring:


### PR DESCRIPTION
Moves monitoring back to this repo

- [x] Add slack `.env` in this branch
- [x] Merge this PR
- [x] Wait for 1-2 runs 
- [ ] Disable monitoring in other public https://github.com/OffchainLabs/arbitrum-token-bridge/pull/2654
