### PR TITLE
refactor: centralize Sentry init in AppShell

### DIFF
--- a/packages/app/src/app/(with-sidebar)/bridge/BridgeClient.tsx
+++ b/packages/app/src/app/(with-sidebar)/bridge/BridgeClient.tsx
@@ -5,13 +5,9 @@ import { ComponentType } from 'react';
 
 import { Loader } from '@/bridge/components/common/atoms/Loader';
 import { isE2eTestingEnvironment, isProductionEnvironment } from '@/bridge/util/CommonUtils';
-import { initializeSentry } from '@/bridge/util/SentryUtils';
 import { registerLocalNetwork } from '@/bridge/util/networks';
 
 import { addOrbitChainsToArbitrumSDK } from '../../../initialization';
-
-// Initialize Sentry for error tracking
-initializeSentry(process.env.NEXT_PUBLIC_SENTRY_DSN);
 
 const App = dynamic(
   () => {

--- a/packages/app/src/components/AppShell/AppShell.tsx
+++ b/packages/app/src/components/AppShell/AppShell.tsx
@@ -6,11 +6,14 @@ import { PropsWithChildren } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import { useSiteBannerVisible } from '@/bridge/components/common/SiteBanner';
+import { initializeSentry } from '@/bridge/util/SentryUtils';
 
 import { AccountBlockedGuard } from './components/AccountBlockedGuard';
 import { Nav } from './components/Nav';
 import { NavLinks } from './components/NavLinks';
 import { SubNav } from './components/SubNav';
+
+initializeSentry(process.env.NEXT_PUBLIC_SENTRY_DSN);
 
 const AppProviders = dynamic(
   () => import('./providers/AppProviders').then((mod) => mod.AppProviders),


### PR DESCRIPTION
## Summary
- Move `initializeSentry` from `BridgeClient` into `AppShell` so every route — bridge, earn, portal - has Sentry available from first render.
- Remove the now-redundant init from `BridgeClient`.

## Test plan
- [ ] Visit `/bridge`, confirm Sentry init runs (network tab → sentry envelope)
- [ ] Visit `/earn` directly, confirm Sentry init runs
- [ ] Trigger a thrown error and verify it reaches Sentry