### PR TITLE
build(deps): bump follow-redirects to 1.16.0 to fix audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "**/defu": "6.1.6",
     "**/brace-expansion": "1.1.13",
     "@typescript-eslint/**/brace-expansion": "5.0.5",
-    "**/hono": "4.12.12"
+    "**/hono": "4.12.12",
+    "**/follow-redirects": "1.16.0"
   },
   "keywords": [],
   "author": "",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8508,10 +8508,10 @@ flickity@2.3.0:
     unidragger "^2.4.0"
     unipointer "^2.4.0"
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.11:
-  version "1.15.11"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+follow-redirects@1.16.0, follow-redirects@^1.0.0, follow-redirects@^1.15.11:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"


### PR DESCRIPTION
## Summary

- Adds yarn resolution for `follow-redirects` to 1.16.0 to fix GHSA-r4q5-vmmm-2653

### Advisory Details

| Advisory | Package | Severity | Strategy |
|----------|---------|----------|----------|
| [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653) | follow-redirects | moderate | Bump to 1.16.0 via resolution |

**GHSA-r4q5-vmmm-2653**: follow-redirects leaks custom authentication headers (e.g. `X-API-Key`, `X-Auth-Token`) to cross-domain redirect targets. The library only strips `authorization`, `proxy-authorization`, and `cookie` headers during cross-domain redirects, but custom auth headers are forwarded verbatim.

Dependency chain: `app > axios > follow-redirects`

## Test plan

- [x] `yarn audit:ci` passes (exit code 0)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)