### PR TITLE
feat: remove ARB extra label

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenRow.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenRow.tsx
@@ -194,16 +194,6 @@ function useTokenInfo(token: ERC20BridgeToken | null) {
     return token.listIds.has(SPECIAL_ARBITRUM_TOKEN_TOKEN_LIST_ID);
   }, [token]);
 
-  const isPotentialFakeArbitrumToken = useMemo(() => {
-    if (!token || isArbitrumToken) {
-      return false;
-    }
-
-    return (
-      token.name.toLowerCase().startsWith('arb') || token.symbol.toLowerCase().startsWith('arb')
-    );
-  }, [token, isArbitrumToken]);
-
   const isBridgeable = useMemo(() => {
     if (!token) {
       return true;
@@ -226,7 +216,6 @@ function useTokenInfo(token: ERC20BridgeToken | null) {
     logoURI,
     balance,
     isArbitrumToken,
-    isPotentialFakeArbitrumToken,
     isBridgeable,
   };
 }


### PR DESCRIPTION
show token without label other than when on Ethereum<->Arbitrum One
<img width="582" height="354" alt="image" src="https://github.com/user-attachments/assets/63eeb180-d71e-4e72-9b6b-cb065d5bc0c6" />
