### PR TITLE
build(deps): bump nextjs

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -7,7 +7,7 @@
     "@arbitrum/sdk": "^4.0.3",
     "@rainbow-me/rainbowkit": "^2.2.4",
     "dayjs": "^1.11.13",
-    "next": "^14.2.34",
+    "next": "^14.2.35",
     "posthog-js": "^1.273.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -32,7 +32,7 @@
     "exponential-backoff": "^3.1.2",
     "graphql": "^16.10.0",
     "lodash-es": "^4.17.21",
-    "next": "^14.2.34",
+    "next": "^14.2.35",
     "next-query-params": "^5.1.0",
     "overmind": "^28.0.1",
     "overmind-react": "^29.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10310,7 +10310,7 @@ next-query-params@^5.1.0:
   dependencies:
     tslib "^2.0.3"
 
-next@^14.2.34:
+next@^14.2.35:
   version "14.2.35"
   resolved "https://registry.yarnpkg.com/next/-/next-14.2.35.tgz#7c68873a15fe5a19401f2f993fea535be3366ee9"
   integrity sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==


### PR DESCRIPTION
- https://nextjs.org/blog/security-update-2025-12-11
- https://react.dev/blog/2025/12/11/denial-of-service-and-source-code-exposure-in-react-server-components

Findings:
1. React 18.3.1 is not affected. The vulnerabilities (CVE-2025-55184, CVE-2025-55183, CVE-2025-67779) affect React 19 (19.0.0–19.2.2).
2. Next.js bundles its own react-server-dom packages. Next.js 14.2.35 includes the patches.
3. The Next.js security advisory confirms that Next.js 14.2.35 fixes these issues for Next.js 14.x applications.

Current status:
1. Next.js: ^14.2.35 (patched)
2. React: ^18.3.1 (not affected)
3. React-dom: ^18.3.1 (not affected)