### PR TITLE
fix(ci): disable auto pnpm cache in monitoring workflow

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Install node_modules
         uses: OffchainLabs/actions/node-modules/install@main

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: 'pnpm'
 
       - name: Install node_modules
         uses: OffchainLabs/actions/node-modules/install@main


### PR DESCRIPTION
## Summary

  Replaces `cache: 'pnpm'` with `package-manager-cache: false` on the `Setup Node 22` step in `monitoring.yml` to
  unblock the scheduled Batch Poster, Assertion, and Retryable monitor jobs.

  ## Why this was failing

  After the yarn → pnpm migration ([0116e0e0](https://github.com/OffchainLabs/arbitrum-portal/commit/0116e0e0)), the
   scheduled monitoring workflows started failing in the **post step** of `Setup Node 22`:

 ```
[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is
  being saved.
```

  Even though the monitoring command itself completed successfully (`Monitoring complete - all chains healthy`), the
   cache-save in post-cleanup failed the whole job, and matrix `fail-fast` then canceled the sibling chain job.
  Failed run for reference: [25813648849](https://github.com/OffchainLabs/arbitrum-portal/actions/runs/25813648849).

  ### Root cause

  `actions/setup-node@v5` introduced a new input, `package-manager-cache` (default `true`), which **auto-enables
  caching** whenever it detects a `packageManager` field in the root `package.json`. The pnpm migration added
  `"packageManager": "pnpm@10.15.1"`, so v5 silently turned pnpm caching back on even after `cache: 'pnpm'` was
  removed.

  This workflow is the only one in the repo with **two** `setup-node` steps in the same job — a second
  `actions/setup-node@v4` (line 50) swaps Node to `latest` so the yarn-based `arbitrum-monitoring` repo can install.
   By the time setup-node v5's post step runs, the pnpm store path it captured pre-step no longer resolves (Node was
   swapped under it), so the save fails the job.

  ### Why disabling the auto-cache is safe

  Node modules are already cached by the next step (`OffchainLabs/actions/node-modules/install@main`), which uses
  its own `cache-key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}`. The setup-node-level cache was
  redundant.

  ## Related

  - Companion PR:
  [OffchainLabs/arbitrum-monitoring#109](https://github.com/OffchainLabs/arbitrum-monitoring/pull/109) — pinned
  `packageManager: yarn@1.22.22` so the yarn install inside `./arbitrum-monitoring` doesn't pick up the parent
  portal repo's pnpm declaration.

  ## Test plan

  - [x] Manually triggered `Assertion Monitor` against this branch — both Core and Orbit jobs pass: [run 25814197329
   follow-up]
  - [ ] After merge, confirm the next scheduled `Batch Poster Monitor` / `Retryable Monitor` / `Assertion Monitor`
  cron run is green