### PR TITLE
build(deps): fix ws and webpack-dev-server audit advisories

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -104,6 +104,9 @@
     // https://github.com/advisories/GHSA-4v9v-hfq4-rm2v
     // webpack-dev-server users' source code may be stolen via malicious site (CVE-2025-30359)
     //
+    // https://github.com/advisories/GHSA-79cf-xcqc-c78w
+    // webpack-dev-server cross-origin source code exposure on non-HTTPS origins (CVE-2026-6402)
+    //
     // Reason to ignore: All from @synthetixio/synpress, an E2E test devDependency.
     // Each fix requires a major bump deep in the synpress chain that would risk
     // breaking E2E tooling. Not used in production builds or runtime code.
@@ -114,5 +117,18 @@
     "GHSA-8mmm-9v2q-x3f9",
     "GHSA-9jgg-88mc-972h",
     "GHSA-4v9v-hfq4-rm2v",
+    "GHSA-79cf-xcqc-c78w",
+    //
+    // https://github.com/advisories/GHSA-58qx-3vcg-4xpx
+    // ws uninitialized memory disclosure when TypedArray is passed as the reason
+    // argument to websocket.close() (CVE-2026-45736)
+    // Reason to ignore: Only triggered by server-side misuse passing a TypedArray
+    // to close(); none of our code paths invoke close() this way. ws is pulled in
+    // transitively by SDKs (ethers, viem/@reown/appkit, @metamask/sdk) and a fix
+    // requires upstream releases.
+    // from: app>@arbitrum/sdk>ethers>@ethersproject/providers>ws
+    // from: app>@reown/appkit>...>@solana/rpc-subscriptions-channel-websocket>ws
+    // from: app>@reown/appkit-adapter-wagmi>@wagmi/connectors>@metamask/sdk>socket.io-client>engine.io-client>ws
+    "GHSA-58qx-3vcg-4xpx",
   ],
 }

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -118,17 +118,5 @@
     "GHSA-9jgg-88mc-972h",
     "GHSA-4v9v-hfq4-rm2v",
     "GHSA-79cf-xcqc-c78w",
-    //
-    // https://github.com/advisories/GHSA-58qx-3vcg-4xpx
-    // ws uninitialized memory disclosure when TypedArray is passed as the reason
-    // argument to websocket.close() (CVE-2026-45736)
-    // Reason to ignore: Only triggered by server-side misuse passing a TypedArray
-    // to close(); none of our code paths invoke close() this way. ws is pulled in
-    // transitively by SDKs (ethers, viem/@reown/appkit, @metamask/sdk) and a fix
-    // requires upstream releases.
-    // from: app>@arbitrum/sdk>ethers>@ethersproject/providers>ws
-    // from: app>@reown/appkit>...>@solana/rpc-subscriptions-channel-websocket>ws
-    // from: app>@reown/appkit-adapter-wagmi>@wagmi/connectors>@metamask/sdk>socket.io-client>engine.io-client>ws
-    "GHSA-58qx-3vcg-4xpx",
   ],
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
       "@vitest/mocker>vite": "7.3.3",
       "sucrase>glob": "10.5.0",
       "test-exclude>glob": "10.5.0",
-      "viem>ws": "8.20.0",
+      "ws@>=8.0.0 <8.20.1": "8.20.1",
       "express>qs": "6.15.1",
       "body-parser>qs": "6.15.1",
       "@cypress/request>qs": "6.15.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ overrides:
   '@vitest/mocker>vite': 7.3.3
   sucrase>glob: 10.5.0
   test-exclude>glob: 10.5.0
-  viem>ws: 8.20.0
+  ws@>=8.0.0 <8.20.1: 8.20.1
   express>qs: 6.15.1
   body-parser>qs: 6.15.1
   '@cypress/request>qs': 6.15.1
@@ -110,10 +110,10 @@ importers:
         version: 2.2.0(react@18.3.1)
       '@reown/appkit':
         specifier: ^1.8.19
-        version: 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+        version: 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-adapter-wagmi':
         specifier: ^1.8.19
-        version: 1.8.19(2e23d23ebd30e8dde60792f9328dc494)
+        version: 1.8.19(cb3bec3c9a7a860e1f66aa19cfbb83dc)
       '@tanstack/react-query':
         specifier: ^5.63.0
         version: 5.63.0(react@18.3.1)
@@ -167,7 +167,7 @@ importers:
         version: 2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       wagmi:
         specifier: ^2.19.5
-        version: 2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+        version: 2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       zod:
         specifier: ^3.24.3
         version: 3.25.76
