### PR TITLE
perf(earn): vercel cache + rate limiting

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,6 +13,7 @@
     "@uidotdev/usehooks": "^2.4.1",
     "@uniswap/token-lists": "^1.0.0-beta.34",
     "@vaultsfyi/sdk": "^2.1.3",
+    "@vercel/firewall": "^1.2.1",
     "@wagmi/core": "^2.22.1",
     "dayjs": "^1.11.20",
     "next": "^14.2.35",

--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/LiFiAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/LiFiAdapter.ts
@@ -1,11 +1,7 @@
 import { createConfig, getStepTransaction, getTransactionHistory } from '@lifi/sdk';
-import { createPublicClient, fallback, http } from 'viem';
-import { arbitrum } from 'viem/chains';
 
 import { LIFI_INTEGRATOR_IDS, getLifiRoutes } from '@/bridge/app/api/crosschain-transfers/lifi';
-import { PORTAL_DOMAIN } from '@/bridge/constants';
 import { ChainId } from '@/bridge/types/ChainId';
-import { rpcURLs } from '@/bridge/util/networks';
 
 import { fetchDuneHistoricalData, fetchDuneHistoricalDataMerged } from '../lib/duneService';
 import { resolveAdapterWindow } from '../lib/historicalWindow';
@@ -20,6 +16,7 @@ import {
   updateLiquidStakingOpportunitiesWithDuneData,
   updateLiquidStakingOpportunityWithDuneData,
 } from '../lib/liquidStaking';
