### PR TITLE
feat(earn): add gas estimation fallbacks 

### DIFF
--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/PendleAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/PendleAdapter.ts
@@ -51,6 +51,17 @@ const DEFAULT_PENDLE_DECIMALS = 18;
 const PENDLE_TX_HISTORY_DEFAULT_PAGE = 1;
 const PENDLE_TX_HISTORY_DEFAULT_PAGE_SIZE = 50;
 
+// Pendle enter/exit on Arbitrum routes through the Pendle aggregator
+// (enableAggregator: true) which consistently uses 950k-1.2M gas.
+// Sampled sUSDai market enters via aggregator (0xdb9b1e94...):
+//   https://arbiscan.io/tx/0x8fc4f73a8e2e63a34375f4f54b6740a6755cab666c98a25ca0a13f8b03438487 (950k)
+//   https://arbiscan.io/tx/0xc74c8f4329c6924d3f31245feeec0000818807767083b3033021cde78078dfba (1.18M)
+//   https://arbiscan.io/tx/0xca6f8f35abc177a38124a5e596fdeab6047de1088d493f79444becfcc72e065e (1.20M)
+// Use 1.2M as the worst-case fallback when on-chain simulation fails
+// (slippage edges, router pre-conditions, etc.).
+const PENDLE_APPROVAL_GAS_FALLBACK = 80_000;
+const PENDLE_TRANSACTION_GAS_FALLBACK = 1_200_000;
+
 function isSupportedChainId(chainId: EarnChainId): boolean {
   return chainId === ChainId.ArbitrumOne;
 }
@@ -383,6 +394,7 @@ export class PendleAdapter implements VendorAdapter {
         data: approvalData,
         value: '0',
         chainId,
+        gasLimitFallback: PENDLE_APPROVAL_GAS_FALLBACK,
       });
 
       stepNumber += 1;
@@ -395,6 +407,7 @@ export class PendleAdapter implements VendorAdapter {
       data: firstRoute.tx.data,
       value: firstRoute.tx.value || '0',
       chainId,
+      gasLimitFallback: PENDLE_TRANSACTION_GAS_FALLBACK,
     });
 
     const receiveAmount = firstRoute.outputs?.[0]?.amount;

--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/VaultsAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/VaultsAdapter.ts
@@ -37,6 +37,17 @@ export type VaultsProtocol = 'aave' | 'compound' | 'fluid' | 'morpho';
 
 export type VaultsActionType = 'deposit' | 'redeem';
 
+// Vault deposit/redeem on Arbitrum is ~180-190k gas across Aave/Compound/Fluid/Morpho.
+// Sampled Aave v3 USDC deposits (~189k):
+//   https://arbiscan.io/tx/0xecb229fb75e36d8f64173b9d1466b48fb4aa549d3f7852dbdfe8e0f6cbc3e88d
+//   https://arbiscan.io/tx/0x39c358dbfe1e7da8ddd98555babebc42450f4d088a97c408f3dcd1362f2400f9
+// Sampled Aave v3 USDC redeems (~180k):
+//   https://arbiscan.io/tx/0x2d3d66b161b4119f5d433100c67051e5eb87bd6d8545691bfd222a6eacb2706c
+//   https://arbiscan.io/tx/0x4eb667a100ff1a1587e5ce6acb995e28bc86fa856834623e81c1d3d50370e0f0
+// Buffer to 250k to cover slower vaults (Morpho / Fluid).
+const VAULTS_APPROVAL_GAS_FALLBACK = 80_000;
+const VAULTS_TRANSACTION_GAS_FALLBACK = 250_000;
+
 type VaultHistoricalPoint = {
   timestamp: number;
   apy?: { total?: number } | null;
@@ -412,6 +423,10 @@ export class VaultsAdapter implements VendorAdapter {
           value: tx.value || '0',
           chainId: tx.chainId,
           description,
+          gasLimitFallback:
+            stepType === 'approval'
+              ? VAULTS_APPROVAL_GAS_FALLBACK
+              : VAULTS_TRANSACTION_GAS_FALLBACK,
         };
       },
     );

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/lifiQuote.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/lifiQuote.ts
@@ -24,6 +24,20 @@ type LifiQuoteBuildResult = {
   priceImpact: number;
 };
 
