### PR TITLE
fix: catch viem-wrapped user rejection errors

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/isUserRejectedError.ts
+++ b/packages/arb-token-bridge-ui/src/util/isUserRejectedError.ts
@@ -16,9 +16,6 @@ export function isUserRejectedError(error: unknown) {
   const hasUserCancelledMessage =
     typeof candidate.message === 'string' && /User Cancelled/.test(candidate.message);
 
-  // viem wraps rejections from some wallets (e.g. Frame) in a higher-level
-  // class like TransactionExecutionError, with UserRejectedRequestError buried
-  // in the .cause chain. Walk the chain to catch them.
   const hasWrappedUserRejection =
     error instanceof BaseError && !!error.walk((e) => e instanceof UserRejectedRequestError);
 

--- a/packages/arb-token-bridge-ui/src/util/isUserRejectedError.ts
+++ b/packages/arb-token-bridge-ui/src/util/isUserRejectedError.ts
@@ -1,4 +1,4 @@
-import { UserRejectedRequestError } from 'viem';
+import { BaseError, UserRejectedRequestError } from 'viem';
 
 /**
  * This should only be used to conditionally act on errors,
@@ -16,11 +16,18 @@ export function isUserRejectedError(error: unknown) {
   const hasUserCancelledMessage =
     typeof candidate.message === 'string' && /User Cancelled/.test(candidate.message);
 
+  // viem wraps rejections from some wallets (e.g. Frame) in a higher-level
+  // class like TransactionExecutionError, with UserRejectedRequestError buried
+  // in the .cause chain. Walk the chain to catch them.
+  const hasWrappedUserRejection =
+    error instanceof BaseError && !!error.walk((e) => e instanceof UserRejectedRequestError);
+
   return (
     candidate.code === 4001 ||
     candidate.code === 'ACTION_REJECTED' ||
     hasUserCancelledMessage ||
     error instanceof UserRejectedRequestError ||
+    hasWrappedUserRejection ||
     candidate.details === 'MetaMask Tx Signature: User denied transaction signature.' ||
     isBundleRejectedError(error)
   );


### PR DESCRIPTION
## Summary

- Wallets like Frame propagate rejections through wagmi/viem's `sendCalls` / `sendTransaction`. The outer error is a higher-level class (e.g. `TransactionExecutionError`) and the actual `UserRejectedRequestError` sits in the `.cause` chain.
- The existing checks (code 4001, instanceof on the outer error, MetaMask-specific `details` string) miss this shape, so the raw viem payload bubbles up to the UI. Symptom: red error box rendering the full request payload (chain, from, to, data, viem version) on user-cancelled txs.

<img width="392" height="210" alt="image" src="https://github.com/user-attachments/assets/a3e2a453-e34b-4657-97d5-b0936970feab" />

## Why Bridge/MetaMask wasn't affected

Bridge uses Ethers v5's sendTransaction, and MetaMask sets `code: 4001` on the outer error → caught by the existing top-level check. Frame puts the code only on the wrapped cause, which the new walk catches.

## Test plan

- [ ] Reject a Pendle enter/exit on Frame — no error renders, panel returns to idle.
- [ ] Repeat on MetaMask — same behaviour (regression check).
- [ ] Reject a bridge transfer on Frame and MetaMask — same behaviour (the util is shared).
- [ ] Real transaction failure (e.g. revert) still surfaces a readable message to the panel.