@@ -228,10 +228,10 @@ importers:
         version: 2.4.5(react@18.3.1)
       '@reown/appkit':
         specifier: ^1.8.19
-        version: 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+        version: 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-adapter-wagmi':
         specifier: ^1.8.19
-        version: 1.8.19(2c748b494f3b72fab72a7ebd2d8839d1)
+        version: 1.8.19(9042fc8b3b66b0110ac2d43b00a34584)
       '@sentry/react':
         specifier: ^9.13.0
         version: 9.13.0(react@18.3.1)
@@ -279,7 +279,7 @@ importers:
         version: 14.2.35(@babel/core@7.28.4)(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-query-params:
         specifier: ^5.1.0
-        version: 5.1.0(next@14.2.35(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 5.1.0(next@14.2.35(@babel/core@7.28.4)(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       p-limit:
         specifier: ^6.2.0
         version: 6.2.0
@@ -327,7 +327,7 @@ importers:
         version: 2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       wagmi:
         specifier: ^2.19.5
-        version: 2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+        version: 2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       zod:
         specifier: ^3.24.3
         version: 3.25.76
@@ -424,7 +424,7 @@ importers:
         version: 6.6.2
       next-query-params:
         specifier: ^5.1.0
-        version: 5.1.0(next@14.2.35(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 5.1.0(next@14.2.35(@babel/core@7.28.4)(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       posthog-js:
         specifier: ^1.273.0
         version: 1.273.0
@@ -2913,7 +2913,7 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
-      ws: ^8.18.0
+      ws: 8.20.1
 
   '@solana/rpc-subscriptions-spec@3.0.3':
     resolution: {integrity: sha512-9KpQ32OBJWS85mn6q3gkM0AjQe1LKYlMU7gpJRrla/lvXxNLhI95tz5K6StctpUreVmRWTVkNamHE69uUQyY8A==}
@@ -6593,17 +6593,17 @@ packages:
   isomorphic-ws@4.0.1:
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
     peerDependencies:
-      ws: '*'
+      ws: 8.20.1
 
   isows@1.0.3:
     resolution: {integrity: sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==}
     peerDependencies:
-      ws: '*'
+      ws: 8.20.1
 
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
-      ws: '*'
+      ws: 8.20.1
 
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -9566,32 +9566,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: 6.0.6
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: 6.0.6
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -10586,9 +10562,9 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-org/account@2.4.0(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
+  '@base-org/account@2.4.0(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
-      '@coinbase/cdp-sdk': 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))
+      '@coinbase/cdp-sdk': 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
@@ -10611,9 +10587,9 @@ snapshots:
       - ws
       - zod
 
-  '@base-org/account@2.4.0(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
+  '@base-org/account@2.4.0(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
-      '@coinbase/cdp-sdk': 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))
+      '@coinbase/cdp-sdk': 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
@@ -10656,11 +10632,11 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@coinbase/cdp-sdk@1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))':
+  '@coinbase/cdp-sdk@1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)))
-      '@solana-program/token': 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)))
-      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))
+      '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)))
+      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)
       abitype: 1.0.6(typescript@5.9.2)(zod@3.25.76)
       axios: 1.15.2(debug@4.4.3)
@@ -11232,7 +11208,7 @@ snapshots:
       '@ethersproject/transactions': 5.8.0
       '@ethersproject/web': 5.8.0
       bech32: 1.1.4
-      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -12208,22 +12184,22 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@reown/appkit-adapter-wagmi@1.8.19(2c748b494f3b72fab72a7ebd2d8839d1)':
+  '@reown/appkit-adapter-wagmi@1.8.19(9042fc8b3b66b0110ac2d43b00a34584)':
     dependencies:
