### PR TITLE
perf(bridge): skip pre-history in batched withdrawal fetch

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -315,7 +315,10 @@ export async function fetchWithdrawalsInBatches(
       typeof params.batchSizeBlocks === 'number' &&
       params.batchSizeBlocks <= SMALL_BATCH_SIZE_THRESHOLD;
 
-    if (batchSizeIsSmall && params.receiver && addressesEqual(params.sender, params.receiver)) {
+    // Apply when there are no separate receiver queries to worry about:
+    // either receiver is undefined (e.g., SCW connected to child chain — only
+    // sent txns are fetched), or receiver == sender (EOA self-withdrawal).
+    if (batchSizeIsSmall && (!params.receiver || addressesEqual(params.sender, params.receiver))) {
       const firstBlock = await findFirstBlockWithNonce({
         address: params.sender,
         provider: params.l2Provider,

--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -322,7 +322,7 @@ export async function fetchWithdrawalsInBatches(
         latestBlock: latestBlockNumber,
       });
       if (firstBlock > fromBlock) {
-        fromBlock = firstBlock;
+        fromBlock = Math.max(0, firstBlock - 1);
       }
     }
   }

--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -29,7 +29,7 @@ import { normalizeTimestamp, transformDeposit, transformWithdrawal } from '../st
 import { useCctpFetching } from '../state/cctpState';
 import { ChainId } from '../types/ChainId';
 import { Transaction, isTeleportTx } from '../types/Transactions';
-import { Address, getNonce } from '../util/AddressUtils';
+import { Address, addressesEqual, findFirstBlockWithNonce, getNonce } from '../util/AddressUtils';
 import { backOff } from '../util/ExponentialBackoffUtils';
 import { captureSentryErrorWithExtraData } from '../util/SentryUtils';
 import { shouldIncludeReceivedTxs, shouldIncludeSentTxs } from '../util/SubgraphUtils';
@@ -276,7 +276,7 @@ export async function fetchWithdrawalsInBatches(
 ): Promise<Withdrawal[]> {
   const latestBlockNumber = await params.l2Provider.getBlockNumber();
 
-  const fromBlock = params.fromBlock ?? 1;
+  let fromBlock = params.fromBlock ?? 1;
   const toBlock = params.toBlock ?? latestBlockNumber;
 
   if (toBlock < fromBlock) {
@@ -299,6 +299,31 @@ export async function fetchWithdrawalsInBatches(
     );
     if (senderNonce === 0) {
       return [];
+    }
+
+    // For self-withdrawals on Orbit chains (sender == receiver), the user
+    // can't have any withdrawals before their first L2 tx. Binary-search
+    // for that block (~log2(latestBlock) RPCs) and use it as the lower bound
+    // to skip empty pre-history.
+    //
+    // Only do this when BATCH_FETCH_BLOCKS is small. On chains like ApeChain
+    // (5M batch size, ~8 total batches), the ~25 sequential probe calls cost
+    // more than they save. On Mind/T-REX (10k batch size, hundreds/thousands
+    // of batches), the savings dominate.
+    const SMALL_BATCH_SIZE_THRESHOLD = 100_000;
+    const batchSizeIsSmall =
+      typeof params.batchSizeBlocks === 'number' &&
+      params.batchSizeBlocks <= SMALL_BATCH_SIZE_THRESHOLD;
+
+    if (batchSizeIsSmall && params.receiver && addressesEqual(params.sender, params.receiver)) {
+      const firstBlock = await findFirstBlockWithNonce({
+        address: params.sender,
+        provider: params.l2Provider,
+        latestBlock: latestBlockNumber,
+      });
+      if (firstBlock > fromBlock) {
+        fromBlock = firstBlock;
+      }
     }
   }
 

--- a/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AddressUtils.ts
@@ -44,3 +44,41 @@ export function getNonce(
 
   return provider.getTransactionCount(address);
 }
+
+/**
+ * Binary-search for the lowest block where `address` has nonce > 0 — i.e. the
+ * block of their first outgoing transaction. Useful as a lower bound for event-log
+ * scans on chains without a working subgraph: the address can't have initiated a
+ * withdrawal before they ever sent an L2 tx.
+ *
+ * Pre-condition: nonce > 0 at `latestBlock`.
+ * Returns `0` if historical nonce lookups aren't supported by the RPC.
+ */
+export async function findFirstBlockWithNonce({
+  address,
+  provider,
+  latestBlock,
+}: {
+  address: string;
+  provider: Provider;
+  latestBlock: number;
+}): Promise<number> {
+  try {
+    let lo = 0;
+    let hi = latestBlock;
+    while (lo < hi) {
+      const mid = Math.floor((lo + hi) / 2);
+      // eslint-disable-next-line no-await-in-loop
+      const nonce = await provider.getTransactionCount(address, mid);
+      if (nonce > 0) {
+        hi = mid;
+      } else {
+        lo = mid + 1;
+      }
+    }
+    return lo;
+  } catch (error) {
+    logger.warn('findFirstBlockWithNonce failed, falling back to 0', error);
+    return 0;
+  }
+}

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchBatchedWithdrawals.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchBatchedWithdrawals.test.ts
@@ -201,6 +201,35 @@ describe.sequential('fetchWithdrawalsInBatches binary-search optimization on Orb
     fetchSpy.mockRestore();
   });
 
+  it('applies the binary search when receiver is undefined (SCW connected to child chain)', async () => {
+    const latestBlock = 60_000_000;
+    const firstNonZeroBlock = 50_000_000;
+    const provider = createMockProvider({
+      chainId: MIND_CHAIN_ID,
+      latestBlock,
+      firstNonZeroBlock,
+    });
+    const searchSpy = vi.spyOn(addressUtils, 'findFirstBlockWithNonce');
+    searchSpy.mockClear();
+    const fetchSpy = vi.spyOn(fetchModule, 'fetchWithdrawals').mockResolvedValue([]);
+    fetchSpy.mockClear();
+
+    await fetchWithdrawalsInBatches({
+      sender: SENDER,
+      receiver: undefined,
+      parentChainId: 1,
+      l2Provider: provider,
+      batchSizeBlocks: 10_000,
+      pageSize: 1000,
+    });
+
+    expect(searchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy.mock.calls[0]?.[0].fromBlock).toBe(firstNonZeroBlock - 1);
+
+    searchSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
   it('skips the binary search when sender !== receiver', async () => {
     const provider = createMockProvider({
       chainId: MIND_CHAIN_ID,

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchBatchedWithdrawals.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchBatchedWithdrawals.test.ts
@@ -1,6 +1,9 @@
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { describe, expect, it, vi } from 'vitest';
 
 import { fetchWithdrawalsInBatches } from '../../../hooks/useTransactionHistory';
+import * as addressUtils from '../../AddressUtils';
+import { initializeBridgeNetworks } from '../../networks';
 import * as fetchModule from '../fetchWithdrawals';
 import { getQueryCoveringClassicAndNitroWithResults } from './fetchWithdrawalsTestHelpers';
 
@@ -69,3 +72,99 @@ describe.sequential(
     });
   },
 );
+
+describe.sequential('fetchWithdrawalsInBatches binary-search optimization on Orbit chains', () => {
+  // Register Mind/T-REX as Orbit chains for isNetwork().isOrbitChain checks
+  initializeBridgeNetworks();
+
+  const SENDER = '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299';
+  const MIND_CHAIN_ID = 228;
+  const TREX_CHAIN_ID = 1628;
+
+  function createMockProvider({
+    chainId,
+    latestBlock,
+    firstNonZeroBlock,
+    failHistoricalLookup = false,
+  }: {
+    chainId: number;
+    latestBlock: number;
+    firstNonZeroBlock?: number;
+    failHistoricalLookup?: boolean;
+  }) {
+    const provider = new StaticJsonRpcProvider('http://test.invalid', {
+      name: 'mock',
+      chainId,
+    });
+    provider.getBlockNumber = vi.fn().mockResolvedValue(latestBlock);
+    provider.getTransactionCount = vi
+      .fn()
+      .mockImplementation((_address: string, blockTag?: number | string) => {
+        // Initial nonce lookup (no block tag) — used by the senderNonce > 0 gate
+        if (typeof blockTag === 'undefined') {
+          return Promise.resolve(5);
+        }
+        // Historical lookups — used by the binary search
+        if (failHistoricalLookup) {
+          return Promise.reject(new Error('historical state not supported'));
+        }
+        const block = typeof blockTag === 'number' ? blockTag : latestBlock;
+        return Promise.resolve(block >= (firstNonZeroBlock ?? 0) ? 1 : 0);
+      });
+    return provider;
+  }
+
+  it('sets fromBlock to firstBlock - 1 for self-withdrawals when batch size is small', async () => {
+    const latestBlock = 60_000_000;
+    const firstNonZeroBlock = 50_000_000;
+    const provider = createMockProvider({
+      chainId: MIND_CHAIN_ID,
+      latestBlock,
+      firstNonZeroBlock,
+    });
+    const spy = vi.spyOn(fetchModule, 'fetchWithdrawals').mockResolvedValue([]);
+
+    await fetchWithdrawalsInBatches({
+      sender: SENDER,
+      receiver: SENDER,
+      parentChainId: 1,
+      l2Provider: provider,
+      batchSizeBlocks: 10_000,
+      pageSize: 1000,
+    });
+
+    expect(spy).toHaveBeenCalled();
+    const firstCallFromBlock = spy.mock.calls[0]?.[0].fromBlock;
+    expect(firstCallFromBlock).toBe(firstNonZeroBlock - 1);
+
+    spy.mockRestore();
+  });
+
+  it('falls back to the default fromBlock when historical nonce lookup throws', async () => {
+    const latestBlock = 100_000;
+    const provider = createMockProvider({
+      chainId: TREX_CHAIN_ID,
+      latestBlock,
+      failHistoricalLookup: true,
+    });
+    const fallbackSpy = vi.spyOn(addressUtils, 'findFirstBlockWithNonce');
+    const fetchSpy = vi.spyOn(fetchModule, 'fetchWithdrawals').mockResolvedValue([]);
+
+    await fetchWithdrawalsInBatches({
+      sender: SENDER,
+      receiver: SENDER,
+      parentChainId: 1,
+      l2Provider: provider,
+      batchSizeBlocks: 10_000,
+      pageSize: 1000,
+    });
+
+    expect(fallbackSpy).toHaveBeenCalled();
+    await expect(fallbackSpy.mock.results[0]?.value).resolves.toBe(0);
+    const firstCallFromBlock = fetchSpy.mock.calls[0]?.[0].fromBlock;
+    expect(firstCallFromBlock).toBe(1);
+
+    fallbackSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+});

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchBatchedWithdrawals.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchBatchedWithdrawals.test.ts
@@ -122,7 +122,10 @@ describe.sequential('fetchWithdrawalsInBatches binary-search optimization on Orb
       latestBlock,
       firstNonZeroBlock,
     });
-    const spy = vi.spyOn(fetchModule, 'fetchWithdrawals').mockResolvedValue([]);
+    const searchSpy = vi.spyOn(addressUtils, 'findFirstBlockWithNonce');
+    searchSpy.mockClear();
+    const fetchSpy = vi.spyOn(fetchModule, 'fetchWithdrawals').mockResolvedValue([]);
+    fetchSpy.mockClear();
 
     await fetchWithdrawalsInBatches({
       sender: SENDER,
@@ -133,11 +136,12 @@ describe.sequential('fetchWithdrawalsInBatches binary-search optimization on Orb
       pageSize: 1000,
     });
 
-    expect(spy).toHaveBeenCalled();
-    const firstCallFromBlock = spy.mock.calls[0]?.[0].fromBlock;
-    expect(firstCallFromBlock).toBe(firstNonZeroBlock - 1);
+    expect(searchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(fetchSpy.mock.calls[0]?.[0].fromBlock).toBe(firstNonZeroBlock - 1);
 
-    spy.mockRestore();
+    searchSpy.mockRestore();
+    fetchSpy.mockRestore();
   });
 
   it('falls back to the default fromBlock when historical nonce lookup throws', async () => {
@@ -147,8 +151,10 @@ describe.sequential('fetchWithdrawalsInBatches binary-search optimization on Orb
       latestBlock,
       failHistoricalLookup: true,
     });
-    const fallbackSpy = vi.spyOn(addressUtils, 'findFirstBlockWithNonce');
+    const searchSpy = vi.spyOn(addressUtils, 'findFirstBlockWithNonce');
+    searchSpy.mockClear();
     const fetchSpy = vi.spyOn(fetchModule, 'fetchWithdrawals').mockResolvedValue([]);
+    fetchSpy.mockClear();
 
     await fetchWithdrawalsInBatches({
       sender: SENDER,
@@ -159,12 +165,94 @@ describe.sequential('fetchWithdrawalsInBatches binary-search optimization on Orb
       pageSize: 1000,
     });
 
-    expect(fallbackSpy).toHaveBeenCalled();
-    await expect(fallbackSpy.mock.results[0]?.value).resolves.toBe(0);
-    const firstCallFromBlock = fetchSpy.mock.calls[0]?.[0].fromBlock;
-    expect(firstCallFromBlock).toBe(1);
+    expect(searchSpy).toHaveBeenCalled();
+    await expect(searchSpy.mock.results[0]?.value).resolves.toBe(0);
+    expect(fetchSpy.mock.calls[0]?.[0].fromBlock).toBe(1);
 
-    fallbackSpy.mockRestore();
+    searchSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it('skips the binary search when batch size is above the threshold (e.g. ApeChain)', async () => {
+    const latestBlock = 38_000_000;
+    const provider = createMockProvider({
+      chainId: MIND_CHAIN_ID,
+      latestBlock,
+      firstNonZeroBlock: 30_000_000,
+    });
+    const searchSpy = vi.spyOn(addressUtils, 'findFirstBlockWithNonce');
+    searchSpy.mockClear();
+    const fetchSpy = vi.spyOn(fetchModule, 'fetchWithdrawals').mockResolvedValue([]);
+    fetchSpy.mockClear();
+
+    await fetchWithdrawalsInBatches({
+      sender: SENDER,
+      receiver: SENDER,
+      parentChainId: 1,
+      l2Provider: provider,
+      batchSizeBlocks: 5_000_000,
+      pageSize: 1000,
+    });
+
+    expect(searchSpy).not.toHaveBeenCalled();
+    expect(fetchSpy.mock.calls[0]?.[0].fromBlock).toBe(1);
+
+    searchSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it('skips the binary search when sender !== receiver', async () => {
+    const provider = createMockProvider({
+      chainId: MIND_CHAIN_ID,
+      latestBlock: 60_000_000,
+      firstNonZeroBlock: 50_000_000,
+    });
+    const searchSpy = vi.spyOn(addressUtils, 'findFirstBlockWithNonce');
+    searchSpy.mockClear();
+    const fetchSpy = vi.spyOn(fetchModule, 'fetchWithdrawals').mockResolvedValue([]);
+    fetchSpy.mockClear();
+
+    await fetchWithdrawalsInBatches({
+      sender: SENDER,
+      receiver: '0x1111111111111111111111111111111111111111',
+      parentChainId: 1,
+      l2Provider: provider,
+      batchSizeBlocks: 10_000,
+      pageSize: 1000,
+    });
+
+    expect(searchSpy).not.toHaveBeenCalled();
+    expect(fetchSpy.mock.calls[0]?.[0].fromBlock).toBe(1);
+
+    searchSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it('skips the binary search and the senderNonce gate when forceFetchReceived is true', async () => {
+    const provider = createMockProvider({
+      chainId: MIND_CHAIN_ID,
+      latestBlock: 60_000_000,
+      firstNonZeroBlock: 50_000_000,
+    });
+    const searchSpy = vi.spyOn(addressUtils, 'findFirstBlockWithNonce');
+    searchSpy.mockClear();
+    const fetchSpy = vi.spyOn(fetchModule, 'fetchWithdrawals').mockResolvedValue([]);
+    fetchSpy.mockClear();
+
+    await fetchWithdrawalsInBatches({
+      sender: SENDER,
+      receiver: SENDER,
+      parentChainId: 1,
+      l2Provider: provider,
+      batchSizeBlocks: 10_000,
+      pageSize: 1000,
+      forceFetchReceived: true,
+    });
+
+    expect(searchSpy).not.toHaveBeenCalled();
+    expect(fetchSpy.mock.calls[0]?.[0].fromBlock).toBe(1);
+
+    searchSpy.mockRestore();
     fetchSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Why

#322 stopped Mind Network from blowing up the RPC with oversized `eth_getLogs` queries — but the fix slices the chain into 10k-block batches, and Mind is now at ~59.7M blocks. For users with any L3 activity on Mind, every page-load still fires ~6,000 `fetchWithdrawals` invocations → **~18,000 network calls**  and **~20 minutes** to fully resolve. The vast majority of those batched-withdrawal fetches return zero - because the user can't have withdrawn before their first L3 tx ever landed.

## Change

Binary-search for the lowest block where the sender has nonce > 0 (their first L3 tx) and use it as the `fromBlock` for batching. ~26 sequential `eth_getTransactionCount` calls upfront, but cuts thousands of pointless batches.

Gated to:
- Orbit chains where `senderNonce > 0` (the existing `senderNonce === 0` early-return handles zero-nonce users)
- Self-withdrawals (`sender == receiver`) — same heuristic as the existing receiver gate
- Small batch sizes (`≤ 100k`) — skips ApeChain (5M batch, ~8 total batches) where the probe cost outweighs the savings

Falls back to `fromBlock = 0` if the RPC rejects historical nonce queries.

## Performance impact

**Mind Network** (chain 228, ~59.7M blocks, 10k batch size):

| Scenario | Before any fix | After #322 | After this PR |
|---|---|---|---|
| Zero-nonce user (no L3 activity) | ~3 calls / instant | **1 call / instant** | 1 call / instant |
| Active user (has L3 activity) | Tx history breaks - RPC returns query too large | ~18,000 calls / ~20 min | **~3,000 calls¹ / ~60s** |

¹ Scales with how recently the user first transacted on Mind. Most users will land between 1,500–5,000 calls.

**Other batched Orbit chains**:

| Chain | Before #322 | After #322 | After this PR |
|---|---|---|---|
| T-REX (1628, 1.28M blocks, 10k batch) | ~384 calls | unchanged | **~100–380 calls** |
| ApeChain (33139, 38M blocks, 5M batch) | ~24 calls | unchanged | unchanged (intentionally excluded — probe cost would outweigh savings) |

## Test plan
- [ ] Test for `0x1BD4a8FcaFa8e16c6DF3C5C9E2359beF2D03A807` (wallet with mind network activity) and see the difference between this vs prod
- [ ] Tx history experience for the rest of the use cases remains unchanged