### PR TITLE
fix(portal): update og image absolute url

### DIFF
--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -3,13 +3,13 @@ import { PropsWithChildren } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import { unica } from '@/bridge/components/common/Font';
-import { PORTAL_DATA_ENDPOINT } from '@/common/constants';
+import { PORTAL_DOMAIN } from '@/bridge/constants';
 
 import { BodyClassSyncer } from '../components/BodyClassSyncer';
 import '../styles/common.css';
 
 export const metadata: Metadata = {
-  metadataBase: new URL(PORTAL_DATA_ENDPOINT),
+  metadataBase: new URL(PORTAL_DOMAIN),
   icons: {
     icon: '/logo.png',
   },


### PR DESCRIPTION
It was reported that OG images are not showing up in previews for portal.arbitrum.io. Turns out it was trying to fetch the OG images from `portal-data` instead of the Portal frontend, where these images are actually present. 