### PR TITLE
fix(earn): QA cleanup

### DIFF
--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/LiFiAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/LiFiAdapter.ts
@@ -1,8 +1,9 @@
 import { createConfig, getStepTransaction, getTransactionHistory } from '@lifi/sdk';
-import { createPublicClient, http } from 'viem';
+import { createPublicClient, fallback, http } from 'viem';
 import { arbitrum } from 'viem/chains';
 
 import { LIFI_INTEGRATOR_IDS, getLifiRoutes } from '@/bridge/app/api/crosschain-transfers/lifi';
+import { PORTAL_DOMAIN } from '@/bridge/constants';
 import { ChainId } from '@/bridge/types/ChainId';
 import { rpcURLs } from '@/bridge/util/networks';
 
@@ -48,9 +49,20 @@ export class LiFiAdapter implements VendorAdapter {
   vendor = Vendor.LiFi;
 
   private getArbitrumPublicClient() {
+    const isNonProd = process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production';
+
+    // Server-side RPC requests have no browser Origin header, which makes Alchemy reject keys without allowlisted Origins.
+    // Hence, set the origin explicitly to the portal domain that would be allowlisted by the Alchemy key.
+    const origin =
+      isNonProd && process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : PORTAL_DOMAIN;
     return createPublicClient({
       chain: arbitrum,
-      transport: http(rpcURLs[ChainId.ArbitrumOne]),
+      transport: fallback([
+        http(rpcURLs[ChainId.ArbitrumOne], {
+          fetchOptions: { headers: { Origin: origin } },
+        }),
+        http('https://arb1.arbitrum.io/rpc'), // public Arbitrum RPC as a fallback in case Alchemy RPC ever fails for whatever reason
+      ]),
     });
   }
 

--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/VaultsAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/VaultsAdapter.ts
@@ -75,24 +75,22 @@ export class VaultsAdapter implements VendorAdapter {
       query: {
         allowedNetworks: network ? ([network] as VaultsNetwork[]) : undefined,
         allowedProtocols: ['aave', 'compound', 'fluid', 'morpho'] satisfies VaultsProtocol[],
+        onlyTransactional: true,
         minTvl: filters.minTvl,
         allowedAssets: [...DEFAULT_ALLOWED_ASSETS],
         perPage: filters.perPage || 50,
       },
     });
 
