### PR TITLE
fix(earn): APY discrepancies in UI

### DIFF
--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/VaultsAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/VaultsAdapter.ts
@@ -96,7 +96,7 @@ export class VaultsAdapter implements VendorAdapter {
 
     const minApy = filters.minApy ?? 0;
     const filtered = response.data.filter((vault) => {
-      const apyData = vault.apy?.['7day'] ?? vault.apy?.['1day'] ?? vault.apy?.['30day'];
+      const apyData = vault.apy?.['7day'] ?? vault.apy?.['30day'] ?? vault.apy?.['1day'];
       const apyPercentage = parseOptionalPercentage(apyData?.total);
       if (apyPercentage === null || apyPercentage <= 0) {
         return false;
@@ -642,7 +642,7 @@ export class VaultsAdapter implements VendorAdapter {
   }
 
   private transformToStandard(vault: DetailedVault): StandardOpportunity {
-    const apyData = vault.apy?.['7day'] ?? vault.apy?.['1day'] ?? vault.apy?.['30day'];
+    const apyData = vault.apy?.['7day'] ?? vault.apy?.['30day'] ?? vault.apy?.['1day'];
     const apyPercentage = parseOptionalPercentage(apyData?.total);
     const apyBreakdown = apyData
       ? {

--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/VaultsAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/VaultsAdapter.ts
@@ -96,7 +96,7 @@ export class VaultsAdapter implements VendorAdapter {
 
     const minApy = filters.minApy ?? 0;
     const filtered = response.data.filter((vault) => {
-      const apyData = vault.apy?.['30day'] ?? vault.apy?.['7day'] ?? vault.apy?.['1day'];
+      const apyData = vault.apy?.['7day'] ?? vault.apy?.['1day'] ?? vault.apy?.['30day'];
       const apyPercentage = parseOptionalPercentage(apyData?.total);
       if (apyPercentage === null || apyPercentage <= 0) {
         return false;
@@ -642,7 +642,7 @@ export class VaultsAdapter implements VendorAdapter {
   }
 
   private transformToStandard(vault: DetailedVault): StandardOpportunity {
-    const apyData = vault.apy?.['30day'] ?? vault.apy?.['7day'] ?? vault.apy?.['1day'];
+    const apyData = vault.apy?.['7day'] ?? vault.apy?.['1day'] ?? vault.apy?.['30day'];
     const apyPercentage = parseOptionalPercentage(apyData?.total);
     const apyBreakdown = apyData
       ? {

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/duneQueries.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/duneQueries.ts
@@ -8,7 +8,7 @@ export const DUNE_QUERY_IDS = {
   // Lido wstETH APY query
   // Query: https://dune.com/queries/570874/1068499
   // Returns: time, protocol_apr, Lido staking APR (instant), Lido staking APR (ma_7), Lido staking APR (ma_30), protocol APR (ma_7)
-  // We use "Lido staking APR (ma_7)" (7-day moving average) for APY
+  // We use "Lido staking APR (ma_7)" (7-day moving average), converted to APY in duneService
   WSTETH_APY: 570874,
 
   // Lido wstETH TVL query

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/duneQueries.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/duneQueries.ts
@@ -8,7 +8,7 @@ export const DUNE_QUERY_IDS = {
   // Lido wstETH APY query
   // Query: https://dune.com/queries/570874/1068499
   // Returns: time, protocol_apr, Lido staking APR (instant), Lido staking APR (ma_7), Lido staking APR (ma_30), protocol APR (ma_7)
-  // We use "Lido staking APR (instant)" for APY
+  // We use "Lido staking APR (ma_7)" (7-day moving average) for APY
   WSTETH_APY: 570874,
 
   // Lido wstETH TVL query

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/duneService.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/duneService.ts
@@ -53,6 +53,7 @@ function findColumn(
 
 /** APY columns that are already expressed as percentages (not decimals). */
 const PERCENTAGE_APY_MATCHERS: Array<(name: string) => boolean> = [
+  (n) => n === 'lido staking apr (ma_7)' || n === 'lido staking apr(ma_7)',
   (n) => n === 'lido staking apr (instant)' || n === 'lido staking apr(instant)',
   (n) => n === 'steth apy',
 ];
@@ -96,12 +97,16 @@ function transformDuneResults(rows: Array<Record<string, unknown>>): DuneDataPoi
 
   const apyColumn = findColumn(
     allColumns,
-    // wstETH new query (already percentage)
+    // wstETH new query — 7-day moving average (already percentage)
+    (n) => n === 'lido staking apr (ma_7)' || n === 'lido staking apr(ma_7)',
+    // wstETH new query — instant fallback (already percentage)
     (n) => n === 'lido staking apr (instant)' || n === 'lido staking apr(instant)',
     // wstETH old query (already percentage)
     (n) => n === 'steth apy',
-    // weETH (decimal format)
-    (n) => n === 'avg_7day_apr' || n === 'daily_apr',
+    // weETH 7-day average (decimal format)
+    (n) => n === 'avg_7day_apr',
+    // weETH daily fallback (decimal format)
+    (n) => n === 'daily_apr',
     // Generic fallback
     (n) => n.includes('apy') || n.includes('apr') || n.includes('yield'),
   );

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/duneService.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/duneService.ts
@@ -1,4 +1,5 @@
 // Dune APY/TVL time series for liquid staking. Pricing lives in zerionService.ts.
+import { convertAprToApy } from '@/bridge/util/NumberUtils';
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -139,12 +140,14 @@ function transformDuneResults(rows: Array<Record<string, unknown>>): DuneDataPoi
         return null;
       }
 
-      // Extract APY (may be percentage or decimal)
+      // Extract APR (may be percentage or decimal) and compound into the APY the
+      // UI shows — Dune exposes APR for liquid staking.
       let apy: number | null = null;
       if (apyColumn && row[apyColumn] !== null && row[apyColumn] !== undefined) {
         const apyValue = Number(row[apyColumn]);
         if (Number.isFinite(apyValue)) {
-          apy = apyIsPercentage || apyValue >= 1 ? apyValue : apyValue * 100;
+          const apr = apyIsPercentage || apyValue >= 1 ? apyValue : apyValue * 100;
+          apy = convertAprToApy(apr);
         }
       }
 

--- a/packages/app/src/components/earn/HistoricalChart/HistoricalLineChart.tsx
+++ b/packages/app/src/components/earn/HistoricalChart/HistoricalLineChart.tsx
@@ -12,7 +12,7 @@ import {
   YAxis,
 } from 'recharts';
 
-import { formatCompactUsd } from '@/bridge/util/NumberUtils';
+import { formatCompactUsd, formatPercentage } from '@/bridge/util/NumberUtils';
 
 import type { ChartConfig } from './chartConfig';
 import { type MetricType, formatMetricValue, formatPriceUsd } from './formatters';
@@ -98,9 +98,7 @@ export function HistoricalLineChart({
 
   const formatYAxisLabel = (value: number): string => {
     if (metricType === 'apy') {
-      const abs = Math.abs(value);
-      const decimals = abs < 1 ? 3 : 2;
-      return `${value.toFixed(decimals)}%`;
+      return formatPercentage(value);
     }
     if (metricType === 'price') {
       return formatPriceUsd(value);
@@ -115,8 +113,8 @@ export function HistoricalLineChart({
       (max, value) => Math.max(max, formatYAxisLabel(value).length),
       0,
     );
-    // ~7px per char at 12px font, floor at 40px
-    return Math.max(40, longestLabelLength * 7);
+    // ~7px per char at 12px font, floor at 48px
+    return Math.max(48, longestLabelLength * 7);
   })();
 
   return (

--- a/packages/app/src/components/earn/HistoricalChart/formatters.ts
+++ b/packages/app/src/components/earn/HistoricalChart/formatters.ts
@@ -1,4 +1,4 @@
-import { formatCompactUsd } from '@/bridge/util/NumberUtils';
+import { formatCompactUsd, formatPercentage } from '@/bridge/util/NumberUtils';
 
 function getPriceMaximumFractionDigits(value: number): number {
   const abs = Math.abs(value);
@@ -23,7 +23,7 @@ export type MetricType = 'apy' | 'tvl' | 'price';
 
 export function formatMetricValue(metricType: MetricType | undefined, value: number): string {
   if (metricType === 'apy') {
-    return `${value.toFixed(2)}%`;
+    return formatPercentage(value);
   }
 
   if (metricType === 'price') {

--- a/packages/app/src/components/earn/LendOpportunityDetailsPage.tsx
+++ b/packages/app/src/components/earn/LendOpportunityDetailsPage.tsx
@@ -106,7 +106,7 @@ export function LendOpportunityDetailsPage({ opportunity }: LendOpportunityDetai
           </div>
 
           <div className="flex justify-between items-center">
-            <span className="text-xs font-medium text-white">Current APR</span>
+            <span className="text-xs font-medium text-white">Current APY</span>
             <span className="text-xs font-medium text-earn-success">{currentApr}</span>
           </div>
         </div>

--- a/packages/app/src/components/earn/LendOpportunityDetailsPage.tsx
+++ b/packages/app/src/components/earn/LendOpportunityDetailsPage.tsx
@@ -179,7 +179,7 @@ export function LendOpportunityDetailsPage({ opportunity }: LendOpportunityDetai
               <div className="text-xs text-white/50 mb-1">7d APY</div>
               <div className="text-base font-medium text-white">
                 {typeof apy7day === 'number' && Number.isFinite(apy7day)
-                  ? `${apy7day.toFixed(1)}%`
+                  ? formatPercentage(apy7day)
                   : '—'}
               </div>
             </div>
@@ -187,7 +187,7 @@ export function LendOpportunityDetailsPage({ opportunity }: LendOpportunityDetai
               <div className="text-xs text-white/50 mb-1">30d APY</div>
               <div className="text-base font-medium text-white">
                 {typeof apy30day === 'number' && Number.isFinite(apy30day)
-                  ? `${apy30day.toFixed(1)}%`
+                  ? formatPercentage(apy30day)
                   : '—'}
               </div>
             </div>

--- a/packages/app/src/components/earn/OpportunitiesTable.tsx
+++ b/packages/app/src/components/earn/OpportunitiesTable.tsx
@@ -113,9 +113,13 @@ function TableHeader({ sortColumn, sortDirection, onSort, category }: TableHeade
             content={<p className="text-xs text-white leading-relaxed">7-day average APY.</p>}
             tippyProps={{ placement: 'top' }}
           >
-            <div className="flex items-center justify-center cursor-pointer">
+            <button
+              type="button"
+              aria-label="APY methodology"
+              className="flex items-center justify-center cursor-pointer"
+            >
               <InformationCircleIcon className="h-3.5 w-3.5 text-white opacity-50 hover:opacity-70" />
-            </div>
+            </button>
           </Tooltip>
         )}
       </div>

--- a/packages/app/src/components/earn/OpportunitiesTable.tsx
+++ b/packages/app/src/components/earn/OpportunitiesTable.tsx
@@ -111,7 +111,7 @@ function TableHeader({ sortColumn, sortDirection, onSort, category }: TableHeade
           category === OpportunityCategory.LiquidStaking) && (
           <Tooltip
             content={<p className="text-xs text-white leading-relaxed">7-day average APY.</p>}
-            tippyProps={{ placement: 'top' }}
+            contentProps={{ side: 'top' }}
           >
             <button
               type="button"

--- a/packages/app/src/components/earn/OpportunitiesTable.tsx
+++ b/packages/app/src/components/earn/OpportunitiesTable.tsx
@@ -87,9 +87,10 @@ interface TableHeaderProps {
   sortColumn: SortColumn;
   sortDirection: SortDirection;
   onSort: (column: NonNullable<SortColumn>) => void;
+  category?: OpportunityCategory;
 }
 
-function TableHeader({ sortColumn, sortDirection, onSort }: TableHeaderProps) {
+function TableHeader({ sortColumn, sortDirection, onSort, category }: TableHeaderProps) {
   return (
     <div className="hidden lg:flex gap-4 items-center pt-4 px-4 pb-0">
       <div className="w-[150px] shrink-0">
@@ -106,6 +107,17 @@ function TableHeader({ sortColumn, sortDirection, onSort }: TableHeaderProps) {
           sortDirection={sortDirection}
           onSort={onSort}
         />
+        {(category === OpportunityCategory.Lend ||
+          category === OpportunityCategory.LiquidStaking) && (
+          <Tooltip
+            content={<p className="text-xs text-white leading-relaxed">7-day average APY.</p>}
+            tippyProps={{ placement: 'top' }}
+          >
+            <div className="flex items-center justify-center cursor-pointer">
+              <InformationCircleIcon className="h-3.5 w-3.5 text-white opacity-50 hover:opacity-70" />
+            </div>
+          </Tooltip>
+        )}
       </div>
       <div className="flex-1 flex gap-2.5 items-center min-w-0">
         <SortableColumnHeader
@@ -379,6 +391,7 @@ export function OpportunitiesTable({
                       sortColumn={sortColumn}
                       sortDirection={sortDirection}
                       onSort={handleSort}
+                      category={category}
                     />
                     {displayedOpportunities.map((opportunity) => (
                       <OpportunityRow

--- a/packages/app/src/lib/earn/utils.ts
+++ b/packages/app/src/lib/earn/utils.ts
@@ -2,6 +2,7 @@ import { BigNumber, constants } from 'ethers';
 import { type Address, getAddress } from 'viem';
 
 import { addressesEqual } from '@/bridge/util/AddressUtils';
+import { formatPercentage } from '@/bridge/util/NumberUtils';
 import { LIQUID_STAKING_OPPORTUNITIES } from '@/earn-api/lib/liquidStaking';
 import type { StandardOpportunityLend } from '@/earn-api/types';
 
@@ -18,14 +19,14 @@ export function parseMetricNumber(value: number | null | undefined): number | nu
 }
 
 export function formatApyBreakdown(value: number | undefined) {
-  return typeof value === 'number' && Number.isFinite(value) ? `${value.toFixed(1)}%` : '—';
+  return typeof value === 'number' && Number.isFinite(value) ? formatPercentage(value) : '—';
 }
 
 export function formatApr(apy: number | undefined) {
   if (apy == null || !Number.isFinite(apy)) {
     return '—';
   }
-  return `${(apy * 100).toFixed(2)}%`;
+  return formatPercentage(apy * 100);
 }
 
 export function deriveVault(opportunity: StandardOpportunityLend) {

--- a/packages/arb-token-bridge-ui/src/util/NumberUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/NumberUtils.ts
@@ -45,6 +45,14 @@ export function formatPercentage(value: number): string {
   return `${Number(value.toFixed(2))}%`;
 }
 
+/**
+ * Convert an APR percentage to an APY percentage assuming daily compounding
+ * (n = 365). Useful for yields published as APR that the UI surfaces as APY.
+ */
+export function convertAprToApy(aprPercentage: number): number {
+  return ((1 + aprPercentage / 100 / 365) ** 365 - 1) * 100;
+}
+
 export enum MaximumFractionDigits {
   None = 0,
   Short = 1,

--- a/packages/arb-token-bridge-ui/src/util/NumberUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/NumberUtils.ts
@@ -38,6 +38,7 @@ export function formatCompactNumber(n: number): string {
 }
 
 export function formatPercentage(value: number): string {
+  if (value === 0) return '0%';
   if (value < 0.01) return `${value.toFixed(4)}%`;
   if (value < 1) return `${value.toFixed(3)}%`;
   return `${value.toFixed(2)}%`;

--- a/packages/arb-token-bridge-ui/src/util/NumberUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/NumberUtils.ts
@@ -39,9 +39,10 @@ export function formatCompactNumber(n: number): string {
 
 export function formatPercentage(value: number): string {
   if (value === 0) return '0%';
-  if (value < 0.01) return `${value.toFixed(4)}%`;
-  if (value < 1) return `${value.toFixed(3)}%`;
-  return `${value.toFixed(2)}%`;
+  // `Number` drops the trailing zeros `toFixed` pads (e.g. 0.05 -> "0.050").
+  if (value < 0.01) return `${Number(value.toFixed(4))}%`;
+  if (value < 1) return `${Number(value.toFixed(3))}%`;
+  return `${Number(value.toFixed(2))}%`;
 }
 
 export enum MaximumFractionDigits {

--- a/packages/arb-token-bridge-ui/src/util/__tests__/NumberUtils.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/__tests__/NumberUtils.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from 'ethers';
 import { describe, expect, it } from 'vitest';
 
-import { formatAmount, truncateExtraDecimals } from '../NumberUtils';
+import { formatAmount, formatPercentage, truncateExtraDecimals } from '../NumberUtils';
 
 describe('formatAmount', () => {
   describe('for short token symbol', () => {
@@ -164,5 +164,29 @@ describe('truncateExtraDecimals', () => {
 
   it('should throw when decimals is negative', () => {
     expect(() => truncateExtraDecimals('1.2345', -1)).toThrow('decimals must be non-negative');
+  });
+});
+
+describe('formatPercentage', () => {
+  it('should render exact zero as 0%', () => {
+    expect(formatPercentage(0)).toBe('0%');
+  });
+
+  it('should not pad trailing zeros', () => {
+    expect(formatPercentage(0.05)).toBe('0.05%');
+    expect(formatPercentage(2.5)).toBe('2.5%');
+    expect(formatPercentage(5)).toBe('5%');
+    expect(formatPercentage(0.005)).toBe('0.005%');
+  });
+
+  it('should round to more decimals for smaller values', () => {
+    expect(formatPercentage(0.0123)).toBe('0.012%');
+    expect(formatPercentage(0.00456)).toBe('0.0046%');
+    expect(formatPercentage(2.4689)).toBe('2.47%');
+  });
+
+  it('should keep significant decimals that are not trailing zeros', () => {
+    expect(formatPercentage(2.75)).toBe('2.75%');
+    expect(formatPercentage(12.3456)).toBe('12.35%');
   });
 });

--- a/packages/arb-token-bridge-ui/src/util/__tests__/NumberUtils.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/__tests__/NumberUtils.test.ts
@@ -1,7 +1,12 @@
 import { BigNumber } from 'ethers';
 import { describe, expect, it } from 'vitest';
 
-import { formatAmount, formatPercentage, truncateExtraDecimals } from '../NumberUtils';
+import {
+  convertAprToApy,
+  formatAmount,
+  formatPercentage,
+  truncateExtraDecimals,
+} from '../NumberUtils';
 
 describe('formatAmount', () => {
   describe('for short token symbol', () => {
@@ -188,5 +193,17 @@ describe('formatPercentage', () => {
   it('should keep significant decimals that are not trailing zeros', () => {
     expect(formatPercentage(2.75)).toBe('2.75%');
     expect(formatPercentage(12.3456)).toBe('12.35%');
+  });
+});
+
+describe('convertAprToApy', () => {
+  it('should return 0 for an APR of 0', () => {
+    expect(convertAprToApy(0)).toBe(0);
+  });
+
+  it('should convert APR to a daily-compounded APY', () => {
+    expect(formatPercentage(convertAprToApy(2.39))).toBe('2.42%');
+    expect(formatPercentage(convertAprToApy(5))).toBe('5.13%');
+    expect(formatPercentage(convertAprToApy(10))).toBe('10.52%');
   });
 });

--- a/packages/arb-token-bridge-ui/src/util/__tests__/NumberUtils.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/__tests__/NumberUtils.test.ts
@@ -182,6 +182,8 @@ describe('formatPercentage', () => {
     expect(formatPercentage(2.5)).toBe('2.5%');
     expect(formatPercentage(5)).toBe('5%');
     expect(formatPercentage(0.005)).toBe('0.005%');
+    expect(formatPercentage(5.05)).toBe('5.05%');
+    expect(formatPercentage(5.1)).toBe('5.1%');
   });
 
   it('should round to more decimals for smaller values', () => {


### PR DESCRIPTION
## Summary

Post-launch fixes for the Earn feature based on Slack feedback:

- Lend (Vaults) APY switched from 30-day → 7-day, matching what users see on vaults.fyi (and much more stable than showing the fluctuating 1d APY)
- wstETH switched from Lido's instant APR → 7-day moving average for parity with weETH
- Liquid staking (wstETH, weETH) now converts the Dune 7-day moving-average **APR → APY** via daily compounding (Dune only exposes APR), so the value matches the "APY" label. Shared `convertAprToApy` helper in `NumberUtils` with unit tests.
- "7-day average APY" tooltip on Lend & Liquid Staking column headers
- Y-axis labels in historical charts no longer crop (e.g. `0.051%`)
- `formatPercentage` now trims trailing zeros (e.g. `0.050%` → `0.05%`) so APY rendering is consistent across rows, cards, chart tooltips, and breakdowns
- Realigned the APY tooltip to the new Radix `Tooltip` API (post Next upgrade)

## Test plan

- [x] /earn landing — Lend & LS sections show 7-day average APYs with info tooltip
- [x] /earn opportunity detail (Aave WETH / WBTC) — y-axis labels not cropped on APY chart
- [x] Liquid staking APY reflects APR→APY conversion (wstETH ~2.39% APR → ~2.42% APY)
- [ ] All APY values (rows, cards, chart tooltip, breakdown) use consistent decimals with no trailing zeros

Closes FS-2235
