### PR TITLE
fix(monitoring): resolve circular import in chain generation

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/__tests__/orbitChainsList.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/__tests__/orbitChainsList.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { getOrbitChains, orbitMainnets, orbitTestnets } from '../orbitChainsList';
+
+describe('getOrbitChains', () => {
+  it('returns a non-empty list of orbit chains by default', () => {
+    // Regression guard: if a circular import appears or if the function is not run as expected, this call throws at module init.
+    const chains = getOrbitChains();
+    expect(chains.length).toBeGreaterThan(0);
+  });
+
+  it('returns mainnet chains only when testnet is disabled', () => {
+    const chains = getOrbitChains({ mainnet: true, testnet: false });
+    const testnetIds = Object.keys(orbitTestnets).map(Number);
+
+    expect(chains.length).toBe(Object.keys(orbitMainnets).length);
+    expect(chains.some((chain) => testnetIds.includes(chain.chainId))).toBe(false);
+  });
+
+  it('returns testnet chains only when mainnet is disabled', () => {
+    const chains = getOrbitChains({ mainnet: false, testnet: true });
+    const mainnetIds = Object.keys(orbitMainnets).map(Number);
+
+    expect(chains.length).toBe(Object.keys(orbitTestnets).length);
+    expect(chains.some((chain) => mainnetIds.includes(chain.chainId))).toBe(false);
+  });
+
+  it('returns fields required by the monitoring script on every chain', () => {
+    // The generateOrbitChainsToMonitor script reads these fields off each chain.
+    const chains = getOrbitChains({ mainnet: true, testnet: false });
+
+    for (const chain of chains) {
+      expect(typeof chain.chainId).toBe('number');
+      expect(typeof chain.rpcUrl).toBe('string');
+      expect(chain.rpcUrl.length).toBeGreaterThan(0);
+      expect(typeof chain.ethBridge?.inbox).toBe('string');
+    }
+  });
+});

--- a/packages/arb-token-bridge-ui/src/util/orbitChainsList.ts
+++ b/packages/arb-token-bridge-ui/src/util/orbitChainsList.ts
@@ -1,16 +1,8 @@
-import { NativeCurrencyBase } from '../hooks/useNativeCurrency';
+import type { NativeCurrencyBase } from '../hooks/useNativeCurrency';
 import { ChainId } from '../types/ChainId';
-import { addressesEqual } from './AddressUtils';
 import { isE2eTestingEnvironment } from './CommonUtils';
-import { ChainWithRpcUrl } from './networks';
+import type { ChainWithRpcUrl } from './networks';
 import orbitChainsData from './orbitChainsData.json';
-
-export type NetworkType =
-  | 'Ethereum'
-  | 'Rollup'
-  | 'AnyTrust'
-  | 'Ethereum Testnet'
-  | 'Arbitrum Testnet';
 
 export type BridgeUiConfig = {
   color: `#${string}`;
@@ -76,14 +68,5 @@ export function getOrbitChains(
 }
 
 export function getInboxAddressFromOrbitChainId(chainId: number) {
-  return (
-    getOrbitChains()
-      //
-      .find((chain) => chain.chainId === chainId)?.ethBridge.inbox
-  );
-}
-
-export function getChainIdFromInboxAddress(inboxAddress: string) {
-  return getOrbitChains().find((chain) => addressesEqual(chain.ethBridge.inbox, inboxAddress))
-    ?.chainId;
+  return getOrbitChains().find((chain) => chain.chainId === chainId)?.ethBridge.inbox;
 }


### PR DESCRIPTION
 ## What broke                                                                                           
                                                                                                         
  `yarn workspace arb-token-bridge-ui generateOrbitChainsToMonitor` fails at module init with:            
                                                                                                          
```  
ReferenceError: Cannot access 'CommonUtils_1' before initialization                                     
    at getOrbitChains (src/util/orbitChainsList.ts:67)                                                    
    at TokenListUtils.ts:129                                                                              
 ```                                                                                                         
  This blocks monitoring-data generation. It started failing after #238.
                                                                                                          
  ## Why                                 
                                                                                                          
  #238 had a small incidental change in `TokenListUtils.ts`: a JSON import was swapped for a top-level    
  call to `getOrbitChains()`. That function lives on the other side of a pre-existing import cycle:
                                                                                                          
  TokenListUtils → orbitChainsList → AddressUtils → ... → TokenListUtils                                  
   
  During init, `getOrbitChains()` runs before `orbitChainsList` finishes importing `CommonUtils` — so     
  `isE2eTestingEnvironment` is still in the TDZ. Next.js's bundler hides this; ts-node doesn't.           
   
  ## Fix (one file, +2 / -19)                                                                             
                                         
  In `orbitChainsList.ts`:                                                                                
   
  - Convert `NativeCurrencyBase` and `ChainWithRpcUrl` to `import type` — they were always types, and     
  eliding them at runtime breaks the cycle.
  - Delete `getChainIdFromInboxAddress` (0 importers). This also drops the `AddressUtils` import, removing
   the other runtime path back into the cycle.                                                            
  - Delete `NetworkType` (0 importers).
                                                                                                          
  No other files changed.                                                                                 
   
  ## Regression guard                                                                                     
                                         
  Added `__tests__/orbitChainsList.test.ts` with 4 cases:

  - Calls `getOrbitChains()` — if a cycle reappears, the test file fails at collect time with the same    
  error the monitoring script would hit (verified by reverting the fix).
  - Mainnet-only and testnet-only filter correctness.                                                     
  - Every returned chain has the fields the monitoring script reads (`chainId`, `rpcUrl`,                 
  `ethBridge.inbox`).
                                                                                                          
  ## Verified                                                                                             
   
  - `yarn lint` clean                                                                                     
  - 4/4 tests pass - https://github.com/OffchainLabs/arbitrum-portal/actions/runs/24715988409/job/72292940341?pr=291#step:6:616                       
  - Monitoring script runs and produces output - https://github.com/OffchainLabs/arbitrum-portal/actions/runs/24715889556/job/72292078516