-      '@reown/appkit': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-common': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-polyfills': 1.8.19
-      '@reown/appkit-scaffold-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
-      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-scaffold-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-wallet': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))
       '@walletconnect/universal-provider': 2.23.7(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       valtio: 2.1.7(@types/react@18.2.12)(react@18.3.1)
       viem: 2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
     optionalDependencies:
-      '@wagmi/connectors': 7.2.1(f3008128bca94f12866e8352be41949b)
+      '@wagmi/connectors': 7.2.1(01637e0daac34c4ae3528e7c90cacdb6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -12259,22 +12235,22 @@ snapshots:
       - ws
       - zod
 
-  '@reown/appkit-adapter-wagmi@1.8.19(2e23d23ebd30e8dde60792f9328dc494)':
+  '@reown/appkit-adapter-wagmi@1.8.19(cb3bec3c9a7a860e1f66aa19cfbb83dc)':
     dependencies:
-      '@reown/appkit': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-common': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-polyfills': 1.8.19
-      '@reown/appkit-scaffold-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
-      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-scaffold-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-wallet': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))
       '@walletconnect/universal-provider': 2.23.7(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       valtio: 2.1.7(@types/react@18.2.12)(react@18.3.1)
       viem: 2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
     optionalDependencies:
-      '@wagmi/connectors': 7.2.1(20ef75c5c38838fdb788b221495ab2e8)
+      '@wagmi/connectors': 7.2.1(75622c5df088f42712bd76f84b5cdeeb)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -12362,12 +12338,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-pay@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
+  '@reown/appkit-pay@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       lit: 3.3.0
       valtio: 2.1.7(@types/react@18.2.12)(react@18.3.1)
     transitivePeerDependencies:
@@ -12398,12 +12374,12 @@ snapshots:
       - ws
       - zod
 
-  '@reown/appkit-pay@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
+  '@reown/appkit-pay@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       lit: 3.3.0
       valtio: 2.1.7(@types/react@18.2.12)(react@18.3.1)
     transitivePeerDependencies:
@@ -12438,13 +12414,13 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@reown/appkit-scaffold-ui@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
+  '@reown/appkit-scaffold-ui@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-pay': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-pay': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-wallet': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)
       lit: 3.3.0
     transitivePeerDependencies:
@@ -12476,13 +12452,13 @@ snapshots:
       - ws
       - zod
 
-  '@reown/appkit-scaffold-ui@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
+  '@reown/appkit-scaffold-ui@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-pay': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-pay': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-wallet': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)
       lit: 3.3.0
     transitivePeerDependencies:
@@ -12545,7 +12521,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
+  '@reown/appkit-utils@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
@@ -12557,7 +12533,7 @@ snapshots:
       valtio: 2.1.7(@types/react@18.2.12)(react@18.3.1)
       viem: 2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
     optionalDependencies:
-      '@base-org/account': 2.4.0(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@base-org/account': 2.4.0(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
     transitivePeerDependencies:
@@ -12588,7 +12564,7 @@ snapshots:
       - ws
       - zod
 
-  '@reown/appkit-utils@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
+  '@reown/appkit-utils@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
@@ -12600,7 +12576,7 @@ snapshots:
       valtio: 2.1.7(@types/react@18.2.12)(react@18.3.1)
       viem: 2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
     optionalDependencies:
-      '@base-org/account': 2.4.0(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@base-org/account': 2.4.0(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
     transitivePeerDependencies:
@@ -12642,15 +12618,15 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reown/appkit@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
+  '@reown/appkit@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-pay': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-pay': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-polyfills': 1.8.19
-      '@reown/appkit-scaffold-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-scaffold-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-wallet': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)
       '@walletconnect/universal-provider': 2.23.7(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       bs58: 6.0.0
@@ -12687,15 +12663,15 @@ snapshots:
       - ws
       - zod
 
-  '@reown/appkit@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
+  '@reown/appkit@1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@reown/appkit-controllers': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-pay': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-pay': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-polyfills': 1.8.19
-      '@reown/appkit-scaffold-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-scaffold-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-ui': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@reown/appkit-utils': 1.8.19(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@18.2.12)(react@18.3.1))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@reown/appkit-wallet': 1.8.19(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)
       '@walletconnect/universal-provider': 2.23.7(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       bs58: 6.0.0
@@ -12928,13 +12904,13 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)))':
+  '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))
+      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))
 
-  '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)))':
+  '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))
+      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))
 
   '@solana/accounts@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)':
     dependencies:
@@ -13064,7 +13040,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))':
+  '@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/accounts': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
@@ -13078,11 +13054,11 @@ snapshots:
       '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/rpc-parsed-types': 3.0.3(typescript@5.9.2)
       '@solana/rpc-spec-types': 3.0.3(typescript@5.9.2)
-      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))
+      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))
       '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/signers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/sysvars': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-confirmation': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))
+      '@solana/transaction-confirmation': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))
       '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       typescript: 5.9.2
@@ -13161,14 +13137,14 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))':
+  '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.9.2)
       '@solana/functional': 3.0.3(typescript@5.9.2)
       '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.9.2)
       '@solana/subscribable': 3.0.3(typescript@5.9.2)
       typescript: 5.9.2
-      ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
 
   '@solana/rpc-subscriptions-spec@3.0.3(typescript@5.9.2)':
     dependencies:
@@ -13178,7 +13154,7 @@ snapshots:
       '@solana/subscribable': 3.0.3(typescript@5.9.2)
       typescript: 5.9.2
 
-  '@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))':
+  '@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.9.2)
       '@solana/fast-stable-stringify': 3.0.3(typescript@5.9.2)
@@ -13186,7 +13162,7 @@ snapshots:
       '@solana/promises': 3.0.3(typescript@5.9.2)
       '@solana/rpc-spec-types': 3.0.3(typescript@5.9.2)
       '@solana/rpc-subscriptions-api': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-subscriptions-channel-websocket': 3.0.3(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))
+      '@solana/rpc-subscriptions-channel-websocket': 3.0.3(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))
       '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.9.2)
       '@solana/rpc-transformers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
@@ -13271,7 +13247,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))':
+  '@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/codecs-strings': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
@@ -13279,7 +13255,7 @@ snapshots:
       '@solana/keys': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/promises': 3.0.3(typescript@5.9.2)
       '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))
+      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))
       '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
@@ -14124,7 +14100,7 @@ snapshots:
       execa: 7.2.0
       get-port: 6.1.2
       http-proxy: 1.18.1(debug@4.4.3)
-      ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -14191,9 +14167,9 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@wagmi/connectors@6.2.0(171f50f47c479f0bd6e86a66ca7a3e82)':
+  '@wagmi/connectors@6.2.0(56e7d9403cb8ce9d36a59748d6846620)':
     dependencies:
-      '@base-org/account': 2.4.0(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      '@base-org/account': 2.4.0(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@18.2.12)(bufferutil@4.0.9)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(zod@3.25.76)
       '@gemini-wallet/core': 0.3.2(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))
       '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
@@ -14202,7 +14178,7 @@ snapshots:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))
       '@walletconnect/ethereum-provider': 2.13.1(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@6.0.6)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(@wagmi/core@2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)))(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76))
+      porto: 0.2.35(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(@wagmi/core@2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)))(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76))
       viem: 2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.2
@@ -14240,21 +14216,7 @@ snapshots:
       - ws
       - zod
 
-  '@wagmi/connectors@7.2.1(20ef75c5c38838fdb788b221495ab2e8)':
-    dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))
-      viem: 2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-    optionalDependencies:
-      '@coinbase/wallet-sdk': 4.3.6(@types/react@18.2.12)(bufferutil@4.0.9)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@walletconnect/ethereum-provider': 2.13.1(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@6.0.6)
-      porto: 0.2.35(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(@wagmi/core@2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)))(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76))
-      typescript: 5.9.2
-    optional: true
-
-  '@wagmi/connectors@7.2.1(f3008128bca94f12866e8352be41949b)':
+  '@wagmi/connectors@7.2.1(01637e0daac34c4ae3528e7c90cacdb6)':
     dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))
       viem: 2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
@@ -14264,7 +14226,21 @@ snapshots:
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       '@walletconnect/ethereum-provider': 2.13.1(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@6.0.6)
-      porto: 0.2.35(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(@wagmi/core@2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)))(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76))
+      porto: 0.2.35(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(@wagmi/core@2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)))(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76))
+      typescript: 5.9.2
+    optional: true
+
+  '@wagmi/connectors@7.2.1(75622c5df088f42712bd76f84b5cdeeb)':
+    dependencies:
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))
+      viem: 2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
+    optionalDependencies:
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@18.2.12)(bufferutil@4.0.9)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@walletconnect/ethereum-provider': 2.13.1(@types/react@18.2.12)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@6.0.6)
+      porto: 0.2.35(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(@wagmi/core@2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)))(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76))
       typescript: 5.9.2
     optional: true
 
@@ -16359,7 +16335,7 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.3.7
       engine.io-parser: 5.2.3
-      ws: 8.17.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
       xmlhttprequest-ssl: 2.1.2
     transitivePeerDependencies:
       - bufferutil
@@ -16902,7 +16878,7 @@ snapshots:
       '@types/node': 22.7.5
       aes-js: 4.0.0-beta.5
       tslib: 2.7.0
-      ws: 8.17.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -17533,7 +17509,7 @@ snapshots:
       '@types/ws': 8.18.1
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -18018,13 +17994,13 @@ snapshots:
     dependencies:
       ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@6.0.6)
 
