### PR TITLE
fix(earn): resolve markets outside pagination limit

### DIFF
--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/PendleAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/PendleAdapter.ts
@@ -19,6 +19,7 @@ import {
   getPendleMarketDetails,
   getPendleMarketHistoricalData,
   getPendleMarkets,
+  getPendleMarketsByAddresses,
   getPendleTransactionHistory,
   getPendleUserPositions,
 } from '../lib/pendleApi';
@@ -255,13 +256,12 @@ export class PendleAdapter implements VendorAdapter {
     chainId: EarnChainId = DEFAULT_CHAIN_ID,
   ): Promise<AvailableActions> {
     assertSupportedChainId(chainId);
-    const [positions, marketsResponse] = await Promise.all([
-      this.getUserPositions(userAddress, chainId),
-      getPendleMarkets(chainId, false),
-    ]);
     const normalizedId = id.toLowerCase();
+    const [positions, market] = await Promise.all([
+      this.getUserPositions(userAddress, chainId),
+      getPendleMarketByAddress(chainId, normalizedId),
+    ]);
     const position = positions.find((item) => item.opportunityId === normalizedId);
-    const market = marketsResponse.markets.find((m) => m.address === normalizedId);
     const isMarketExpired = market?.expiry
       ? Date.now() >= new Date(market.expiry).getTime()
       : position?.expiryDate
@@ -433,11 +433,7 @@ export class PendleAdapter implements VendorAdapter {
       return [];
     }
 
-    const [marketsResponse, userPositionsResponse] = await Promise.all([
-      getPendleMarkets(chainId, false),
-      getPendleUserPositions(userAddress),
-    ]);
-
+    const userPositionsResponse = await getPendleUserPositions(userAddress);
     const chainPositions = userPositionsResponse.positions.find(
       (entry) => entry.chainId === chainId,
     );
@@ -445,13 +441,25 @@ export class PendleAdapter implements VendorAdapter {
       return [];
     }
 
+    const allPositions = chainPositions.openPositions.concat(chainPositions.closedPositions);
+    // Fetch only the markets the user actually has positions in. Listing /v2/markets/all
+    // is capped at PENDLE_MARKETS_LIMIT, which would silently drop positions in markets
+    // ranked past the cap (e.g. USDai, sUSDai).
+    const marketAddresses = Array.from(
+      new Set(
+        allPositions
+          .map((position) => position.marketId.split('-').pop()?.toLowerCase())
+          .filter((address): address is string => Boolean(address)),
+      ),
+    );
+    const markets = await getPendleMarketsByAddresses(chainId, marketAddresses);
     const marketByAddress = new Map<string, PendleMarket>();
-    for (const market of marketsResponse.markets) {
+    for (const market of markets) {
       marketByAddress.set(market.address, market);
     }
 
     const positions: StandardUserPosition[] = [];
-    for (const position of chainPositions.openPositions.concat(chainPositions.closedPositions)) {
+    for (const position of allPositions) {
       const marketAddress = position.marketId.split('-').pop()?.toLowerCase();
       if (!marketAddress) {
         continue;
@@ -522,10 +530,9 @@ export class PendleAdapter implements VendorAdapter {
       return [];
     }
 
-    const marketsResponse = await getPendleMarkets(chainId, false);
-    const rawMarket = marketsResponse.markets.find(
-      (candidate) => candidate.address === id.toLowerCase(),
-    );
+    // Targeted lookup by address — `/v2/markets/all` caps results at PENDLE_MARKETS_LIMIT,
+    // so listing-and-finding silently drops markets ranked past that cap (e.g. USDai).
+    const rawMarket = await getPendleMarketByAddress(chainId, id.toLowerCase());
 
     const market = rawMarket
       ? enrichMarketWithAssets(

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/pendleApi.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/pendleApi.ts
@@ -138,10 +138,20 @@ export async function getPendleMarketByAddress(
   chainId: number,
   marketAddress: string,
 ): Promise<PendleMarket | null> {
-  const marketId = `${chainId}-${marketAddress}`;
+  const markets = await getPendleMarketsByAddresses(chainId, [marketAddress]);
+  return markets[0] ?? null;
+}
+
+export async function getPendleMarketsByAddresses(
+  chainId: number,
+  marketAddresses: string[],
+): Promise<PendleMarket[]> {
+  if (!marketAddresses.length) return [];
+
+  const ids = marketAddresses.map((address) => `${chainId}-${address.toLowerCase()}`).join(',');
   const url = new URL(`${PENDLE_API_BASE_URL}/v2/markets/all`);
-  url.searchParams.set('ids', marketId);
-  url.searchParams.set('limit', '1');
+  url.searchParams.set('ids', ids);
+  url.searchParams.set('limit', marketAddresses.length.toString());
 
   const response = await fetch(url.toString());
   if (!response.ok) throw new Error(await parsePendleApiError(response));
@@ -151,9 +161,7 @@ export async function getPendleMarketByAddress(
       details: RawPendleMarketDetails;
     })[];
   } = await response.json();
-  const market = data.results[0];
-  if (!market) return null;
-  return normalizeMarket(market);
+  return data.results.map(normalizeMarket);
 }
 
 export async function getPendleMarketDetails(


### PR DESCRIPTION
## Summary

- Our Pendle opportunities listing is capped at 50 results, so trying to reuse these fetched opportunities to find details of an opportunity outside of this 50 limit cap silently gives a very buggy experience - drops the markets (e.g. USDai, sUSDai) from showing up. Other symptoms: positions in those markets disappear, and tx rows render as "1 Asset" with placeholder icons because we never properly fetched their token address / symbols.
- `getUserTransactions` and `getAvailableActions` now use the targeted `getPendleMarketByAddress` lookup (`ids=`, no cap).
- `getUserPositions` now fetches the user's positions first and batch-fetches only the markets they hold via a new `getPendleMarketsByAddresses` helper. Zero-position users skip the markets fetch entirely.

## Test plan

- [ ] Check for wallet `0x6A2CF13f0CAB8B0099d53fa29a12bFF90Ac0e33c` before and after the fix - earlier shows no Pendle positions, after the fix, shows 2 user positions.
- [ ] Transaction history table rows show real symbols + logos
