### PR TITLE
fix(earn): clean up API failure handling

### DIFF
--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/LiFiAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/LiFiAdapter.ts
@@ -279,7 +279,7 @@ export class LiFiAdapter implements VendorAdapter {
     id: string,
     request: TransactionQuoteRequest,
     chainId: EarnChainId = ChainId.ArbitrumOne,
-  ): Promise<TransactionQuoteResponse> {
+  ): Promise<TransactionQuoteResponse | null> {
     if (chainId !== ChainId.ArbitrumOne) {
       throw new ValidationError(
         'UNSUPPORTED_CHAIN_ID',
@@ -319,15 +319,7 @@ export class LiFiAdapter implements VendorAdapter {
     });
 
     if (!step) {
-      return {
-        opportunityId: id,
-        vendor: Vendor.LiFi,
-        action: 'swap',
-        canExecute: false,
-        estimatedGas: '0',
-        estimatedGasUsd: '0',
-        transactionSteps: [],
-      };
+      return null;
     }
 
     if (!userAddress) {

--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/LiFiAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/LiFiAdapter.ts
@@ -67,7 +67,7 @@ export class LiFiAdapter implements VendorAdapter {
       integrator: LIFI_INTEGRATOR_IDS.NORMAL,
     });
     if (!routes || routes.length === 0) {
-      throw new Error('No routes found');
+      return { step: null };
     }
 
     const quote = routes[0];
@@ -84,7 +84,7 @@ export class LiFiAdapter implements VendorAdapter {
   }
 
   private async getQuoteStepWithTransaction(
-    step: Awaited<ReturnType<LiFiAdapter['getQuoteStep']>>['step'],
+    step: NonNullable<Awaited<ReturnType<LiFiAdapter['getQuoteStep']>>['step']>,
   ) {
     const { transactionRequest } = await getStepTransaction(step);
     const to = transactionRequest?.to;
@@ -317,6 +317,18 @@ export class LiFiAdapter implements VendorAdapter {
       userAddress,
       slippage,
     });
+
+    if (!step) {
+      return {
+        opportunityId: id,
+        vendor: Vendor.LiFi,
+        action: 'swap',
+        canExecute: false,
+        estimatedGas: '0',
+        estimatedGasUsd: '0',
+        transactionSteps: [],
+      };
+    }
 
     if (!userAddress) {
       const { transactionSteps, estimatedGas, estimatedGasUsd, receiveAmount, priceImpact } =

--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/PendleAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/PendleAdapter.ts
@@ -291,7 +291,7 @@ export class PendleAdapter implements VendorAdapter {
     id: string,
     request: TransactionQuoteRequest,
     chainId: EarnChainId = DEFAULT_CHAIN_ID,
-  ): Promise<TransactionQuoteResponse> {
+  ): Promise<TransactionQuoteResponse | null> {
     const {
       action,
       amount,
@@ -366,15 +366,7 @@ export class PendleAdapter implements VendorAdapter {
 
     const firstRoute = route.routes?.[0];
     if (!firstRoute) {
-      return {
-        opportunityId: id,
-        vendor: Vendor.Pendle,
-        action,
-        canExecute: false,
-        estimatedGas: '0',
-        estimatedGasUsd: '0',
-        transactionSteps: [],
-      };
+      return null;
     }
 
     const transactionSteps: TransactionStep[] = [];

--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/PendleAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/PendleAdapter.ts
@@ -366,10 +366,15 @@ export class PendleAdapter implements VendorAdapter {
 
     const firstRoute = route.routes?.[0];
     if (!firstRoute) {
-      throw new ValidationError(
-        'QUOTE_ROUTE_NOT_FOUND',
-        'No route found in Pendle convert response',
-      );
+      return {
+        opportunityId: id,
+        vendor: Vendor.Pendle,
+        action,
+        canExecute: false,
+        estimatedGas: '0',
+        estimatedGasUsd: '0',
+        transactionSteps: [],
+      };
     }
 
     const transactionSteps: TransactionStep[] = [];

--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/VaultsAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/VaultsAdapter.ts
@@ -3,6 +3,7 @@ import { ChainId } from '@/bridge/types/ChainId';
 
 import { resolveAdapterWindow } from '../lib/historicalWindow';
 import { parseOptionalNumber, parseOptionalPercentage } from '../lib/metricParsers';
+import { ValidationError } from '../lib/validation';
 import { DEFAULT_ALLOWED_ASSETS, vaultsSdk } from '../lib/vaultsSdk';
 import { fetchAlignedPriceLookup } from '../lib/zerionService';
 import {
@@ -326,7 +327,10 @@ export class VaultsAdapter implements VendorAdapter {
     const { action, amount, userAddress, simulate = false } = request;
 
     if (!userAddress) {
-      throw new Error('userAddress is required for vault transactions');
+      throw new ValidationError(
+        'USER_ADDRESS_REQUIRED',
+        'userAddress is required for vault transactions',
+      );
     }
 
     if (action !== 'deposit' && action !== 'redeem') {

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/historical-data/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/historical-data/route.ts
@@ -128,7 +128,9 @@ export async function GET(
     });
   } catch (error) {
     const routeError = error as { message?: string; code?: string; status?: number };
-    console.error('Error fetching historical data:', {
+    const status = routeError.status ?? 500;
+    const log = status >= 500 ? console.error : console.warn;
+    log('Error fetching historical data:', {
       message: routeError.message,
       code: routeError.code,
       status: routeError.status,
@@ -139,7 +141,7 @@ export async function GET(
         message: routeError.message ?? 'Failed to fetch historical data',
         code: routeError.code ?? 'HISTORICAL_DATA_FETCH_ERROR',
       },
-      { status: routeError.status ?? 500 },
+      { status },
     );
   }
 }

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/historical-data/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/historical-data/route.ts
@@ -133,7 +133,7 @@ export async function GET(
     log('Error fetching historical data:', {
       message: routeError.message,
       code: routeError.code,
-      status: routeError.status,
+      status,
       error,
     });
     return NextResponse.json(

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transaction-quote/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transaction-quote/route.ts
@@ -163,14 +163,16 @@ export async function GET(
       },
     });
   } catch (error) {
-    console.error('Error preparing transaction:', error);
     const routeError = error as { message?: string; code?: string; status?: number };
+    const status = routeError.status ?? 500;
+    const log = status >= 500 ? console.error : console.warn;
+    log('Error preparing transaction:', error);
     return NextResponse.json(
       {
         message: routeError.message ?? 'Failed to get transaction quote',
         code: routeError.code ?? 'TRANSACTION_QUOTE_ERROR',
       },
-      { status: routeError.status ?? 500 },
+      { status },
     );
   }
 }

--- a/packages/app/src/app/api/onchain-actions/v1/earn/types.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/types.ts
@@ -404,7 +404,7 @@ export interface VendorAdapter {
     id: string,
     request: TransactionQuoteRequest,
     chainId: EarnChainId,
-  ): Promise<TransactionQuoteResponse>;
+  ): Promise<TransactionQuoteResponse | null>;
   getUserPositions(userAddress: string, chainId: EarnChainId): Promise<StandardUserPosition[]>;
   getUserTransactions(
     id: string,

--- a/packages/app/src/components/earn/EarnActionPanel/EarnAmountInputSection.tsx
+++ b/packages/app/src/components/earn/EarnActionPanel/EarnAmountInputSection.tsx
@@ -57,13 +57,15 @@ export function EarnAmountInputSection({
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between">
           <span className="text-xs font-medium text-white/50">{label}</span>
-          <Button
-            variant="secondary"
-            onClick={onMaxClick}
-            className="px-2.5 py-0 h-4 text-[10px] rounded-md bg-white/10 border-0"
-          >
-            MAX
-          </Button>
+          {isConnected && (
+            <Button
+              variant="secondary"
+              onClick={onMaxClick}
+              className="px-2.5 py-0 h-4 text-[10px] rounded-md bg-white/10 border-0"
+            >
+              MAX
+            </Button>
+          )}
         </div>
         <div className="flex items-center justify-between gap-2">
           <EarnActionPanelInput

--- a/packages/app/src/components/earn/LiquidStakingActionPanel.tsx
+++ b/packages/app/src/components/earn/LiquidStakingActionPanel.tsx
@@ -314,7 +314,7 @@ export function LiquidStakingActionPanel({
     slippagePercent: controls.slippagePercent,
     walletAddress: walletAddress || undefined,
     isConnected,
-    transactionQuote,
+    transactionQuote: transactionQuote ?? undefined,
     canSubmit: !data.submitDisabled,
     checkAndShowToS,
     showTransactionDetails,

--- a/packages/app/src/components/earn/LiquidStakingAmountSection.tsx
+++ b/packages/app/src/components/earn/LiquidStakingAmountSection.tsx
@@ -48,13 +48,15 @@ export function LiquidStakingAmountSection({
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between">
           <span className="text-xs font-medium text-white/50">{label}</span>
-          <Button
-            variant="secondary"
-            onClick={onMaxClick}
-            className="px-2.5 py-0 h-4 text-[10px] rounded-md bg-white/10 border-0"
-          >
-            MAX
-          </Button>
+          {isConnected && (
+            <Button
+              variant="secondary"
+              onClick={onMaxClick}
+              className="px-2.5 py-0 h-4 text-[10px] rounded-md bg-white/10 border-0"
+            >
+              MAX
+            </Button>
+          )}
         </div>
         <div className="flex items-center justify-between gap-2">
           <EarnActionPanelInput

--- a/packages/app/src/components/earn/PendleActionPanel.tsx
+++ b/packages/app/src/components/earn/PendleActionPanel.tsx
@@ -112,7 +112,7 @@ export function PendleActionPanel({
     outputTokenLogo: data.outputTokenLogo,
     slippagePercent,
     estimatedTxCost: data.estimatedTxCost,
-    transactionQuote: data.transactionQuote,
+    transactionQuote: data.transactionQuote ?? undefined,
     transferReadiness: data.transferReadiness,
     refetch: data.refetch,
     checkAndShowToS,

--- a/packages/app/src/components/earn/VaultActionPanel.tsx
+++ b/packages/app/src/components/earn/VaultActionPanel.tsx
@@ -179,7 +179,7 @@ export function VaultActionPanel({
     inputTokenAddress:
       selectedAction === 'supply' ? asset?.address || vault.asset?.address : vault.asset?.address,
     chainId: requestChainId,
-    enabled: amountInRawUnits !== '0' && (!isConnected || !amountExceedsBalance),
+    enabled: amountInRawUnits !== '0' && isConnected && !amountExceedsBalance,
   });
 
   const chainId = useMemo(

--- a/packages/app/src/components/earn/VaultActionPanel.tsx
+++ b/packages/app/src/components/earn/VaultActionPanel.tsx
@@ -179,7 +179,7 @@ export function VaultActionPanel({
     inputTokenAddress:
       selectedAction === 'supply' ? asset?.address || vault.asset?.address : vault.asset?.address,
     chainId: requestChainId,
-    enabled: amountInRawUnits !== '0' && isConnected && !amountExceedsBalance,
+    enabled: amountInRawUnits !== '0' && isConnected && !!walletAddress && !amountExceedsBalance,
   });
 
   const chainId = useMemo(

--- a/packages/app/src/hooks/earn/useTransactionQuote.ts
+++ b/packages/app/src/hooks/earn/useTransactionQuote.ts
@@ -126,7 +126,7 @@ export function useTransactionQuote({
         );
       }
 
-      return (await response.json()) as TransactionQuoteResponse;
+      return (await response.json()) as TransactionQuoteResponse | null;
     },
     {
       refreshInterval: 20_000,


### PR DESCRIPTION
## Summary

Cleanup of failures in the earn API that we found in server logs. Three changes:

1. **Empty-result quotes return 200, not errors** — LiFi `NO_ROUTES_FOUND` and Pendle `QUOTE_ROUTE_NOT_FOUND` were really "computation produced no executable route," which is a valid success path, not a server error.
2. **Validation errors get proper HTTP status + code** — `userAddress is required` from Vaults now flows through `ValidationError` → 400, not a bare `Error` → 500. Also - we are no longer fetching quotes for Lending markets (vaults) if the wallet is not connected - this takes care of this error from the UI side.
3. **Log level follows status** — route handlers now `console.warn` for 4xx and `console.error` for 5xx, so validation failures stop tripping the 5xx alert rules.

## Behavioral change to flag

`/transaction-quote` consumers previously got 5xx/4xx with `code: NO_ROUTES_FOUND` or `QUOTE_ROUTE_NOT_FOUND` when no route existed. They now get a successful 200 response with `canExecute: false` and `transactionSteps: []`. Internal callers (frontend) already treat empty steps as "not ready," so no UI changes were required.

## Test plan

- [ ] Manually verify Vaults supply / redeem still works end-to-end with a connected wallet
- [ ] Manually verify Pendle and Liquid Staking quotes still work with a connected wallet
- [ ] Trigger the no-route case on Liquid Staking (e.g., bogus token pair) and confirm 200 + empty steps, no error toast, submit disabled
- [ ] Confirm disconnected Vaults panel no longer triggers a 400 in network tab (no quote request fired)
- [ ] Monitor 5xx error rates on the earn endpoints after deploy

Closes FS-2236