-  isows@1.0.3(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)):
+  isows@1.0.3(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
 
-  isows@1.0.7(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)):
+  isows@1.0.7(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
 
   isstream@0.1.2: {}
 
@@ -18599,7 +18575,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-query-params@5.1.0(next@14.2.35(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  next-query-params@5.1.0(next@14.2.35(@babel/core@7.28.4)(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       next: 14.2.35(@babel/core@7.28.4)(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -19155,7 +19131,7 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(@wagmi/core@2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)))(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(@wagmi/core@2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)))(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)):
     dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))
       hono: 4.12.18
@@ -19169,13 +19145,13 @@ snapshots:
       '@tanstack/react-query': 5.63.0(react@18.3.1)
       react: 18.3.1
       typescript: 5.9.2
-      wagmi: 2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - immer
       - use-sync-external-store
 
-  porto@0.2.35(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(@wagmi/core@2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)))(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(@wagmi/core@2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76)))(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)):
     dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.6.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))
       hono: 4.12.18
@@ -19189,7 +19165,7 @@ snapshots:
       '@tanstack/react-query': 5.63.0(react@18.3.1)
       react: 18.3.1
       typescript: 5.9.2
-      wagmi: 2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -19743,7 +19719,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.1
       uuid: 14.0.0
-      ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 6.0.6
@@ -20914,8 +20890,8 @@ snapshots:
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
       abitype: 0.9.8(typescript@5.9.2)(zod@3.25.76)
-      isows: 1.0.3(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))
-      ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      isows: 1.0.3(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -20930,9 +20906,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.2)(zod@3.22.4)
-      isows: 1.0.7(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))
+      isows: 1.0.7(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))
       ox: 0.14.5(typescript@5.9.2)(zod@3.22.4)
-      ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -20947,9 +20923,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.2)(zod@3.25.76)
-      isows: 1.0.7(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))
+      isows: 1.0.7(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))
       ox: 0.14.5(typescript@5.9.2)(zod@3.25.76)
-      ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -21050,10 +21026,10 @@ snapshots:
       - tsx
       - yaml
 
-  wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76):
+  wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@18.3.1))(@types/react@18.2.12)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76):
     dependencies:
       '@tanstack/react-query': 5.63.0(react@18.3.1)
-      '@wagmi/connectors': 6.2.0(171f50f47c479f0bd6e86a66ca7a3e82)
+      '@wagmi/connectors': 6.2.0(56e7d9403cb8ce9d36a59748d6846620)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))
       react: 18.3.1
       use-sync-external-store: 1.4.0(react@18.3.1)
@@ -21168,7 +21144,7 @@ snapshots:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack-dev-middleware: 5.3.4(webpack@5.106.2(postcss@8.5.12))
-      ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+      ws: 8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6)
     optionalDependencies:
       webpack: 5.106.2(postcss@8.5.12)
     transitivePeerDependencies:
@@ -21340,17 +21316,7 @@ snapshots:
       bufferutil: 4.0.9
       utf-8-validate: 6.0.6
 
-  ws@8.17.1(bufferutil@4.0.9)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.0.9
-      utf-8-validate: 6.0.6
-
-  ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.0.9
-      utf-8-validate: 6.0.6
-
-  ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@6.0.6):
+  ws@8.20.1(bufferutil@4.0.9)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 6.0.6


### PR DESCRIPTION
## Summary

Two new advisories were failing `audit:ci`. Resolved each via the lowest-risk path:

- **`GHSA-58qx-3vcg-4xpx` (ws — uninitialized memory disclosure)** — fixed by bumping all vulnerable transitive copies to `8.20.1` via a scoped `pnpm.overrides` entry: `"ws@>=8.0.0 <8.20.1": "8.20.1"`. This replaces the existing `viem>ws` pin so every 8.x caller (viem, @reown/appkit, @ethersproject/providers, rpc-websockets, etc.) lands on the patched release while leaving the unaffected ws@7 callers (jayson, @walletconnect/jsonrpc-ws-connection) alone.
- **`GHSA-79cf-xcqc-c78w` (webpack-dev-server — cross-origin source code exposure)** — added to the existing `@synthetixio/synpress` allowlist block. Patch is in `webpack-dev-server@5.2.4`, but we're pulled in via `@cypress/webpack-dev-server@3.11.0` → `webpack-dev-server@4.15.2`. Upgrading would require a major bump through cypress + synpress (E2E devDependency only, not in production runtime), matching the rationale for the other entries in that block.

## Test plan

- [x] `pnpm audit:ci` passes
- [x] `pnpm -r why ws` confirms all vulnerable ws@8.x copies resolve to `8.20.1`; ws@7 callers unchanged
- [ ] CI green