### PR TITLE
chore: add more code style rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,9 @@ See `tsconfig.base.json` for the full list.
 - Prettier with `@offchainlabs/prettier-config` + Tailwind CSS plugin + import sorting
 - ESLint with `@offchainlabs/eslint-config-typescript` (base + next)
 - Zustand rules enforced: `enforce-use-setstate`, `no-state-mutation`, `use-store-selectors`
-- **Use `twMerge`** for combining class names — do not use template literal className concatenation (e.g., `` className={`foo ${bar}`} ``). Use `twMerge()` to merge Tailwind classes safely.
-- **`useMemo` only for expensive computations** — do not memoize trivially cheap values (simple strings, booleans, shallow object literals). Reserve `useMemo` for genuinely expensive derivations.
-- **Object params for functions with many args** — when a function takes 3+ parameters, use a single options/params object instead of positional arguments for readability.
+- **Prefer `twMerge`** over template literal className concatenation in new code. Do not refactor existing usages unprompted.
+- **Avoid unnecessary `useMemo`** — reserve for expensive derivations or stabilizing referential identity. Don't memoize simple strings, booleans, or pass-through values.
+- **Object params for 4+ args** — use an object when a function has 4+ parameters, multiple optional params, or ambiguous positional args of similar types.
 
 ## Testing and Quality Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,9 @@ See `tsconfig.base.json` for the full list.
 - Prettier with `@offchainlabs/prettier-config` + Tailwind CSS plugin + import sorting
 - ESLint with `@offchainlabs/eslint-config-typescript` (base + next)
 - Zustand rules enforced: `enforce-use-setstate`, `no-state-mutation`, `use-store-selectors`
+- **Use `twMerge`** for combining class names — do not use template literal className concatenation (e.g., `` className={`foo ${bar}`} ``). Use `twMerge()` to merge Tailwind classes safely.
+- **`useMemo` only for expensive computations** — do not memoize trivially cheap values (simple strings, booleans, shallow object literals). Reserve `useMemo` for genuinely expensive derivations.
+- **Object params for functions with many args** — when a function takes 3+ parameters, use a single options/params object instead of positional arguments for readability.
 
 ## Testing and Quality Checklist
 


### PR DESCRIPTION
Adding these rules after learning from another PR review as agents tend to deviate from existing patterns
1. Using `twMerge()`
2. Using `useMemo` cautiously
3. Using typed objects instead of long chain function arguments