+// LiFi liquid-staking flows on Arbitrum typically use 230-470k gas direct via
+// the LiFi diamond (0x1231deb6...); aggregator-routed flows (0xdb9b1e94...)
+// can spike to ~1.3M.
+// Sampled Lido wstETH via LiFi diamond (~300k):
+//   https://arbiscan.io/tx/0x7cb99bff05fc8c8a05e0674726e29e75f5fe1408a798ae040b4af036ef21cbac
+// Sampled Lido wstETH via aggregator (~1.1-1.3M):
+//   https://arbiscan.io/tx/0x8ae4b5e2dec77dce3c3405c229e6c33392cf41039e2567d6f1e29c9d04254c4b
+//   https://arbiscan.io/tx/0xc6e188198a79a41a26b6fc5fb0aaab5b79649c6dd1dffa3c471310d0b6c93c30
+// Sampled Ether.fi weETH via aggregator (~435k):
+//   https://arbiscan.io/tx/0xb40ede2bdcd4ec599963d870f7de6d223fdfc2cdf35b58a924d02c3d35f99c2e
+// Use 700k as a middle-ground fallback when on-chain simulation fails.
+const LIFI_APPROVAL_GAS_FALLBACK = 80_000;
+const LIFI_TRANSACTION_GAS_FALLBACK = 700_000;
+
 async function buildTransactionSteps({
   amount,
   inputTokenAddress,
@@ -64,6 +78,7 @@ async function buildTransactionSteps({
           value: '0',
           chainId: ChainId.ArbitrumOne,
           description: `Approve ${step.action.fromToken.symbol}`,
+          gasLimitFallback: LIFI_APPROVAL_GAS_FALLBACK,
         });
       }
     } catch (error) {
@@ -81,6 +96,7 @@ async function buildTransactionSteps({
     value: transactionValue,
     chainId: ChainId.ArbitrumOne,
     description: `Swap ${step.action.fromToken.symbol} to ${step.action.toToken.symbol}`,
+    gasLimitFallback: LIFI_TRANSACTION_GAS_FALLBACK,
   });
 
   return transactionSteps;

--- a/packages/app/src/app/api/onchain-actions/v1/earn/types.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/types.ts
@@ -206,6 +206,10 @@ export interface TransactionStep {
   value?: string;
   chainId: number;
   description?: string;
+  // Per-vendor gas-limit hint, used as a fallback when on-chain `estimateGas`
+  // simulation fails (e.g., Pendle router pre-conditions, slippage edges).
+  // Derived from observed on-chain history per vendor; see useEarnGasEstimate.
+  gasLimitFallback?: number;
 }
 
 /** Pre-built template for the transaction details popup (minus runtime fields). */

--- a/packages/app/src/components/earn/EarnActionPanel/EarnGasEstimateDisplay.tsx
+++ b/packages/app/src/components/earn/EarnActionPanel/EarnGasEstimateDisplay.tsx
@@ -29,5 +29,9 @@ export function EarnGasEstimateDisplay({
   const usdValue = estimate.usd ? Number(estimate.usd) : null;
   const formattedUsd = usdValue != null && Number.isFinite(usdValue) ? formatUSD(usdValue) : null;
 
-  return <span className="text-xs text-white">{formattedUsd ?? `~${estimate.eth} ETH`}</span>;
+  return (
+    <span className="text-xs text-white">
+      {formattedUsd ? `~${formattedUsd}` : `~${estimate.eth} ETH`}
+    </span>
+  );
 }

--- a/packages/app/src/components/earn/LiquidStakingActionPanel.tsx
+++ b/packages/app/src/components/earn/LiquidStakingActionPanel.tsx
@@ -25,6 +25,10 @@ import { EarnActionTabs } from './EarnActionPanel/EarnActionTabs';
 import { EarnErrorDisplay } from './EarnActionPanel/EarnErrorDisplay';
 import { EarnGasEstimateDisplay } from './EarnActionPanel/EarnGasEstimateDisplay';
 import { EarnPositionValueCard } from './EarnActionPanel/EarnPositionValueCard';
+import {
+  EarnTransactionDetailsSection,
+  type TransactionDetail,
+} from './EarnActionPanel/EarnTransactionDetailsSection';
 import type { TransactionDetails } from './EarnTransactionDetailsPopup';
 import { LiquidStakingAmountSection } from './LiquidStakingAmountSection';
 import { LiquidStakingReceiveSection } from './LiquidStakingReceiveSection';
@@ -385,27 +389,23 @@ export function LiquidStakingActionPanel({
           slippagePercent={controls.slippagePercent}
           onSlippageChange={controls.onSlippageChange}
         />
-        <div className="flex flex-col gap-3">
-          <div className="flex items-center">
-            <span className="text-xs text-white">Transaction Details</span>
-          </div>
-          {opportunity.apy && (
-            <div className="flex items-center justify-between">
-              <span className="text-xs text-white/40">APY</span>
-              <span className="text-xs text-white">{opportunity.apy}</span>
-            </div>
-          )}
-          <div className="flex items-center justify-between">
-            <span className="text-xs text-white/40">Transaction Cost</span>
-            <span className="text-xs text-white">
-              <EarnGasEstimateDisplay
-                estimate={data.estimatedTxCostUsd}
-                isLoading={data.isGasEstimateLoading}
-                error={data.gasEstimateError}
-              />
-            </span>
-          </div>
-        </div>
+        <EarnTransactionDetailsSection
+          details={[
+            ...(opportunity.apy
+              ? [{ label: 'APY', value: opportunity.apy } satisfies TransactionDetail]
+              : []),
+            {
+              label: 'Transaction Cost',
+              value: (
+                <EarnGasEstimateDisplay
+                  estimate={data.estimatedTxCostUsd}
+                  isLoading={data.isGasEstimateLoading}
+                  error={data.gasEstimateError}
+                />
+              ),
+            },
+          ]}
+        />
       </div>
 
       <EarnErrorDisplay error={execution.txError} />

--- a/packages/app/src/components/earn/PendleActionPanel.tsx
+++ b/packages/app/src/components/earn/PendleActionPanel.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo } from 'react';
 import { useAccount } from 'wagmi';
 
 import { type PendleAction, getPendleSettlementTokens } from '@/app-hooks/earn/pendlePanelUtils';
-import type { GasEstimate } from '@/app-hooks/earn/useEarnGasEstimate';
 import { useEarnTokenPrice } from '@/app-hooks/earn/useEarnPrices';
 import { usePendlePanelControls } from '@/app-hooks/earn/usePendlePanelControls';
 import { usePendlePanelData } from '@/app-hooks/earn/usePendlePanelData';
@@ -32,32 +31,16 @@ import { SlippageSettingsPanel } from './SlippageSettingsPanel';
 
 function PendleTransactionInfo({
   transactionDetails,
-  estimatedTxCost,
-  isGasEstimateLoading,
-  gasEstimateError,
   slippagePercent,
   onSlippageChange,
 }: {
   transactionDetails: TransactionDetail[];
-  estimatedTxCost: GasEstimate | null;
-  isGasEstimateLoading: boolean;
-  gasEstimateError: Error | null;
   slippagePercent: number;
   onSlippageChange: (value: number) => void;
 }) {
   return (
     <div className="flex flex-col gap-3">
       <EarnTransactionDetailsSection details={transactionDetails} />
-      <div className="flex items-center justify-between">
-        <span className="text-xs text-white/40">Transaction Cost</span>
-        <span className="text-xs text-white">
-          <EarnGasEstimateDisplay
-            estimate={estimatedTxCost}
-            isLoading={isGasEstimateLoading}
-            error={gasEstimateError}
-          />
-        </span>
-      </div>
       <SlippageSettingsPanel
         slippagePercent={slippagePercent}
         onSlippageChange={onSlippageChange}
@@ -212,8 +195,25 @@ export function PendleActionPanel({
       });
     }
 
+    details.push({
+      label: 'Transaction Cost',
+      value: (
+        <EarnGasEstimateDisplay
+          estimate={data.estimatedTxCost}
+          isLoading={data.isGasEstimateLoading}
+          error={data.gasEstimateError}
+        />
+      ),
+    });
+
     return details;
-  }, [data.fixedApy, data.priceImpact]);
+  }, [
+    data.estimatedTxCost,
+    data.fixedApy,
+    data.gasEstimateError,
+    data.isGasEstimateLoading,
+    data.priceImpact,
+  ]);
 
   const enterTokenControl =
     selectedInputToken != null