+import { createEarnPublicClient } from '../lib/serverPublicClient';
 import { ValidationError } from '../lib/validation';
 import { fetchAlignedPriceLookup } from '../lib/zerionService';
 import {
@@ -49,21 +46,7 @@ export class LiFiAdapter implements VendorAdapter {
   vendor = Vendor.LiFi;
 
   private getArbitrumPublicClient() {
-    const isNonProd = process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production';
-
-    // Server-side RPC requests have no browser Origin header, which makes Alchemy reject keys without allowlisted Origins.
-    // Hence, set the origin explicitly to the portal domain that would be allowlisted by the Alchemy key.
-    const origin =
-      isNonProd && process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : PORTAL_DOMAIN;
-    return createPublicClient({
-      chain: arbitrum,
-      transport: fallback([
-        http(rpcURLs[ChainId.ArbitrumOne], {
-          fetchOptions: { headers: { Origin: origin } },
-        }),
-        http('https://arb1.arbitrum.io/rpc'), // public Arbitrum RPC as a fallback in case Alchemy RPC ever fails for whatever reason
-      ]),
-    });
+    return createEarnPublicClient(ChainId.ArbitrumOne);
   }
 
   private async getQuoteStep(params: {

--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/LiFiAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/LiFiAdapter.ts
@@ -16,7 +16,7 @@ import {
   updateLiquidStakingOpportunitiesWithDuneData,
   updateLiquidStakingOpportunityWithDuneData,
 } from '../lib/liquidStaking';
-import { createEarnPublicClient } from '../lib/serverPublicClient';
+import { createServerSidePublicClient } from '../lib/serverPublicClient';
 import { ValidationError } from '../lib/validation';
 import { fetchAlignedPriceLookup } from '../lib/zerionService';
 import {
@@ -46,7 +46,7 @@ export class LiFiAdapter implements VendorAdapter {
   vendor = Vendor.LiFi;
 
   private getArbitrumPublicClient() {
-    return createEarnPublicClient(ChainId.ArbitrumOne);
+    return createServerSidePublicClient(ChainId.ArbitrumOne);
   }
 
   private async getQuoteStep(params: {

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/cache.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/cache.ts
@@ -1,0 +1,30 @@
+export const EARN_CACHE_SECONDS = {
+  opportunities: 6 * 60 * 60,
+  historical1d: 6 * 60 * 60,
+  historicalDefault: 24 * 60 * 60,
+  positions: 3 * 60 * 60,
+  transactions: 3 * 60 * 60,
+} as const;
+
+const normalize = (value: string) => value.toLowerCase();
+
+export const earnCacheTags = {
+  opportunities: () => ['earn', 'earn:opportunities'],
+  opportunity: (id: string) => ['earn', 'earn:opportunities', `earn:opportunity:${normalize(id)}`],
+  historical: () => ['earn', 'earn:historical'],
+  historicalOpportunity: (id: string) => [
+    'earn',
+    'earn:historical',
+    `earn:historical:${normalize(id)}`,
+  ],
+  positions: (wallet: string) => ['earn', 'earn:positions', `earn:positions:${normalize(wallet)}`],
+  transactions: (wallet: string) => [
+    'earn',
+    'earn:transactions',
+    `earn:transactions:${normalize(wallet)}`,
+  ],
+  userAction: (wallet: string) => [
+    `earn:positions:${normalize(wallet)}`,
+    `earn:transactions:${normalize(wallet)}`,
+  ],
+};

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/cache.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/cache.ts
@@ -18,13 +18,17 @@ export const earnCacheTags = {
     `earn:historical:${normalize(id)}`,
   ],
   positions: (wallet: string) => ['earn', 'earn:positions', `earn:positions:${normalize(wallet)}`],
-  transactions: (wallet: string) => [
-    'earn',
-    'earn:transactions',
-    `earn:transactions:${normalize(wallet)}`,
-  ],
-  userAction: (wallet: string) => [
+  transactions: (wallet: string, opportunityId?: string) => {
+    const tags = ['earn', 'earn:transactions', `earn:transactions:${normalize(wallet)}`];
+    if (opportunityId) {
+      tags.push(`earn:transactions:${normalize(wallet)}:${normalize(opportunityId)}`);
+    }
+    return tags;
+  },
+  userAction: (wallet: string, opportunityId?: string) => [
     `earn:positions:${normalize(wallet)}`,
-    `earn:transactions:${normalize(wallet)}`,
+    opportunityId
+      ? `earn:transactions:${normalize(wallet)}:${normalize(opportunityId)}`
+      : `earn:transactions:${normalize(wallet)}`,
   ],
 };

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/rateLimit.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/rateLimit.ts
@@ -1,0 +1,27 @@
+import { checkRateLimit } from '@vercel/firewall';
+import { NextResponse } from 'next/server';
+
+const EARN_RATE_LIMIT_ID = 'earn-api';
+
+export async function enforceEarnRateLimit(
+  request: Request,
+  options?: { key?: string | null },
+): Promise<NextResponse | null> {
+  const { rateLimited } = await checkRateLimit(EARN_RATE_LIMIT_ID, {
+    request,
+    rateLimitKey: options?.key?.trim().toLowerCase() || undefined,
+  });
+
+  if (!rateLimited) return null;
+
+  return NextResponse.json(
+    { message: 'Rate limit exceeded', code: 'RATE_LIMIT_EXCEEDED' },
+    {
+      status: 429,
+      headers: {
+        'Cache-Control': 'private, no-store',
+        'Retry-After': '60',
+      },
+    },
+  );
+}

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/serverPublicClient.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/serverPublicClient.ts
@@ -1,0 +1,42 @@
+import { createPublicClient, fallback, http } from 'viem';
+import { arbitrum, mainnet } from 'viem/chains';
+
+import { PORTAL_DOMAIN } from '@/bridge/constants';
+import { ChainId } from '@/bridge/types/ChainId';
+import { rpcURLs } from '@/bridge/util/networks';
+
+import type { EarnChainId } from '../types';
+import { ValidationError } from './validation';
+
+function getServerOrigin() {
+  const vercelUrl = process.env.VERCEL_URL?.trim();
+  if (vercelUrl) {
+    return vercelUrl.startsWith('http') ? vercelUrl : `https://${vercelUrl}`;
+  }
+
+  return process.env.PORTAL_DOMAIN?.trim() || PORTAL_DOMAIN;
+}
+
+function getEarnChain(chainId: EarnChainId) {
+  if (chainId === ChainId.Ethereum) return mainnet;
+  if (chainId === ChainId.ArbitrumOne) return arbitrum;
+  throw new ValidationError('UNSUPPORTED_CHAIN_ID', `Unsupported chainId ${chainId}`);
+}
+
+export function createEarnPublicClient(chainId: EarnChainId) {
+  const chain = getEarnChain(chainId);
+  const primaryRpcUrl = rpcURLs[chainId];
+  const publicRpcUrl = chain.rpcUrls.default.http[0];
+  const primaryTransport = http(primaryRpcUrl, {
+    fetchOptions: { headers: { Origin: getServerOrigin() } },
+  });
+  const transport =
+    publicRpcUrl && publicRpcUrl !== primaryRpcUrl
+      ? fallback([primaryTransport, http(publicRpcUrl)])
+      : primaryTransport;
+
+  return createPublicClient({
+    chain,
+    transport,
+  });
+}

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/serverPublicClient.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/serverPublicClient.ts
@@ -23,7 +23,7 @@ function getEarnChain(chainId: EarnChainId) {
   throw new ValidationError('UNSUPPORTED_CHAIN_ID', `Unsupported chainId ${chainId}`);
 }
 
-export function createEarnPublicClient(chainId: EarnChainId) {
+export function createServerSidePublicClient(chainId: EarnChainId) {
   const chain = getEarnChain(chainId);
   const primaryRpcUrl = rpcURLs[chainId];
   const publicRpcUrl = chain.rpcUrls.default.http[0];

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/serverPublicClient.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/serverPublicClient.ts
@@ -9,8 +9,12 @@ import type { EarnChainId } from '../types';
 import { ValidationError } from './validation';
 
 function getServerOrigin() {
+  // VERCEL_URL is also set in production (to the deployment URL, not the
+  // custom domain), so only use it in non-prod envs — prod must hit the
+  // canonical PORTAL_DOMAIN to satisfy Alchemy's Origin allowlist.
+  const isNonProd = process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production';
   const vercelUrl = process.env.VERCEL_URL?.trim();
-  if (vercelUrl) {
+  if (isNonProd && vercelUrl) {
     return vercelUrl.startsWith('http') ? vercelUrl : `https://${vercelUrl}`;
   }
 

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunities/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunities/route.ts
@@ -1,4 +1,4 @@
-import { unstable_cache } from 'next/cache';
+import { unstable_noStore as noStore, unstable_cache } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '../CategoryRouter';
@@ -18,11 +18,8 @@ const CACHE_HEADERS = {
 };
 const router = new CategoryRouter();
 
-// Reads `request.nextUrl.searchParams`, so this route can't be statically
-// rendered. CDN caching is handled by the `Cache-Control` header below.
-export const dynamic = 'force-dynamic';
-
 export async function GET(request: NextRequest) {
+  noStore();
   try {
     const rateLimited = await enforceEarnRateLimit(request);
     if (rateLimited) return rateLimited;

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunities/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunities/route.ts
@@ -1,6 +1,8 @@
+import { unstable_cache } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '../CategoryRouter';
+import { EARN_CACHE_SECONDS, earnCacheTags } from '../lib/cache';
 import {
   ValidationError,
   parseOptionalEarnChainId,
@@ -10,7 +12,9 @@ import {
 import { OpportunityFilters, StandardOpportunity } from '../types';
 
 const MAX_RESULTS = 50;
-const CACHE_HEADERS = { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=3600' };
+const CACHE_HEADERS = {
+  'Cache-Control': `public, s-maxage=${EARN_CACHE_SECONDS.opportunities}, stale-while-revalidate=${EARN_CACHE_SECONDS.opportunities}`,
+};
 const router = new CategoryRouter();
 
 // Reads `request.nextUrl.searchParams`, so this route can't be statically
@@ -45,33 +49,46 @@ export async function GET(request: NextRequest) {
       perPage: MAX_RESULTS,
     };
 
-    let opportunities: StandardOpportunity[] = [];
+    // keyParts must encode every closure-captured input; missed fields cause cross-request collisions.
+    const getCachedOpportunities = unstable_cache(
+      async () => {
+        let opportunities: StandardOpportunity[] = [];
 
-    if (category) {
-      const adapter = router.routeToAdapter(category);
-      opportunities = await adapter.getOpportunities(filters);
-    } else {
-      const adapters = router.getAllAdapters();
-      const results = await Promise.allSettled(
-        adapters.map((adapter) => adapter.getOpportunities(filters)),
-      );
-      for (const result of results) {
-        if (result.status === 'fulfilled') opportunities.push(...result.value);
-      }
-    }
+        if (category) {
+          const adapter = router.routeToAdapter(category);
+          opportunities = await adapter.getOpportunities(filters);
+        } else {
+          const adapters = router.getAllAdapters();
+          const results = await Promise.allSettled(
+            adapters.map((adapter) => adapter.getOpportunities(filters)),
+          );
+          for (const result of results) {
+            if (result.status === 'fulfilled') opportunities.push(...result.value);
+          }
+        }
 
-    const sortKey = orderBy === 'rawTvl' ? 'rawTvl' : 'rawApy';
-    opportunities.sort((a, b) => (b.metrics[sortKey] ?? 0) - (a.metrics[sortKey] ?? 0));
+        const sortKey = orderBy === 'rawTvl' ? 'rawTvl' : 'rawApy';
+        opportunities.sort((a, b) => (b.metrics[sortKey] ?? 0) - (a.metrics[sortKey] ?? 0));
 
-    const capped = opportunities.slice(0, MAX_RESULTS);
+        const capped = opportunities.slice(0, MAX_RESULTS);
 
-    const result = {
-      opportunities: capped,
-      total: opportunities.length,
-      vendors: Array.from(new Set(capped.map((o) => o.vendor))),
-      categories: Array.from(new Set(capped.map((o) => o.category))),
-    };
+        return {
+          opportunities: capped,
+          total: opportunities.length,
+          vendors: Array.from(new Set(capped.map((o) => o.vendor))),
+          categories: Array.from(new Set(capped.map((o) => o.category))),
+        };
+      },
+      [
+        `earn:opportunities:${category ?? 'all'}:${filters.chainId ?? 'all'}:${minTvl ?? 'all'}:${minApy ?? 'all'}:${orderBy}`,
+      ],
+      {
+        revalidate: EARN_CACHE_SECONDS.opportunities,
+        tags: earnCacheTags.opportunities(),
+      },
+    );
 
+    const result = await getCachedOpportunities();
     return NextResponse.json(result, { headers: CACHE_HEADERS });
   } catch (error) {
     console.error('Error fetching opportunities:', error);

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunities/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunities/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '../CategoryRouter';
 import { EARN_CACHE_SECONDS, earnCacheTags } from '../lib/cache';
+import { enforceEarnRateLimit } from '../lib/rateLimit';
 import {
   ValidationError,
   parseOptionalEarnChainId,
@@ -23,6 +24,9 @@ export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
   try {
+    const rateLimited = await enforceEarnRateLimit(request);
+    if (rateLimited) return rateLimited;
+
     const searchParams = request.nextUrl.searchParams;
     const category = parseOptionalOpportunityCategory(searchParams.get('category'));
     const orderByParam = searchParams.get('orderBy');

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/available-actions/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/available-actions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '../../../../CategoryRouter';
+import { enforceEarnRateLimit } from '../../../../lib/rateLimit';
 import {
   assertAddress,
   parseEarnChainId,
@@ -20,6 +21,9 @@ export async function GET(
     const userAddress = assertAddress(searchParams.get('userAddress'), 'userAddress');
     const chainId = parseEarnChainId(searchParams.get('chainId'));
     const opportunityId = assertAddress(params.id, 'opportunityId');
+
+    const rateLimited = await enforceEarnRateLimit(request, { key: userAddress });
+    if (rateLimited) return rateLimited;
 
     const adapter = router.routeToAdapter(category);
     const availableActions: AvailableActions = await adapter.getAvailableActions(

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/historical-data/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/historical-data/route.ts
@@ -1,12 +1,13 @@
+import { unstable_cache } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '@/earn-api/CategoryRouter';
+import { EARN_CACHE_SECONDS, earnCacheTags } from '@/earn-api/lib/cache';
 import {
   alignTimestampToGranularity,
   buildWindowFromRange,
   deriveGranularityFromWindow,
   deriveRangeFromWindow,
-  getSuggestedCacheTtlSeconds,
 } from '@/earn-api/lib/historicalWindow';
 import {
   ValidationError,
@@ -18,7 +19,6 @@ import {
   parseOptionalTimestamp,
 } from '@/earn-api/lib/validation';
 import {
-  HISTORICAL_VENDOR_TTL_SECONDS,
   type HistoricalData,
   type HistoricalGranularity,
   type HistoricalTimeRange,
@@ -66,8 +66,6 @@ function resolveWindow(
   };
 }
 
-export const revalidate = HISTORICAL_VENDOR_TTL_SECONDS;
-
 const router = new CategoryRouter();
 
 export async function GET(
@@ -90,23 +88,34 @@ export async function GET(
       toTimestampParam,
     );
 
-    const adapter = router.routeToAdapter(category);
+    const cacheTtlSeconds =
+      resolvedRange === '1d'
+        ? EARN_CACHE_SECONDS.historical1d
+        : EARN_CACHE_SECONDS.historicalDefault;
 
-    const historicalData: HistoricalData = await adapter.getHistoricalData(
-      opportunityId,
-      resolvedRange,
-      chainId,
-      { assetSymbol, fromTimestamp, toTimestamp, granularity, resolvedRange },
+    const adapter = router.routeToAdapter(category);
+    const getCachedHistoricalData = unstable_cache(
+      () =>
+        adapter.getHistoricalData(opportunityId, resolvedRange, chainId, {
+          assetSymbol,
+          fromTimestamp,
+          toTimestamp,
+          granularity,
+          resolvedRange,
+        }),
+      [
+        `earn:historical:${category}:${chainId}:${opportunityId.toLowerCase()}:${resolvedRange}:${fromTimestamp}:${toTimestamp}:${assetSymbol ?? 'default'}`,
+      ],
+      {
+        revalidate: cacheTtlSeconds,
+        tags: earnCacheTags.historicalOpportunity(opportunityId),
+      },
     );
+    const historicalData: HistoricalData = await getCachedHistoricalData();
 
     if (!historicalData) {
       throw new ValidationError('HISTORICAL_DATA_NOT_FOUND', 'No historical data found', 404);
     }
-
-    const cacheTtlSeconds = Math.min(
-      HISTORICAL_VENDOR_TTL_SECONDS,
-      getSuggestedCacheTtlSeconds(granularity),
-    );
 
     return NextResponse.json(historicalData, {
       headers: {

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/historical-data/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/historical-data/route.ts
@@ -9,6 +9,7 @@ import {
   deriveGranularityFromWindow,
   deriveRangeFromWindow,
 } from '@/earn-api/lib/historicalWindow';
+import { enforceEarnRateLimit } from '@/earn-api/lib/rateLimit';
 import {
   ValidationError,
   assertAddress,
@@ -73,6 +74,9 @@ export async function GET(
   { params }: { params: { category: string; id: string } },
 ) {
   try {
+    const rateLimited = await enforceEarnRateLimit(request);
+    if (rateLimited) return rateLimited;
+
     const searchParams = request.nextUrl.searchParams;
     const category = parseOpportunityCategory(params.category);
     const chainId = parseEarnChainId(searchParams.get('chainId'));

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '@/earn-api/CategoryRouter';
 import { EARN_CACHE_SECONDS, earnCacheTags } from '@/earn-api/lib/cache';
+import { enforceEarnRateLimit } from '@/earn-api/lib/rateLimit';
 import {
   assertAddress,
   parseEarnChainId,
@@ -16,6 +17,9 @@ export async function GET(
   { params }: { params: { category: string; id: string } },
 ) {
   try {
+    const rateLimited = await enforceEarnRateLimit(request);
+    if (rateLimited) return rateLimited;
+
     const searchParams = request.nextUrl.searchParams;
     const category = parseOpportunityCategory(params.category);
     const chainId = parseEarnChainId(searchParams.get('chainId'));

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/route.ts
@@ -1,6 +1,8 @@
+import { unstable_cache } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '@/earn-api/CategoryRouter';
+import { EARN_CACHE_SECONDS, earnCacheTags } from '@/earn-api/lib/cache';
 import {
   assertAddress,
   parseEarnChainId,
@@ -8,8 +10,6 @@ import {
 } from '@/earn-api/lib/validation';
 
 const router = new CategoryRouter();
-
-export const revalidate = 3600;
 
 export async function GET(
   request: NextRequest,
@@ -22,11 +22,19 @@ export async function GET(
     const opportunityId = assertAddress(params.id, 'opportunityId');
 
     const adapter = router.routeToAdapter(category);
-    const opportunity = await adapter.getOpportunityDetails(opportunityId, chainId);
+    const getCachedOpportunity = unstable_cache(
+      () => adapter.getOpportunityDetails(opportunityId, chainId),
+      [`earn:opportunity:${category}:${chainId}:${opportunityId.toLowerCase()}`],
+      {
+        revalidate: EARN_CACHE_SECONDS.opportunities,
+        tags: earnCacheTags.opportunity(opportunityId),
+      },
+    );
+    const opportunity = await getCachedOpportunity();
 
     return NextResponse.json(opportunity, {
       headers: {
-        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=3600',
+        'Cache-Control': `public, s-maxage=${EARN_CACHE_SECONDS.opportunities}, stale-while-revalidate=${EARN_CACHE_SECONDS.opportunities}`,
       },
     });
   } catch (error) {

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transaction-quote/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transaction-quote/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '../../../../CategoryRouter';
+import { enforceEarnRateLimit } from '../../../../lib/rateLimit';
 import {
   ValidationError,
   assertAddress,
@@ -135,6 +136,11 @@ export async function GET(
 ) {
   try {
     const url = new URL(request.url);
+    const rateLimited = await enforceEarnRateLimit(request, {
+      key: url.searchParams.get('userAddress'),
+    });
+    if (rateLimited) return rateLimited;
+
     const quoteInput = {
       category: params.category,
       opportunityId: params.id,

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transactions/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transactions/route.ts
@@ -2,6 +2,7 @@ import { unstable_cache } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '@/earn-api/CategoryRouter';
+import { EARN_CACHE_SECONDS, earnCacheTags } from '@/earn-api/lib/cache';
 import {
   assertAddress,
   parseEarnChainId,
@@ -24,21 +25,21 @@ export async function GET(
 
     const adapter = router.routeToAdapter(category);
 
-    const rateLimitKey = `transactions-rl:${category}:${chainId}:${opportunityId}:${userAddress}`;
+    const cacheKey = `transactions:${category}:${chainId}:${opportunityId}:${userAddress}`;
 
-    const getRateLimitedTransactions = unstable_cache(
+    const getCachedTransactions = unstable_cache(
       async () => {
         const transactions = await adapter.getUserTransactions(opportunityId, userAddress, chainId);
         return transactions;
       },
-      [rateLimitKey],
+      [cacheKey],
       {
-        revalidate: 30, // 30 seconds - rate limiting only
-        tags: ['transactions-rl', rateLimitKey],
+        revalidate: EARN_CACHE_SECONDS.transactions,
+        tags: earnCacheTags.transactions(userAddress),
       },
     );
 
-    const transactions = await getRateLimitedTransactions();
+    const transactions = await getCachedTransactions();
 
     const response: TransactionHistoryResponse = {
       opportunityId,

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transactions/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transactions/route.ts
@@ -29,7 +29,7 @@ export async function GET(
 
     const adapter = router.routeToAdapter(category);
 
-    const cacheKey = `transactions:${category}:${chainId}:${opportunityId}:${userAddress}`;
+    const cacheKey = `transactions:${category}:${chainId}:${opportunityId.toLowerCase()}:${userAddress.toLowerCase()}`;
 
     const getCachedTransactions = unstable_cache(
       async () => {
@@ -39,7 +39,7 @@ export async function GET(
       [cacheKey],
       {
         revalidate: EARN_CACHE_SECONDS.transactions,
-        tags: earnCacheTags.transactions(userAddress),
+        tags: earnCacheTags.transactions(userAddress, opportunityId),
       },
     );
 

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transactions/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transactions/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '@/earn-api/CategoryRouter';
 import { EARN_CACHE_SECONDS, earnCacheTags } from '@/earn-api/lib/cache';
+import { enforceEarnRateLimit } from '@/earn-api/lib/rateLimit';
 import {
   assertAddress,
   parseEarnChainId,
@@ -22,6 +23,9 @@ export async function GET(
     const chainId = parseEarnChainId(searchParams.get('chainId'));
     const opportunityId = assertAddress(params.id, 'opportunityId');
     const userAddress = assertAddress(searchParams.get('userAddress'), 'userAddress');
+
+    const rateLimited = await enforceEarnRateLimit(request, { key: userAddress });
+    if (rateLimited) return rateLimited;
 
     const adapter = router.routeToAdapter(category);
 

--- a/packages/app/src/app/api/onchain-actions/v1/earn/positions/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/positions/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { OpportunityCategory } from '@/app-types/earn/vaults';
 
 import { CategoryRouter } from '../CategoryRouter';
+import { EARN_CACHE_SECONDS, earnCacheTags } from '../lib/cache';
 import {
   assertAddress,
   parseEarnChainId,
@@ -184,8 +185,8 @@ export async function GET(request: NextRequest) {
       },
       [cacheKey],
       {
-        revalidate: 300, // 5 minutes (positions change frequently)
-        tags: ['positions', userAddress, cacheKey],
+        revalidate: EARN_CACHE_SECONDS.positions,
+        tags: earnCacheTags.positions(userAddress),
       },
     );
 
@@ -193,7 +194,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(result, {
       headers: {
-        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300',
+        'Cache-Control': 'private, no-cache, no-store, must-revalidate',
       },
     });
   } catch (error) {

--- a/packages/app/src/app/api/onchain-actions/v1/earn/positions/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/positions/route.ts
@@ -5,6 +5,7 @@ import { OpportunityCategory } from '@/app-types/earn/vaults';
 
 import { CategoryRouter } from '../CategoryRouter';
 import { EARN_CACHE_SECONDS, earnCacheTags } from '../lib/cache';
+import { enforceEarnRateLimit } from '../lib/rateLimit';
 import {
   assertAddress,
   parseEarnChainId,
@@ -126,6 +127,9 @@ export async function GET(request: NextRequest) {
     const userAddress = assertAddress(searchParams.get('userAddress'), 'userAddress');
     const category = parseOptionalOpportunityCategory(searchParams.get('category'));
     const chainId = parseEarnChainId(searchParams.get('chainId'));
+
+    const rateLimited = await enforceEarnRateLimit(request, { key: userAddress });
+    if (rateLimited) return rateLimited;
 
     const cacheKey = `positions:${userAddress.toLowerCase()}:${category ?? 'all'}:${chainId}`;
 

--- a/packages/app/src/app/api/onchain-actions/v1/earn/positions/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/positions/route.ts
@@ -1,4 +1,4 @@
-import { unstable_cache } from 'next/cache';
+import { unstable_noStore as noStore, unstable_cache } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { OpportunityCategory } from '@/app-types/earn/vaults';
@@ -14,10 +14,6 @@ import {
 import { StandardUserPosition, Vendor } from '../types';
 
 const router = new CategoryRouter();
-
-// Reads `request.nextUrl.searchParams`, so this route can't be statically
-// rendered. The handler still memoizes per-user results via `unstable_cache`.
-export const dynamic = 'force-dynamic';
 
 const ALL_CATEGORIES: readonly OpportunityCategory[] = [
   OpportunityCategory.Lend,
@@ -122,6 +118,7 @@ function calculatePositionsSummary(positions: StandardUserPosition[]) {
 }
 
 export async function GET(request: NextRequest) {
+  noStore();
   try {
     const searchParams = request.nextUrl.searchParams;
     const userAddress = assertAddress(searchParams.get('userAddress'), 'userAddress');

--- a/packages/app/src/app/api/onchain-actions/v1/earn/revalidate-action/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/revalidate-action/route.ts
@@ -8,6 +8,7 @@ import { createServerSidePublicClient } from '@/earn-api/lib/serverPublicClient'
 import {
   ValidationError,
   assertAddress,
+  assertOptionalAddress,
   assertPlainObject,
   assertString,
   parseEarnChainId,
@@ -31,6 +32,10 @@ export async function POST(request: NextRequest) {
     const chainId = parseEarnChainId(getRequestString(body, 'chainId'));
     const userAddress = assertAddress(getRequestString(body, 'userAddress'), 'userAddress');
     const txHash = assertTxHash(assertString(body.txHash, 'txHash'));
+    const opportunityId = assertOptionalAddress(
+      getRequestString(body, 'opportunityId'),
+      'opportunityId',
+    );
 
     const rateLimited = await enforceEarnRateLimit(request, { key: userAddress });
     if (rateLimited) return rateLimited;
@@ -53,7 +58,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    for (const tag of earnCacheTags.userAction(userAddress)) revalidateTag(tag);
+    for (const tag of earnCacheTags.userAction(userAddress, opportunityId)) revalidateTag(tag);
 
     return NextResponse.json(
       { revalidated: true },

--- a/packages/app/src/app/api/onchain-actions/v1/earn/revalidate-action/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/revalidate-action/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAddress } from 'viem';
 
 import { earnCacheTags } from '@/earn-api/lib/cache';
+import { enforceEarnRateLimit } from '@/earn-api/lib/rateLimit';
 import { createEarnPublicClient } from '@/earn-api/lib/serverPublicClient';
 import {
   ValidationError,
@@ -30,6 +31,9 @@ export async function POST(request: NextRequest) {
     const chainId = parseEarnChainId(getRequestString(body, 'chainId'));
     const userAddress = assertAddress(getRequestString(body, 'userAddress'), 'userAddress');
     const txHash = assertTxHash(assertString(body.txHash, 'txHash'));
+
+    const rateLimited = await enforceEarnRateLimit(request, { key: userAddress });
+    if (rateLimited) return rateLimited;
 
     const client = createEarnPublicClient(chainId);
     const receipt = await client.waitForTransactionReceipt({

--- a/packages/app/src/app/api/onchain-actions/v1/earn/revalidate-action/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/revalidate-action/route.ts
@@ -1,0 +1,73 @@
+import { revalidateTag } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
+import { getAddress } from 'viem';
+
+import { earnCacheTags } from '@/earn-api/lib/cache';
+import { createEarnPublicClient } from '@/earn-api/lib/serverPublicClient';
+import {
+  ValidationError,
+  assertAddress,
+  assertPlainObject,
+  assertString,
+  parseEarnChainId,
+} from '@/earn-api/lib/validation';
+
+function getRequestString(body: Record<string, unknown>, field: string) {
+  const value = body[field];
+  return typeof value === 'string' || typeof value === 'number' ? String(value) : null;
+}
+
+function assertTxHash(value: unknown): `0x${string}` {
+  if (typeof value !== 'string' || !/^0x[a-fA-F0-9]{64}$/.test(value)) {
+    throw new ValidationError('INVALID_TX_HASH', 'txHash must be a valid transaction hash');
+  }
+  return value as `0x${string}`;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = assertPlainObject(await request.json());
+    const chainId = parseEarnChainId(getRequestString(body, 'chainId'));
+    const userAddress = assertAddress(getRequestString(body, 'userAddress'), 'userAddress');
+    const txHash = assertTxHash(assertString(body.txHash, 'txHash'));
+
+    const client = createEarnPublicClient(chainId);
+    const receipt = await client.waitForTransactionReceipt({
+      hash: txHash,
+      timeout: 5_000,
+      pollingInterval: 500,
+    });
+
+    if (receipt.status !== 'success') {
+      throw new ValidationError('TX_NOT_SUCCESSFUL', 'Transaction is not successful', 409);
+    }
+    if (getAddress(receipt.from) !== getAddress(userAddress)) {
+      throw new ValidationError(
+        'TX_SENDER_MISMATCH',
+        'Transaction sender does not match userAddress',
+        403,
+      );
+    }
+
+    for (const tag of earnCacheTags.userAction(userAddress)) revalidateTag(tag);
+
+    return NextResponse.json(
+      { revalidated: true },
+      { headers: { 'Cache-Control': 'private, no-store' } },
+    );
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json(
+        { message: error.message, code: error.code },
+        { status: error.status, headers: { 'Cache-Control': 'private, no-store' } },
+      );
+    }
+    // Don't surface raw upstream errors — viem/RPC errors can include request
+    // URLs that contain provider API keys.
+    console.error('Earn revalidate-action failed:', error);
+    return NextResponse.json(
+      { message: 'Failed to revalidate earn action', code: 'EARN_ACTION_REVALIDATION_ERROR' },
+      { status: 500, headers: { 'Cache-Control': 'private, no-store' } },
+    );
+  }
+}

--- a/packages/app/src/app/api/onchain-actions/v1/earn/revalidate-action/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/revalidate-action/route.ts
@@ -4,7 +4,7 @@ import { getAddress } from 'viem';
 
 import { earnCacheTags } from '@/earn-api/lib/cache';
 import { enforceEarnRateLimit } from '@/earn-api/lib/rateLimit';
-import { createEarnPublicClient } from '@/earn-api/lib/serverPublicClient';
+import { createServerSidePublicClient } from '@/earn-api/lib/serverPublicClient';
 import {
   ValidationError,
   assertAddress,
@@ -35,7 +35,7 @@ export async function POST(request: NextRequest) {
     const rateLimited = await enforceEarnRateLimit(request, { key: userAddress });
     if (rateLimited) return rateLimited;
 
-    const client = createEarnPublicClient(chainId);
+    const client = createServerSidePublicClient(chainId);
     const receipt = await client.waitForTransactionReceipt({
       hash: txHash,
       timeout: 5_000,

--- a/packages/app/src/components/earn/VaultActionPanel.tsx
+++ b/packages/app/src/components/earn/VaultActionPanel.tsx
@@ -17,6 +17,7 @@ import {
   parseAmountToRawUnits,
 } from '@/app-hooks/earn/useEarnTransactionUtils';
 import { useEarnTransferReadiness } from '@/app-hooks/earn/useEarnTransferReadiness';
+import { useRevalidateEarnAction } from '@/app-hooks/earn/useRevalidateEarnAction';
 import { useTransactionQuote } from '@/app-hooks/earn/useTransactionQuote';
 import {
   deriveVault,
@@ -66,6 +67,7 @@ export function VaultActionPanel({
   const [selectedAction, setSelectedAction] = useState<ActionType>(initialAction);
   const [txError, setTxError] = useState<string | null>(null);
   const requestChainId = vault.chainId;
+  const revalidateEarnAction = useRevalidateEarnAction();
 
   useEffect(() => {
     setAmount('');
@@ -261,6 +263,13 @@ export function VaultActionPanel({
             vendor: Vendor.Vaults,
             transaction: historyRecord,
           });
+          revalidateEarnAction({
+            category: OpportunityCategory.Lend,
+            chainId: vault.chainId,
+            opportunityId: vault.address,
+            userAddress: walletAddress,
+            txHash,
+          });
         }
       }
 
@@ -288,6 +297,7 @@ export function VaultActionPanel({
       posthog,
       refetchAssetBalance,
       refetchLpTokenBalance,
+      revalidateEarnAction,
       selectedAction,
       showTransactionDetails,
       transactionQuote,

--- a/packages/app/src/hooks/earn/earnSwrKeys.ts
+++ b/packages/app/src/hooks/earn/earnSwrKeys.ts
@@ -1,0 +1,19 @@
+import type { OpportunityCategory } from '@/app-types/earn/vaults';
+import type { EarnChainId } from '@/earn-api/types';
+
+export const earnSwrKeys = {
+  userPositions: (userAddress: string, chainId: EarnChainId) =>
+    [userAddress, chainId, 'userPositions'] as const,
+  earnTransactions: (
+    category: OpportunityCategory,
+    opportunityId: string,
+    userAddress: string,
+    chainId: EarnChainId,
+  ) => [category, opportunityId, userAddress, chainId, 'earn-transactions'] as const,
+  availableActions: (
+    category: OpportunityCategory,
+    opportunityId: string,
+    userAddress: string,
+    chainId: EarnChainId,
+  ) => ['available-actions', category, opportunityId, userAddress, chainId] as const,
+};

--- a/packages/app/src/hooks/earn/useAvailableActions.ts
+++ b/packages/app/src/hooks/earn/useAvailableActions.ts
@@ -10,6 +10,8 @@ import {
   type LiquidStakingAvailableActions,
 } from '@/earn-api/types';
 
+import { earnSwrKeys } from './earnSwrKeys';
+
 export type { FixedYieldAvailableActions, LendAvailableActions, LiquidStakingAvailableActions };
 
 type AvailableActionsByCategory = {
@@ -31,7 +33,7 @@ export function useAvailableActions<C extends OpportunityCategory>(
   const { opportunityId, category, userAddress, chainId } = params;
   const swrKey =
     opportunityId && category && userAddress
-      ? (['available-actions', category, opportunityId, userAddress, chainId] as const)
+      ? earnSwrKeys.availableActions(category, opportunityId, userAddress, chainId)
       : null;
 
   return useSWRImmutable(

--- a/packages/app/src/hooks/earn/useEarnTransactionHistory.ts
+++ b/packages/app/src/hooks/earn/useEarnTransactionHistory.ts
@@ -13,6 +13,8 @@ import type {
   Vendor,
 } from '@/earn-api/types';
 
+import { earnSwrKeys } from './earnSwrKeys';
+
 export function useEarnTransactionHistory(
   category: OpportunityCategory,
   opportunityId: string,
@@ -21,7 +23,7 @@ export function useEarnTransactionHistory(
 ) {
   const historyKey =
     userAddress && opportunityId
-      ? ([category, opportunityId, userAddress, chainId, 'earn-transactions'] as const)
+      ? earnSwrKeys.earnTransactions(category, opportunityId, userAddress, chainId)
       : null;
 
   const { data, error, isLoading, mutate } = useSWRImmutable(

--- a/packages/app/src/hooks/earn/useLiquidStakingTransactionSuccess.ts
+++ b/packages/app/src/hooks/earn/useLiquidStakingTransactionSuccess.ts
@@ -7,6 +7,7 @@ import { getLiquidStakingHistoryValues } from '@/app-lib/earn/utils';
 import { OpportunityCategory, type StandardTransactionHistory, Vendor } from '@/earn-api/types';
 
 import type { TransactionDetails } from '../../components/earn/EarnTransactionDetailsPopup';
+import { useRevalidateEarnAction } from './useRevalidateEarnAction';
 
 interface TokenLike {
   symbol: string;
@@ -80,6 +81,7 @@ export function useLiquidStakingTransactionSuccess({
   resetAmount,
 }: UseLiquidStakingTransactionSuccessParams) {
   const posthog = usePostHog();
+  const revalidateEarnAction = useRevalidateEarnAction();
 
   return useCallback(
     async (txHash: string | undefined) => {
@@ -173,6 +175,13 @@ export function useLiquidStakingTransactionSuccess({
             transactionHash: txHash,
           },
         });
+        revalidateEarnAction({
+          category: OpportunityCategory.LiquidStaking,
+          chainId: requestChainId,
+          opportunityId: opportunity.id,
+          userAddress: walletAddress,
+          txHash,
+        });
       }
 
       if (txHash) {
@@ -194,6 +203,7 @@ export function useLiquidStakingTransactionSuccess({
       refetchErc20Balance,
       refetchEthBalance,
       refetchUserBalance,
+      revalidateEarnAction,
       requestChainId,
       resetAmount,
       selectedAction,

--- a/packages/app/src/hooks/earn/usePendlePanelExecution.ts
+++ b/packages/app/src/hooks/earn/usePendlePanelExecution.ts
@@ -5,6 +5,7 @@ import { useCallback, useState } from 'react';
 
 import { useEarnTransactionExecution } from '@/app-hooks/earn/useEarnTransactionExecution';
 import { useEarnTransactionHistory } from '@/app-hooks/earn/useEarnTransactionHistory';
+import { useRevalidateEarnAction } from '@/app-hooks/earn/useRevalidateEarnAction';
 import { formatTransactionError, isUserRejectedError } from '@/bridge/util/isUserRejectedError';
 import { OpportunityCategory, Vendor } from '@/earn-api/types';
 import type { StandardOpportunityFixedYield, StandardTransactionHistory } from '@/earn-api/types';
@@ -82,6 +83,7 @@ export function usePendlePanelExecution({
 }: UsePendlePanelExecutionParams) {
   const posthog = usePostHog();
   const [txError, setTxError] = useState<string | null>(null);
+  const revalidateEarnAction = useRevalidateEarnAction();
   const { addTransaction } = useEarnTransactionHistory(
     OpportunityCategory.FixedYield,
     opportunity.id,
@@ -164,6 +166,13 @@ export function usePendlePanelExecution({
           vendor: Vendor.Pendle,
           transaction: historyItem,
         });
+        revalidateEarnAction({
+          category: OpportunityCategory.FixedYield,
+          chainId: opportunity.chainId,
+          opportunityId: opportunity.id,
+          userAddress: walletAddress,
+          txHash,
+        });
       }
 
       if (txHash) {
@@ -199,6 +208,7 @@ export function usePendlePanelExecution({
       posthog,
       quoteAmountRaw,
       refetch,
+      revalidateEarnAction,
       resetAmount,
       selectedAction,
       selectedInputToken?.logoUrl,

--- a/packages/app/src/hooks/earn/useRevalidateEarnAction.ts
+++ b/packages/app/src/hooks/earn/useRevalidateEarnAction.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useSWRConfig } from 'swr';
+
+import type { OpportunityCategory } from '@/app-types/earn/vaults';
+import { captureSentryErrorWithExtraData } from '@/bridge/util/SentryUtils';
+
+interface RevalidateEarnActionParams {
+  category: OpportunityCategory;
+  chainId: number;
+  opportunityId: string;
+  userAddress: string;
+  txHash: string;
+}
+
+export function useRevalidateEarnAction() {
+  const { mutate } = useSWRConfig();
+
+  return useCallback(
+    async (params: RevalidateEarnActionParams) => {
+      try {
+        const response = await fetch('/api/onchain-actions/v1/earn/revalidate-action', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            chainId: params.chainId,
+            userAddress: params.userAddress,
+            txHash: params.txHash,
+          }),
+        });
+        if (!response.ok) {
+          throw new Error(`Revalidate request failed with status ${response.status}`);
+        }
+      } catch (error) {
+        captureSentryErrorWithExtraData({
+          error,
+          originFunction: 'useRevalidateEarnAction',
+          additionalData: {
+            chainId: String(params.chainId),
+            userAddress: params.userAddress,
+            txHash: params.txHash,
+          },
+        });
+      }
+
+      await Promise.allSettled([
+        mutate([params.userAddress, params.chainId, 'userPositions']),
+        mutate([
+          'available-actions',
+          params.category,
+          params.opportunityId,
+          params.userAddress,
+          params.chainId,
+        ]),
+        mutate([
+          params.category,
+          params.opportunityId,
+          params.userAddress,
+          params.chainId,
+          'earn-transactions',
+        ]),
+      ]);
+    },
+    [mutate],
+  );
+}

--- a/packages/app/src/hooks/earn/useRevalidateEarnAction.ts
+++ b/packages/app/src/hooks/earn/useRevalidateEarnAction.ts
@@ -48,18 +48,15 @@ export function useRevalidateEarnAction() {
         });
       }
 
+      // Intentionally NOT revalidating earnTransactions here: vendor indexers can
+      // lag a few seconds behind the chain, and an immediate refetch would replace
+      // the locally-added optimistic row with stale server history. The row stays
+      // via useEarnTransactionHistory's addTransaction, and the server tag was
+      // already busted so the next natural fetch picks up the indexed tx.
       await Promise.allSettled([
         mutate(earnSwrKeys.userPositions(params.userAddress, params.chainId)),
         mutate(
           earnSwrKeys.availableActions(
-            params.category,
-            params.opportunityId,
-            params.userAddress,
-            params.chainId,
-          ),
-        ),
-        mutate(
-          earnSwrKeys.earnTransactions(
             params.category,
             params.opportunityId,
             params.userAddress,

--- a/packages/app/src/hooks/earn/useRevalidateEarnAction.ts
+++ b/packages/app/src/hooks/earn/useRevalidateEarnAction.ts
@@ -5,10 +5,13 @@ import { useSWRConfig } from 'swr';
 
 import type { OpportunityCategory } from '@/app-types/earn/vaults';
 import { captureSentryErrorWithExtraData } from '@/bridge/util/SentryUtils';
+import type { EarnChainId } from '@/earn-api/types';
+
+import { earnSwrKeys } from './earnSwrKeys';
 
 interface RevalidateEarnActionParams {
   category: OpportunityCategory;
-  chainId: number;
+  chainId: EarnChainId;
   opportunityId: string;
   userAddress: string;
   txHash: string;
@@ -26,6 +29,7 @@ export function useRevalidateEarnAction() {
           body: JSON.stringify({
             chainId: params.chainId,
             userAddress: params.userAddress,
+            opportunityId: params.opportunityId,
             txHash: params.txHash,
           }),
         });
@@ -45,21 +49,23 @@ export function useRevalidateEarnAction() {
       }
 
       await Promise.allSettled([
-        mutate([params.userAddress, params.chainId, 'userPositions']),
-        mutate([
-          'available-actions',
-          params.category,
-          params.opportunityId,
-          params.userAddress,
-          params.chainId,
-        ]),
-        mutate([
-          params.category,
-          params.opportunityId,
-          params.userAddress,
-          params.chainId,
-          'earn-transactions',
-        ]),
+        mutate(earnSwrKeys.userPositions(params.userAddress, params.chainId)),
+        mutate(
+          earnSwrKeys.availableActions(
+            params.category,
+            params.opportunityId,
+            params.userAddress,
+            params.chainId,
+          ),
+        ),
+        mutate(
+          earnSwrKeys.earnTransactions(
+            params.category,
+            params.opportunityId,
+            params.userAddress,
+            params.chainId,
+          ),
+        ),
       ]);
     },
     [mutate],

--- a/packages/app/src/hooks/earn/useUserPositions.ts
+++ b/packages/app/src/hooks/earn/useUserPositions.ts
@@ -9,6 +9,8 @@ import { ChainId } from '@/bridge/types/ChainId';
 import { formatAmount } from '@/bridge/util/NumberUtils';
 import { type EarnChainId, type UserPositionsResponse } from '@/earn-api/types';
 
+import { earnSwrKeys } from './earnSwrKeys';
+
 const DEFAULT_BY_CATEGORY: Record<OpportunityCategory, { count: number; valueUsd: number }> = {
   [OpportunityCategory.Lend]: { count: 0, valueUsd: 0 },
   [OpportunityCategory.LiquidStaking]: { count: 0, valueUsd: 0 },
@@ -148,7 +150,7 @@ export function useUserPositions(
   allowedChainIds: EarnChainId[] = [ChainId.ArbitrumOne],
 ): UseUserPositionsResult {
   const primaryChainId = allowedChainIds[0] ?? ChainId.ArbitrumOne;
-  const swrKey = userAddress ? ([userAddress, primaryChainId, 'userPositions'] as const) : null;
+  const swrKey = userAddress ? earnSwrKeys.userPositions(userAddress, primaryChainId) : null;
 
   const {
     data: rawData,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@vaultsfyi/sdk':
         specifier: ^2.1.3
         version: 2.1.3
+      '@vercel/firewall':
+        specifier: ^1.2.1
+        version: 1.2.1
       '@wagmi/core':
         specifier: ^2.22.1
         version: 2.22.1(@tanstack/query-core@5.62.16)(@types/react@18.2.12)(immer@10.2.0)(react@18.3.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@6.0.6)(zod@3.25.76))
@@ -177,7 +180,7 @@ importers:
     devDependencies:
       '@headlessui/tailwindcss':
         specifier: ^0.2.2
-        version: 0.2.2(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.2)))
+        version: 0.2.2(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.18.7)(typescript@5.9.2)))
       '@types/react':
         specifier: 18.2.12
         version: 18.2.12
@@ -192,7 +195,7 @@ importers:
         version: 8.5.12
       tailwindcss:
         specifier: ^3.4.16
-        version: 3.4.16(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.2))
+        version: 3.4.16(ts-node@10.9.2(@types/node@22.18.7)(typescript@5.9.2))
 
   packages/arb-token-bridge-ui:
     dependencies:
@@ -279,7 +282,7 @@ importers:
         version: 14.2.35(@babel/core@7.28.4)(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-query-params:
         specifier: ^5.1.0
-        version: 5.1.0(next@14.2.35(@babel/core@7.28.4)(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 5.1.0(next@14.2.35(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       p-limit:
         specifier: ^6.2.0
         version: 6.2.0
@@ -337,7 +340,7 @@ importers:
     devDependencies:
       '@headlessui/tailwindcss':
         specifier: ^0.2.2
-        version: 0.2.2(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.2)))
+        version: 0.2.2(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.18.7)(typescript@5.9.2)))
       '@synthetixio/synpress':
         specifier: 3.7.3
         version: 3.7.3(@babel/core@7.28.4)(@babel/preset-env@7.29.5(@babel/core@7.28.4))(@types/react@18.2.12)(babel-loader@10.1.1(@babel/core@7.28.4)(webpack@5.106.2(postcss@8.5.12)))(bufferutil@4.0.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.12))(zod@3.25.76)
@@ -391,13 +394,13 @@ importers:
         version: 2.1.2
       tailwindcss:
         specifier: ^3.4.16
-        version: 3.4.16(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.2))
+        version: 3.4.16(ts-node@10.9.2(@types/node@22.18.7)(typescript@5.9.2))
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.5.0)(typescript@5.9.2)
+        version: 10.9.2(@types/node@22.18.7)(typescript@5.9.2)
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/node@25.5.0)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.6))(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.18.7)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.6))(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3)
       yargs:
         specifier: ^18.0.0
         version: 18.0.0
@@ -424,7 +427,7 @@ importers:
         version: 6.6.2
       next-query-params:
         specifier: ^5.1.0
-        version: 5.1.0(next@14.2.35(@babel/core@7.28.4)(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 5.1.0(next@14.2.35(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       posthog-js:
         specifier: ^1.273.0
         version: 1.273.0
@@ -464,7 +467,7 @@ importers:
     devDependencies:
       '@headlessui/tailwindcss':
         specifier: ^0.2.2
-        version: 0.2.2(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.2)))
+        version: 0.2.2(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.18.7)(typescript@5.9.2)))
       '@types/react':
         specifier: 18.2.12
         version: 18.2.12
@@ -482,7 +485,7 @@ importers:
         version: 8.5.12
       tailwindcss:
         specifier: ^3.4.16
-        version: 3.4.16(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.2))
+        version: 3.4.16(ts-node@10.9.2(@types/node@22.18.7)(typescript@5.9.2))
 
   packages/scripts:
     dependencies:
@@ -2032,9 +2035,11 @@ packages:
 
   '@metamask/sdk-analytics@0.0.5':
     resolution: {integrity: sha512-fDah+keS1RjSUlC8GmYXvx6Y26s3Ax1U9hGpWb6GSY5SAdmTSIqp2CvYy6yW0WgLhnYhW+6xERuD0eVqV63QIQ==}
+    deprecated: No longer maintained, superseded by @metamask/connect-analytics
 
   '@metamask/sdk-communication-layer@0.33.1':
     resolution: {integrity: sha512-0bI9hkysxcfbZ/lk0T2+aKVo1j0ynQVTuB3sJ5ssPWlz+Z3VwveCkP1O7EVu1tsVVCb0YV5WxK9zmURu2FIiaA==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       cross-fetch: ^4.0.0
       eciesjs: '*'
@@ -2044,9 +2049,11 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.32.1':
     resolution: {integrity: sha512-MGmAo6qSjf1tuYXhCu2EZLftq+DSt5Z7fsIKr2P+lDgdTPWgLfZB1tJKzNcwKKOdf6q9Qmmxn7lJuI/gq5LrKw==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk@0.33.1':
     resolution: {integrity: sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/superstruct@3.1.0':
     resolution: {integrity: sha512-N08M56HdOgBfRKkrgCMZvQppkZGcArEop3kixNEtVbJKm6P9Cfg0YkI6X0s1g78sNrj2fWUwvJADdZuzJgFttA==}
@@ -3629,6 +3636,10 @@ packages:
 
   '@vaultsfyi/sdk@2.1.3':
     resolution: {integrity: sha512-1R8sGEBMwmcD3aqPHCFldx3MtslsVKrCFuuDu/1Z5IEIb5T4EaqyoBGD77544d74mXLZofN7ZZDcV80Zs8CE1Q==}
+
+  '@vercel/firewall@1.2.1':
+    resolution: {integrity: sha512-WlxjEPpf+GWYMontNNZqZjvLL40ziGwy9swwI9da/L1fB/syAO1S2fMtlBXkp4EGVF6nlXSKmwvkUd6YPWJbbg==}
+    engines: {node: '>= 20'}
 
   '@viem/anvil@0.0.6':
     resolution: {integrity: sha512-OjKR/+FVwzuygXYFqP8MBal1SXG8bT2gbZwqqB0XuLw81LNBBvmE/Repm6+5kkBh4IUj0PhYdrqOsnayS14Gtg==}
@@ -6029,7 +6040,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -11392,9 +11403,9 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
 
-  '@headlessui/tailwindcss@0.2.2(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.2)))':
+  '@headlessui/tailwindcss@0.2.2(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.18.7)(typescript@5.9.2)))':
     dependencies:
-      tailwindcss: 3.4.16(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.2))
+      tailwindcss: 3.4.16(ts-node@10.9.2(@types/node@22.18.7)(typescript@5.9.2))
 
   '@heroicons/react@2.2.0(react@18.3.1)':
     dependencies:
@@ -13617,7 +13628,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.18.7
 
   '@types/d3-array@3.2.2': {}
 
@@ -13802,7 +13813,7 @@ snapshots:
 
   '@types/send@1.2.0':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.18.7
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -14095,6 +14106,8 @@ snapshots:
 
   '@vaultsfyi/sdk@2.1.3': {}
 
+  '@vercel/firewall@1.2.1': {}
+
   '@viem/anvil@0.0.6(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)':
     dependencies:
       execa: 7.2.0
@@ -14132,6 +14145,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.2.0
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@22.18.7)(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.3.3(@types/node@22.18.7)(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@25.5.0)(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3))':
     dependencies:
@@ -18515,7 +18536,7 @@ snapshots:
 
   mlly@1.7.1:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       pathe: 1.1.2
       pkg-types: 1.1.1
       ufo: 1.6.3
@@ -18575,7 +18596,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-query-params@5.1.0(next@14.2.35(@babel/core@7.28.4)(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  next-query-params@5.1.0(next@14.2.35(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(use-query-params@2.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       next: 14.2.35(@babel/core@7.28.4)(@playwright/test@1.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -19188,13 +19209,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.12
 
-  postcss-load-config@4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.2)):
+  postcss-load-config@4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@22.18.7)(typescript@5.9.2)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
     optionalDependencies:
       postcss: 8.5.12
-      ts-node: 10.9.2(@types/node@25.5.0)(typescript@5.9.2)
+      ts-node: 10.9.2(@types/node@22.18.7)(typescript@5.9.2)
 
   postcss-nested@6.2.0(postcss@8.5.12):
     dependencies:
@@ -20356,7 +20377,7 @@ snapshots:
 
   tailwind-merge@3.2.0: {}
 
-  tailwindcss@3.4.16(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.2)):
+  tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.18.7)(typescript@5.9.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -20375,7 +20396,7 @@ snapshots:
       postcss: 8.5.12
       postcss-import: 15.1.0(postcss@8.5.12)
       postcss-js: 4.0.1(postcss@8.5.12)
-      postcss-load-config: 4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.2))
+      postcss-load-config: 4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@22.18.7)(typescript@5.9.2))
       postcss-nested: 6.2.0(postcss@8.5.12)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -20533,14 +20554,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.2):
+  ts-node@10.9.2(@types/node@22.18.7)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 25.5.0
+      '@types/node': 22.18.7
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -20933,6 +20954,27 @@ snapshots:
       - utf-8-validate
       - zod
 
+  vite-node@3.2.4(@types/node@22.18.7)(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@8.1.1)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.3(@types/node@22.18.7)(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@25.5.0)(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
@@ -20969,6 +21011,21 @@ snapshots:
       terser: 5.44.0
       yaml: 2.8.3
 
+  vite@7.3.3(@types/node@22.18.7)(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rollup: 4.60.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.18.7
+      fsevents: 2.3.3
+      jiti: 1.21.6
+      terser: 5.44.0
+      yaml: 2.8.3
+
   vite@7.3.3(@types/node@25.5.0)(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
@@ -20983,6 +21040,48 @@ snapshots:
       jiti: 1.21.6
       terser: 5.44.0
       yaml: 2.8.3
+
+  vitest@3.2.4(@types/node@22.18.7)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.6))(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@22.18.7)(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      debug: 4.4.3(supports-color@8.1.1)
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.3(@types/node@22.18.7)(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.18.7)(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.18.7
+      happy-dom: 20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.4(@types/node@25.5.0)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.6))(jiti@1.21.6)(terser@5.44.0)(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
## Summary

- **Tag-based caching layer** across all Earn API routes using `unstable_cache`, with a centralized hierarchical tag builder (`earn-api/lib/cache.ts`). Each cached entry is tagged at multiple granularities so operators can bust caches from the Vercel dashboard at any scope.
- **Per-tx cache invalidation.** New `POST /api/onchain-actions/v1/earn/revalidate-action` endpoint verifies the on-chain receipt (tx exists, succeeded, sender matches `userAddress`) before flushing the wallet's positions + transactions tags. Wired into all 3 panel execution paths (Vaults, Pendle, Liquid Staking) via `useRevalidateEarnAction`.
- **Rate limiting** via `@vercel/firewall` on all Earn API routes. Catalog routes key on IP; personalized routes key on wallet so the throttle survives IP rotation.
- **Shared server-side viem client** (`lib/serverPublicClient.ts`) that forges an `Origin` header (Vercel preview/prod aware) and wraps the transport in `fallback()` with the chain's public RPC. Replaces the inline copy in `LiFiAdapter` and is used by the new `revalidate-action` endpoint.
- **Sentry logging** on revalidation failures so we have visibility if the on-tx cache bust ever fails in prod.

## TTLs

| Route | TTL | Rationale |
| --- | --- | --- |
| `/opportunities`, `/opportunity/[id]` | 6 h | APY drift across the day; CDN-cached, server cache catches cold-CDN misses |
| `/historical-data` (`1d` range) | 6 h | Latest data point on the day chart refreshes hourly-ish, 6h is fine |
| `/historical-data` (other ranges) | 24 h | Older buckets are effectively immutable |
| `/positions`, `/transactions` | 3 h | Safety net under aggressive on-tx invalidation |
| `/transaction-quote`, `/available-actions` | `no-store` | Real-time, must not cache |


## Test plan

- [ ] Browse `/opportunities` — first request hits vendors, subsequent requests within 6 h served from `unstable_cache` (verify via Vercel function logs)
- [ ] Open an opportunity's detail page — historical chart loads, refresh within TTL is instant
- [ ] Deposit into a vault — positions list refreshes within ~1s (revalidate-action POST → tag bust → SWR re-fetch)
- [ ] Same flow for Pendle and Liquid Staking
- [ ] Hit `/api/onchain-actions/v1/earn/revalidate-action` with a tx hash whose sender doesn't match `userAddress` → 403 `TX_SENDER_MISMATCH`
- [ ] Hit it with a reverted tx → 409 `TX_NOT_SUCCESSFUL`
- [ ] Hit it with a tx hash not yet mined → 500 after 5s timeout (no infinite wait)
- [ ] Hammer any earn API endpoint past the rate-limit threshold → 429 with `Retry-After: 60`
- [ ] Manual `revalidateTag('earn:opportunity:<id>')` from Vercel dashboard flushes that opportunity's cache on the next request
- [ ] Confirm Vercel function logs show no Alchemy "unspecified origin" rejections from the revalidate endpoint