### PR TITLE
fix(earn): load Pendle quotes without a connected wallet

### DIFF
--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/PendleAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/PendleAdapter.ts
@@ -320,8 +320,11 @@ export class PendleAdapter implements VendorAdapter {
       );
     }
 
-    if (!userAddress) {
-      throw new ValidationError('INVALID_QUOTE_PARAMS', 'userAddress is required');
+    if ((action === 'rollover' || action === 'redeem') && !userAddress) {
+      throw new ValidationError(
+        'INVALID_QUOTE_PARAMS',
+        `userAddress is required for ${action}`,
+      );
     }
 
     if (!amount || !/^\d+$/.test(amount) || BigNumber.from(amount).lte(0)) {
@@ -329,25 +332,28 @@ export class PendleAdapter implements VendorAdapter {
     }
 
     assertSupportedChainId(chainId);
-    const availableActions = await this.getAvailableActions(id, userAddress, chainId);
 
-    if (!availableActions.availableActions.includes(action)) {
-      throw new ValidationError(
-        'ACTION_NOT_AVAILABLE',
-        `Action "${action}" is not available for this Pendle position`,
-      );
-    }
+    if (userAddress) {
+      const availableActions = await this.getAvailableActions(id, userAddress, chainId);
 
-    if (
-      action === 'rollover' &&
-      !availableActions.rolloverTargets?.some(
-        (target) => target.id === rolloverTargetOpportunityId?.toLowerCase(),
-      )
-    ) {
-      throw new ValidationError(
-        'INVALID_ROLLOVER_TARGET',
-        'Selected rollover target is not available for this Pendle position',
-      );
+      if (!availableActions.availableActions.includes(action)) {
+        throw new ValidationError(
+          'ACTION_NOT_AVAILABLE',
+          `Action "${action}" is not available for this Pendle position`,
+        );
+      }
+
+      if (
+        action === 'rollover' &&
+        !availableActions.rolloverTargets?.some(
+          (target) => target.id === rolloverTargetOpportunityId?.toLowerCase(),
+        )
+      ) {
+        throw new ValidationError(
+          'INVALID_ROLLOVER_TARGET',
+          'Selected rollover target is not available for this Pendle position',
+        );
+      }
     }
 
     const clampedSlippage = Math.min(Math.max(slippage, 0), 50) / 100;

--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/PendleAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/PendleAdapter.ts
@@ -321,10 +321,7 @@ export class PendleAdapter implements VendorAdapter {
     }
 
     if ((action === 'rollover' || action === 'redeem') && !userAddress) {
-      throw new ValidationError(
-        'INVALID_QUOTE_PARAMS',
-        `userAddress is required for ${action}`,
-      );
+      throw new ValidationError('INVALID_QUOTE_PARAMS', `userAddress is required for ${action}`);
     }
 
     if (!amount || !/^\d+$/.test(amount) || BigNumber.from(amount).lte(0)) {

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/pendleApi.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/pendleApi.ts
@@ -219,7 +219,7 @@ interface PendleConvertRouteParams {
   tokensIn: string[];
   amountsIn: string[];
   tokensOut: string[];
-  receiver: string;
+  receiver?: string;
   slippage?: number;
   enableAggregator?: boolean;
 }

--- a/packages/app/src/hooks/earn/usePendlePanelData.ts
+++ b/packages/app/src/hooks/earn/usePendlePanelData.ts
@@ -252,7 +252,6 @@ export function usePendlePanelData({
         : !!inputTokenAddressForQuote &&
           !!outputTokenAddress &&
           quoteAmountRaw !== '0' &&
-          !!walletAddress &&
           !amountExceedsBalance,
   });
 


### PR DESCRIPTION
## Summary

Pendle quotes don't load when the wallet is disconnected — Vaults and Liquid Staking already do. This PR brings Pendle in line.

The blocker was `userAddress` being treated as required. Per Pendle's docs and a direct API probe, `receiver` is optional on `/v3/sdk/.../convert` and the response still includes `amountOut`, `priceImpact`, and `tx.data` without it.


### Before
<img height="200" alt="image" src="https://github.com/user-attachments/assets/447ed629-44f6-434a-a773-c73d0f3abc2e" />

### After
<img  height="200" alt="image" src="https://github.com/user-attachments/assets/90479645-f7fb-426d-b042-77446cf6b87c" />


## Changes

- Drop `!!walletAddress` from the Pendle panel's quote `enabled` gate (enter/exit only — rollover still needs it).
- In the adapter, only require `userAddress` for `rollover` / `redeem` (which need position info), and skip the available-actions lookup when it's missing.
- Make `receiver` optional in the convert helper; `JSON.stringify` drops it when undefined.

## Test plan

- [ ] Disconnect wallet, open a Pendle market, enter an amount → quote renders.
- [ ] Same for exit.
- [ ] Reconnect → execution still works.
- [ ] Rollover / redeem still require a wallet.