@@ -289,9 +289,6 @@ export function PendleActionPanel({
 
   const sharedTransactionInfoProps = {
     transactionDetails,
-    estimatedTxCost: data.estimatedTxCost,
-    isGasEstimateLoading: data.isGasEstimateLoading,
-    gasEstimateError: data.gasEstimateError,
     slippagePercent,
     onSlippageChange,
   };

--- a/packages/app/src/hooks/earn/useEarnGasEstimate.test.tsx
+++ b/packages/app/src/hooks/earn/useEarnGasEstimate.test.tsx
@@ -9,6 +9,7 @@ import { useEarnGasEstimate } from './useEarnGasEstimate';
 
 const mockEstimateGas = vi.fn();
 const mockGetGasPrice = vi.fn();
+const mockEthPrice = vi.fn(() => 0);
 
 vi.mock('@uidotdev/usehooks', () => ({
   useDebounce: <T,>(value: T) => value,
@@ -21,6 +22,15 @@ vi.mock('wagmi', () => ({
 
 vi.mock('wagmi/actions', () => ({
   estimateGas: (...args: unknown[]) => mockEstimateGas(...args),
+}));
+
+vi.mock('@/bridge/hooks/useETHPrice', () => ({
+  useETHPrice: () => ({
+    ethPrice: mockEthPrice(),
+    ethToUSD: (eth: number) => eth * mockEthPrice(),
+    isValidating: false,
+    mutate: vi.fn(),
+  }),
 }));
 
 /**
@@ -56,6 +66,7 @@ const defaultParams = {
 
 afterEach(() => {
   vi.clearAllMocks();
+  mockEthPrice.mockReturnValue(0);
 });
 
 describe('useEarnGasEstimate', () => {
@@ -209,16 +220,18 @@ describe('useEarnGasEstimate', () => {
       expect(result.current.estimate?.eth).toBe('0.000021');
     });
 
-    it('includes USD estimate from apiEstimate when provided', async () => {
+    it('derives USD estimate from onchain ETH cost and ETH price', async () => {
+      // gasPrice = 1 gwei, gasLimit = 21000 => 0.000021 ETH * $4000 = $0.084
       mockGetGasPrice.mockResolvedValue(BigInt(1_000_000_000));
       mockEstimateGas.mockResolvedValue(BigInt(21_000));
+      mockEthPrice.mockReturnValue(4000);
 
       const { result } = renderHook(
         () =>
           useEarnGasEstimate({
             ...defaultParams,
             transactionSteps: [makeStep()],
-            apiEstimate: '1.5',
+            apiEstimate: '0',
           }),
         { wrapper: testWrapper },
       );
@@ -228,7 +241,7 @@ describe('useEarnGasEstimate', () => {
       });
 
       expect(result.current.estimate?.eth).toBe('0.000021');
-      expect(result.current.estimate?.usd).toBe('1.50');
+      expect(result.current.estimate?.usd).toBe('0.084000');
     });
   });
 
@@ -332,9 +345,11 @@ describe('useEarnGasEstimate', () => {
   });
 
   describe('non-allowance errors', () => {
-    it('surfaces non-allowance errors', async () => {
+    it('falls back to heuristic gas estimate for non-allowance simulation failures', async () => {
+      // gasPrice = 1 gwei; transaction fallback = 1_000_000 gas => 0.001 ETH @ $4000 = $4.00
       mockGetGasPrice.mockResolvedValue(BigInt(1_000_000_000));
       mockEstimateGas.mockRejectedValue(new Error('execution reverted'));
+      mockEthPrice.mockReturnValue(4000);
 
       const { result } = renderHook(
         () =>
@@ -346,11 +361,62 @@ describe('useEarnGasEstimate', () => {
       );
 
       await waitFor(() => {
-        expect(result.current.error).not.toBeNull();
+        expect(result.current.estimate).not.toBeNull();
       });
 
-      expect(result.current.error?.message).toBe('execution reverted');
-      expect(result.current.estimate).toBeNull();
+      expect(result.current.estimate?.eth).toBe('0.001000');
+      expect(result.current.estimate?.usd).toBe('4.000000');
+      expect(result.current.error).toBeNull();
+    });
+
+    it('falls back to heuristic gas estimate when one step in a multi-step quote fails', async () => {
+      // First (approval) step: 21000 gas; second (transaction) step: simulation reverts → 1_000_000 fallback
+      mockGetGasPrice.mockResolvedValue(BigInt(1_000_000_000));
+      mockEstimateGas
+        .mockResolvedValueOnce(BigInt(21_000))
+        .mockRejectedValueOnce(new Error('execution reverted'));
+
+      const { result } = renderHook(
+        () =>
+          useEarnGasEstimate({
+            ...defaultParams,
+            transactionSteps: [
+              makeStep({ step: 1, type: 'approval' }),
+              makeStep({ step: 2, type: 'transaction' }),
+            ],
+          }),
+        { wrapper: testWrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.estimate).not.toBeNull();
+      });
+
+      // 21_000 + 1_000_000 = 1_021_000 gas at 1 gwei = 0.001021 ETH
+      expect(result.current.estimate?.eth).toBe('0.001021');
+      expect(result.current.error).toBeNull();
+    });
+
+    it('prefers the step-level gasLimitFallback over the generic default', async () => {
+      // Adapter attaches a vendor-specific fallback (e.g. Vaults: 250_000)
+      mockGetGasPrice.mockResolvedValue(BigInt(1_000_000_000));
+      mockEstimateGas.mockRejectedValue(new Error('execution reverted'));
+
+      const { result } = renderHook(
+        () =>
+          useEarnGasEstimate({
+            ...defaultParams,
+            transactionSteps: [makeStep({ gasLimitFallback: 250_000 })],
+          }),
+        { wrapper: testWrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.estimate).not.toBeNull();
+      });
+
+      // 250_000 gas at 1 gwei = 0.000250 ETH (not the generic 1M default)
+      expect(result.current.estimate?.eth).toBe('0.000250');
     });
   });
 
@@ -367,7 +433,7 @@ describe('useEarnGasEstimate', () => {
       );
 
       // No onchain estimate possible (no steps), so API fallback kicks in
-      expect(result.current.estimate).toEqual({ eth: '—', usd: '2.50' });
+      expect(result.current.estimate).toEqual({ eth: '—', usd: '2.500000' });
       expect(result.current.isLoading).toBe(false);
     });
 
@@ -388,6 +454,7 @@ describe('useEarnGasEstimate', () => {
     it('prefers onchain estimate over API fallback', async () => {
       mockGetGasPrice.mockResolvedValue(BigInt(1_000_000_000));
       mockEstimateGas.mockResolvedValue(BigInt(21_000));
+      mockEthPrice.mockReturnValue(4000);
 
       const { result } = renderHook(
         () =>
@@ -403,9 +470,9 @@ describe('useEarnGasEstimate', () => {
         expect(result.current.estimate).not.toBeNull();
       });
 
-      // Onchain estimate is used, with USD from apiEstimate
+      // Onchain ETH cost converted via ETH price (21000 * 1 gwei = 0.000021 ETH * $4000)
       expect(result.current.estimate?.eth).toBe('0.000021');
-      expect(result.current.estimate?.usd).toBe('5.00');
+      expect(result.current.estimate?.usd).toBe('0.084000');
     });
   });
 });

--- a/packages/app/src/hooks/earn/useEarnGasEstimate.ts
+++ b/packages/app/src/hooks/earn/useEarnGasEstimate.ts
@@ -6,6 +6,7 @@ import useSWR from 'swr';
 import { useConfig, usePublicClient } from 'wagmi';
 import { estimateGas } from 'wagmi/actions';
 
+import { useETHPrice } from '@/bridge/hooks/useETHPrice';
 import type { TransactionStep } from '@/earn-api/types';
 
 interface UseEarnGasEstimateParams {
@@ -45,6 +46,21 @@ function isAllowanceRelatedError(err: unknown): boolean {
   );
 }
 
+// Generic fallback gas limits used when on-chain simulation throws AND the
+// adapter didn't attach a vendor-specific `gasLimitFallback` to the step.
+// Adapters set their own values based on observed history; this is a safety
+// net only. Surfacing a rough estimate is better than showing "-" — real
+// submit-time errors still bubble up to the user from the transaction
+// execution path.
+const FALLBACK_GAS_LIMITS: Record<'approval' | 'transaction', number> = {
+  approval: 80_000,
+  transaction: 1_000_000,
+};
+
+function getFallbackGasLimit(step: TransactionStep): BigNumber {
+  return BigNumber.from(step.gasLimitFallback ?? FALLBACK_GAS_LIMITS[step.type]);
+}
+
 export function useEarnGasEstimate({
   transactionSteps,
   chainId,
@@ -54,24 +70,18 @@ export function useEarnGasEstimate({
 }: UseEarnGasEstimateParams): UseEarnGasEstimateResult {
   const wagmiConfig = useConfig();
   const publicClient = usePublicClient({ chainId });
+  const { ethToUSD } = useETHPrice();
   const hasSteps = transactionSteps && transactionSteps.length > 0;
 
   const {
-    data: onchainEstimate,
+    data: onchainEstimateEth,
     error: onchainError,
     isLoading: isOnchainLoading,
   } = useSWR(
     enabled && hasSteps && walletAddress && publicClient && chainId !== 0
-      ? ([
-          transactionSteps,
-          walletAddress,
-          chainId,
-          apiEstimate,
-          publicClient,
-          'earn-gas-estimate',
-        ] as const)
+      ? ([transactionSteps, walletAddress, chainId, publicClient, 'earn-gas-estimate'] as const)
       : null,
-    async ([_steps, _walletAddress, _chainId, _apiEstimate, _publicClient]) => {
+    async ([_steps, _walletAddress, _chainId, _publicClient]) => {
       const chainSteps = _steps.filter((step) => step.chainId === _chainId);
 
       if (chainSteps.length === 0) {
@@ -80,7 +90,6 @@ export function useEarnGasEstimate({
 
       const gasPrice = BigNumber.from((await _publicClient.getGasPrice()).toString());
 
-      // Estimate gas for each step; approval/allowance failures are treated as zero-cost
       const perStepCosts = await Promise.all(
         chainSteps.map(async (step) => {
           try {
@@ -97,24 +106,16 @@ export function useEarnGasEstimate({
             if (step.type === 'approval' || isAllowanceRelatedError(err)) {
               return BigNumber.from(0);
             }
-            throw err;
+            return getFallbackGasLimit(step).mul(gasPrice);
           }
         }),
       );
 
-      const hasValidEstimate = perStepCosts.some((cost) => !cost.isZero());
-      if (!hasValidEstimate && perStepCosts.length > 0) {
+      const totalGasCostWei = perStepCosts.reduce((sum, cost) => sum.add(cost), BigNumber.from(0));
+      if (totalGasCostWei.isZero()) {
         return null;
       }
-
-      const totalGasCostWei = perStepCosts.reduce((sum, cost) => sum.add(cost), BigNumber.from(0));
-      const totalGasCostEth = Number(utils.formatEther(totalGasCostWei));
-      const apiEstimateUsd = parseApiEstimateUsd(_apiEstimate);
-
-      return {
-        eth: totalGasCostEth.toFixed(6),
-        usd: apiEstimateUsd != null ? apiEstimateUsd.toFixed(2) : null,
-      } satisfies GasEstimate;
+      return Number(utils.formatEther(totalGasCostWei));
     },
     {
       revalidateOnFocus: false,
@@ -125,16 +126,27 @@ export function useEarnGasEstimate({
     },
   );
 
+  const onchainEstimate = useMemo<GasEstimate | null>(() => {
+    if (typeof onchainEstimateEth !== 'number') {
+      return null;
+    }
+    const usdValue = ethToUSD(onchainEstimateEth);
+    return {
+      eth: onchainEstimateEth.toFixed(6),
+      usd: usdValue > 0 ? usdValue.toFixed(6) : null,
+    };
+  }, [onchainEstimateEth, ethToUSD]);
+
   // --- API fallback: used only when onchain estimation is unavailable ---
   const apiGasEstimate = useMemo<GasEstimate | null>(() => {
     if (onchainEstimate || isOnchainLoading) {
       return null;
     }
     const cost = parseApiEstimateUsd(apiEstimate);
-    if (cost == null) {
+    if (cost == null || cost <= 0) {
       return null;
     }
-    return { eth: '—', usd: cost.toFixed(2) };
+    return { eth: '—', usd: cost.toFixed(6) };
   }, [apiEstimate, onchainEstimate, isOnchainLoading]);
 
   return {

--- a/packages/app/src/hooks/earn/useEarnGasEstimate.ts
+++ b/packages/app/src/hooks/earn/useEarnGasEstimate.ts
@@ -103,7 +103,7 @@ export function useEarnGasEstimate({
 
             return BigNumber.from(gasLimit.toString()).mul(gasPrice);
           } catch (err) {
-            if (step.type === 'approval' || isAllowanceRelatedError(err)) {
+            if (isAllowanceRelatedError(err)) {
               return BigNumber.from(0);
             }
             return getFallbackGasLimit(step).mul(gasPrice);

--- a/packages/app/src/hooks/earn/usePendlePanelExecution.ts
+++ b/packages/app/src/hooks/earn/usePendlePanelExecution.ts
@@ -179,12 +179,7 @@ export function usePendlePanelExecution({
             timestamp,
             protocolName: 'Pendle',
             protocolLogo: opportunity.protocolIcon,
-            networkFee: estimatedTxCost
-              ? {
-                  amount: estimatedTxCost.eth,
-                  usd: estimatedTxCost.usd ?? '0.00',
-                }
-              : undefined,
+            networkFee: estimatedTxCost ? { amount: estimatedTxCost.eth } : undefined,
             opportunityName: opportunity.name ?? opportunity.token,
           },
           true,


### PR DESCRIPTION
## Summary
- Add per-vendor `gasLimitFallback` on `TransactionStep` (Vaults, Pendle, LiFi) so the gas estimate degrades to a sensible number when on-chain `estimateGas()` throws, instead of showing \"-\" to the user. Values are derived from sampled on-chain history (links in adapter comments).
- Switch USD conversion in `useEarnGasEstimate` to live ETH price via `useETHPrice`, replacing the unrelated API estimate value previously carried through the SWR key.
- Prefix USD with `~` in `EarnGasEstimateDisplay` to match the ETH fallback formatting.
- Move the \"Transaction Cost\" row in `LiquidStakingActionPanel` and `PendleActionPanel` into the shared `EarnTransactionDetailsSection` so all action panels render details consistently.

## Test plan
- [ ] Vault supply/withdraw: gas estimate renders as `~$X`
- [ ] Pendle enter/exit: gas estimate renders, falls back to vendor limit when simulation fails
- [ ] LiFi buy/sell: gas estimate renders for both diamond and aggregator routes
- [ ] Confirm `useEarnGasEstimate` unit tests pass (`pnpm test:ci`)