-    const vaults = response.data;
-
-    let filtered = vaults;
-    if (filters.minApy) {
-      filtered = filtered.filter((vault) => {
-        const apyData = vault.apy?.['30day'] ?? vault.apy?.['7day'] ?? vault.apy?.['1day'];
-        const apyPercentage = parseOptionalPercentage(apyData?.total);
-        return (
-          apyPercentage !== null && filters.minApy !== undefined && apyPercentage >= filters.minApy
-        );
-      });
-    }
+    const minApy = filters.minApy ?? 0;
+    const filtered = response.data.filter((vault) => {
+      const apyData = vault.apy?.['30day'] ?? vault.apy?.['7day'] ?? vault.apy?.['1day'];
+      const apyPercentage = parseOptionalPercentage(apyData?.total);
+      if (apyPercentage === null || apyPercentage <= 0) {
+        return false;
+      }
+      return apyPercentage >= minApy;
+    });
 
     return filtered.map((vault) => this.transformToStandard(vault));
   }

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/vaultsSdk.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/vaultsSdk.ts
@@ -18,7 +18,6 @@ export const DEFAULT_ALLOWED_ASSETS = [
   'osETH',
   'pufETH',
   'rETH',
-  'rsETH',
   'stETH',
   'tETH',
   'UETH',

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/zerionPriceSources.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/zerionPriceSources.ts
@@ -66,21 +66,23 @@ const PRICE_BY_SYMBOL: Record<string, ZerionPriceLookup> = {
 // Keyed by `${chainId}:${lowercaseAddress}` — used when the exact contract
 // is known from on-chain or vendor metadata.
 const PRICE_BY_ADDRESS: Record<string, ZerionPriceLookup> = {
+  // Zerion's Arbitrum impls for WETH/WSTETH/WBTC resolve to a multi-chain
+  // fungible with no chart attached, so route to the Ethereum impl instead.
   [`${ChainId.ArbitrumOne}:${CommonAddress.ArbitrumOne.WETH.toLowerCase()}`]: impl(
-    ARB,
-    CommonAddress.ArbitrumOne.WETH,
+    ETH,
+    CommonAddress.Ethereum.WETH,
   ),
   [`${ChainId.ArbitrumOne}:${CommonAddress.ArbitrumOne.WSTETH.toLowerCase()}`]: impl(
-    ARB,
-    CommonAddress.ArbitrumOne.WSTETH,
+    ETH,
+    CommonAddress.Ethereum.WSTETH,
   ),
   [`${ChainId.ArbitrumOne}:${CommonAddress.ArbitrumOne.WEETH.toLowerCase()}`]: impl(
     ARB,
     CommonAddress.ArbitrumOne.WEETH,
   ),
   [`${ChainId.ArbitrumOne}:${CommonAddress.ArbitrumOne.WBTC.toLowerCase()}`]: impl(
-    ARB,
-    CommonAddress.ArbitrumOne.WBTC,
+    ETH,
+    CommonAddress.Ethereum.WBTC,
   ),
   [`${ChainId.ArbitrumOne}:${CommonAddress.ArbitrumOne.ARB.toLowerCase()}`]: impl(
     ARB,

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunities/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunities/route.ts
@@ -13,7 +13,9 @@ const MAX_RESULTS = 50;
 const CACHE_HEADERS = { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=3600' };
 const router = new CategoryRouter();
 
-export const revalidate = 3600;
+// Reads `request.nextUrl.searchParams`, so this route can't be statically
+// rendered. CDN caching is handled by the `Cache-Control` header below.
+export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
   try {

--- a/packages/app/src/app/api/onchain-actions/v1/earn/positions/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/positions/route.ts
@@ -13,6 +13,10 @@ import { StandardUserPosition, Vendor } from '../types';
 
 const router = new CategoryRouter();
 
+// Reads `request.nextUrl.searchParams`, so this route can't be statically
+// rendered. The handler still memoizes per-user results via `unstable_cache`.
+export const dynamic = 'force-dynamic';
+
 const ALL_CATEGORIES: readonly OpportunityCategory[] = [
   OpportunityCategory.Lend,
   OpportunityCategory.LiquidStaking,

--- a/packages/app/src/components/earn/AllOpportunitiesPage.tsx
+++ b/packages/app/src/components/earn/AllOpportunitiesPage.tsx
@@ -4,7 +4,7 @@ import { usePostHog } from 'posthog-js/react';
 import { useCallback, useMemo } from 'react';
 import { useAccount } from 'wagmi';
 
-import { useAllOpportunities } from '@/app-hooks/earn/useAllOpportunities';
+import { DEFAULT_EARN_MIN_TVL, useAllOpportunities } from '@/app-hooks/earn/useAllOpportunities';
 import { useUserPositions } from '@/app-hooks/earn/useUserPositions';
 import {
   type OpportunitySelectHandler,
@@ -25,7 +25,7 @@ export function AllOpportunitiesPage() {
     opportunities: allOpportunities,
     isLoading: opportunitiesLoading,
     error: opportunitiesError,
-  } = useAllOpportunities({ chainId: ChainId.ArbitrumOne, minTvl: 5_000_000 });
+  } = useAllOpportunities({ chainId: ChainId.ArbitrumOne, minTvl: DEFAULT_EARN_MIN_TVL });
 
   const { positionsMap, isLoading: positionsLoading } = useUserPositions(
     isConnected ? (address ?? null) : null,

--- a/packages/app/src/components/earn/EarnFooter.tsx
+++ b/packages/app/src/components/earn/EarnFooter.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+
 import {
   ARBITRUM_TECHNOLOGY_LINK,
   DISCORD_LINK,
@@ -12,17 +14,26 @@ import {
 import { ExternalLink } from '@/components/ExternalLink';
 
 const EarnDisclaimer = () => (
-  <p>
-    The Arbitrum Portal is only a front-end interface for interacting with existing smart contract
-    protocols. It does not host or control the underlying DeFi smart contracts being presented to
-    you here, nor does it manage funds or make investing decisions on your behalf. You are solely
-    responsible for understanding how these protocols work before using them. To learn more about
-    the protocols we support and how we chose them, please visit our{' '}
-    <ExternalLink href={TERMS_OF_SERVICE_LINK} className="arb-hover text-white/50 underline">
-      terms of service page
-    </ExternalLink>
-    .
-  </p>
+  <div className="flex flex-col lg:flex-row items-start gap-5 rounded-2xl lg:bg-neutral-25 bg-transparent lg:p-8 py-8">
+    <div className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-2xl bg-neutral-50">
+      <ExclamationTriangleIcon className="h-6 w-6 text-white/50" />
+    </div>
+    <div className="flex flex-col gap-4 pt-3">
+      <p className="flex flex-wrap items-baseline gap-x-4">
+        <span className="font-medium text-white">Non-custodial interface.</span>
+        <span>
+          Third-party protocols only. Do your own independent research and proceed at your own risk.
+        </span>
+      </p>
+      <p>
+        Arbitrum Earn is a non-custodial interface for interacting with 3rd party protocols. Any
+        transactions are facilitated by 3rd party protocols that are not controlled by Arbitrum
+        Earn. Base APY, Rewards or any other amounts are provided by such protocols, not Arbitrum
+        Earn. Data is provided by 3rd parties for informational purposes only. Do your own research
+        and proceed at your own risk.
+      </p>
+    </div>
+  </div>
 );
 
 const footerLinks = [

--- a/packages/app/src/components/earn/EarnToSPopupDialog.tsx
+++ b/packages/app/src/components/earn/EarnToSPopupDialog.tsx
@@ -49,14 +49,19 @@ export function EarnToSPopupDialog(props: DialogProps & { isOpen: boolean }) {
             Please acknowledge before proceeding
           </h2>
 
-          <div className="text-[14px] leading-[1.35] tracking-[-0.28px] text-white/70">
+          <div className="flex flex-col gap-4 text-[14px] leading-[1.35] tracking-[-0.28px] text-white/70">
             <p>
-              The Arbitrum Portal is only a front-end interface for interacting with existing smart
-              contract protocols. It does not host or control the underlying DeFi smart contracts
-              being presented to you here, nor does it manage funds or make investing decisions on
-              your behalf. You are solely responsible for understanding how these protocols work
-              before using them.
-              <br /> <br />
+              <span className="font-medium text-white">Non-custodial interface.</span> Third-party
+              protocols only. Do your own independent research and proceed at your own risk.
+            </p>
+            <p>
+              Arbitrum Earn is a non-custodial interface for interacting with 3rd party protocols.
+              Any transactions are facilitated by 3rd party protocols that are not controlled by
+              Arbitrum Earn. Base APY, Rewards or any other amounts are provided by such protocols,
+              not Arbitrum Earn. Data is provided by 3rd parties for informational purposes only. Do
+              your own research and proceed at your own risk.
+            </p>
+            <p>
               To learn more about the protocols we support and how we chose them, please visit our{' '}
               <ExternalLink
                 href={TERMS_OF_SERVICE_LINK}

--- a/packages/app/src/components/earn/MyPositionsPage.tsx
+++ b/packages/app/src/components/earn/MyPositionsPage.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
 import { useAccount, useAccountEffect } from 'wagmi';
 
-import { useAllOpportunities } from '@/app-hooks/earn/useAllOpportunities';
+import { DEFAULT_EARN_MIN_TVL, useAllOpportunities } from '@/app-hooks/earn/useAllOpportunities';
 import { useUserPositions } from '@/app-hooks/earn/useUserPositions';
 import { OpportunityTableRow } from '@/app-types/earn/vaults';
 import { ChainId } from '@/bridge/types/ChainId';
@@ -30,7 +30,7 @@ export function MyPositionsPage() {
     opportunities: allOpportunities,
     isLoading: opportunitiesLoading,
     error: opportunitiesError,
-  } = useAllOpportunities({ chainId: ChainId.ArbitrumOne, minTvl: 5_000_000 });
+  } = useAllOpportunities({ chainId: ChainId.ArbitrumOne, minTvl: DEFAULT_EARN_MIN_TVL });
 
   const {
     positionsMap,

--- a/packages/app/src/components/earn/SlippageSettingsPanel.tsx
+++ b/packages/app/src/components/earn/SlippageSettingsPanel.tsx
@@ -43,8 +43,8 @@ export function SlippageSettingsPanel({
 
   const isSlippageValid = Number.isFinite(draft) && draft >= SLIPPAGE_MIN && draft <= SLIPPAGE_MAX;
   const activePreset = customInput === '' && isPreset(draft) ? draft : null;
-  const slippageIsTooLow = isSlippageValid && draft <= 0.01;
-  const slippageIsTooHigh = isSlippageValid && draft >= 1;
+  const slippageIsTooLow = isSlippageValid && draft <= SLIPPAGE_MIN;
+  const slippageIsTooHigh = isSlippageValid && draft > 1;
 
   const handleUpdate = useCallback(() => {
     if (!isSlippageValid) return;

--- a/packages/app/src/components/earn/SlippageSettingsPanel.tsx
+++ b/packages/app/src/components/earn/SlippageSettingsPanel.tsx
@@ -1,7 +1,15 @@
 'use client';
 
-import { Cog6ToothIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import {
+  ArrowTopRightOnSquareIcon,
+  Cog6ToothIcon,
+  ExclamationCircleIcon,
+  InformationCircleIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
 import { useCallback, useState } from 'react';
+
+import { ExternalLink } from '@/components/ExternalLink';
 
 const SLIPPAGE_PRESETS = [0.2, 0.25, 0.5, 1] as const;
 const SLIPPAGE_MIN = 0.01;
@@ -35,6 +43,8 @@ export function SlippageSettingsPanel({
 
   const isSlippageValid = Number.isFinite(draft) && draft >= SLIPPAGE_MIN && draft <= SLIPPAGE_MAX;
   const activePreset = customInput === '' && isPreset(draft) ? draft : null;
+  const slippageIsTooLow = isSlippageValid && draft <= 0.01;
+  const slippageIsTooHigh = isSlippageValid && draft >= 1;
 
   const handleUpdate = useCallback(() => {
     if (!isSlippageValid) return;
@@ -84,9 +94,37 @@ export function SlippageSettingsPanel({
       </div>
       {open && (
         <>
-          <p className="text-xs text-gray-650">
-            Select the maximum amount of slippage you&apos;re willing to accept on this swap.
-          </p>
+          <div className="flex flex-nowrap items-start gap-1 text-xs py-2">
+            {slippageIsTooLow ? (
+              <>
+                <ExclamationCircleIcon className="h-4 w-4 shrink-0 text-orange" />
+                <span className="text-orange">
+                  Slippage amount is low. You may see very limited route options.
+                </span>
+              </>
+            ) : slippageIsTooHigh ? (
+              <>
+                <ExclamationCircleIcon className="h-4 w-4 shrink-0 text-orange" />
+                <span className="text-orange">
+                  Slippage amount is high. Industry recommendation is 0.5% or less.
+                </span>
+              </>
+            ) : (
+              <>
+                <InformationCircleIcon className="h-4 w-4 shrink-0 text-gray-650" />
+                <span className="flex flex-wrap gap-1 whitespace-nowrap text-gray-650">
+                  0.5% - 1% is the recommended range for slippage.{' '}
+                  <ExternalLink
+                    href="https://www.ledger.com/academy/what-is-slippage-in-crypto"
+                    className="arb-hover flex items-center underline"
+                  >
+                    Read more
+                    <ArrowTopRightOnSquareIcon className="ml-[2px] h-3 w-3" />
+                  </ExternalLink>
+                </span>
+              </>
+            )}
+          </div>
           <div className="grid grid-cols-6 gap-2">
             {SLIPPAGE_PRESETS.map((p) => (
               <button

--- a/packages/app/src/hooks/earn/useAllOpportunities.ts
+++ b/packages/app/src/hooks/earn/useAllOpportunities.ts
@@ -8,6 +8,8 @@ import { OpportunityTableRow } from '@/app-types/earn/vaults';
 import { formatCompactUsd, formatPercentage } from '@/bridge/util/NumberUtils';
 import { type EarnChainId, type StandardOpportunity } from '@/earn-api/types';
 
+export const DEFAULT_EARN_MIN_TVL = 5_000_000;
+
 interface UseAllOpportunitiesResult {
   opportunities: OpportunityTableRow[];
   isLoading: boolean;

--- a/packages/app/src/hooks/earn/useEarnPrices.ts
+++ b/packages/app/src/hooks/earn/useEarnPrices.ts
@@ -10,7 +10,7 @@ import { ChainId } from '@/bridge/types/ChainId';
 import { addressesEqual } from '@/bridge/util/AddressUtils';
 import { type EarnChainId, OpportunityCategory } from '@/earn-api/types';
 
-import { useAllOpportunities } from './useAllOpportunities';
+import { DEFAULT_EARN_MIN_TVL, useAllOpportunities } from './useAllOpportunities';
 import { useUserPositions } from './useUserPositions';
 
 type AssetDescriptor = {
@@ -46,7 +46,10 @@ export function useEarnPrices(params?: {
   chainId?: EarnChainId;
 }): UseEarnPricesResult {
   const chainId = params?.chainId ?? ChainId.ArbitrumOne;
-  const { opportunities, isLoading: opportunitiesLoading } = useAllOpportunities({ chainId });
+  const { opportunities, isLoading: opportunitiesLoading } = useAllOpportunities({
+    chainId,
+    minTvl: DEFAULT_EARN_MIN_TVL,
+  });
   const { positionsMap, isLoading: positionsLoading } = useUserPositions(params?.userAddress, [
     chainId,
   ]);


### PR DESCRIPTION
## Summary
Bundled QA fixes, one commit per concern:

- **Dynamic routes** — mark `opportunities` and `positions` route handlers as `dynamic = 'force-dynamic'` to fix the `DYNAMIC_SERVER_USAGE` build error caused by reading `nextUrl.searchParams`. CDN/per-user caching preserved.
- **History chart 404** — route Arbitrum WETH/wstETH/WBTC chart lookups to their Ethereum impl (Zerion's Arbitrum impl is a chartless multi-chain fungible). weETH stays on Arbitrum.
- **minTvl consolidation** — export `DEFAULT_EARN_MIN_TVL` and apply it consistently across `AllOpportunitiesPage`, `MyPositionsPage`, and `useEarnPrices` (the latter was previously unfiltered).
- **Zero-APY + non-transactional filter** — drop vaults with `apy <= 0` or that aren't currently transactable; remove rsETH from vault-allowed assets (LST, not a lend asset).
- **Disclaimer copy** — refresh ToS dialog and `EarnFooter` to consistent "Non-custodial interface" messaging with matching visual treatment.
- **Slippage guidance** — context-sensitive warnings for too-low (≤ 0.01%), too-high (≥ 1%), and an info link for the default range.
- **LiFi server RPC fix** — Alchemy was rejecting server-side RPC calls because Vercel functions have no browser `Origin` header. Forge the `Origin` per request (per-deployment `VERCEL_URL` on preview/dev, `PORTAL_DOMAIN` in prod) and wrap the transport in `viem`'s `fallback()` with the public Arbitrum RPC as a safety net for any remaining rejections / partial outages.

## Test plan
- [ ] `pnpm build` succeeds (no `DYNAMIC_SERVER_USAGE`)
- [ ] Opportunity charts load for wstETH/WETH/WBTC across all timeframes
- [ ] Opportunities & holdings pages still filter by 5M TVL; `useEarnPrices` returns expected assets
- [ ] No 0-APY or paused vaults surface in the list
- [ ] ToS dialog + footer show updated copy
- [ ] Slippage panel shows the right warning for 0.01 / 0.5 / 1.5 values
- [ ] `/api/onchain-actions/v1/earn/positions` returns 200 with wstETH/weETH balances populated (no Alchemy "Unspecified origin" errors in Vercel logs)