### PR TITLE
feat: hide live incentives when empty

### DIFF
--- a/packages/portal/components/HomePage/LiveIncentivesProjects.tsx
+++ b/packages/portal/components/HomePage/LiveIncentivesProjects.tsx
@@ -31,7 +31,7 @@ export function LiveIncentivesProjects() {
   );
 
   if (projectsWithLiveIncentives.length === 0) {
-    return null
+    return null;
   }
 
   const carouselOptions: FlickityOptions = {


### PR DESCRIPTION
currently on prod:
<img width="1335" height="619" alt="image" src="https://github.com/user-attachments/assets/1cb2421d-3a3e-476f-a8c7-06af39a62c8f" />
