### PR TITLE
build(deps): bump hono to 4.12.12 to fix audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "**/flatted": "3.4.2",
     "**/defu": "6.1.6",
     "**/brace-expansion": "1.1.13",
-    "@typescript-eslint/**/brace-expansion": "5.0.5"
+    "@typescript-eslint/**/brace-expansion": "5.0.5",
+    "**/hono": "4.12.12"
   },
   "keywords": [],
   "author": "",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9265,10 +9265,10 @@ hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.2:
   dependencies:
     react-is "^16.7.0"
 
-hono@^4.10.3:
-  version "4.12.7"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.7.tgz#ca000956e965c2b3d791e43540498e616d6c6442"
-  integrity sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==
+hono@4.12.12, hono@^4.10.3:
+  version "4.12.12"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.12.tgz#1f14b0ffb47c386ff50d457d66e706d9c9a7f09c"
+  integrity sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==
 
 hpack.js@^2.1.6:
   version "2.1.6"


### PR DESCRIPTION
Adds a `**/hono` resolution to fix 5 moderate security advisories (GHSA-26pp-8wgv-hjvm, GHSA-r5rp-j6wh-rvv4, GHSA-xpcf-pg52-r92g, GHSA-xf4j-xp2r-rqqx, GHSA-wmmm-f939-6g9c) in the transitive dependency chain wagmi > @wagmi/connectors > porto > hono.

Closing https://github.com/OffchainLabs/arbitrum-portal/pull/256