### PR TITLE
chore: add qs to audit ci ignore list

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -107,6 +107,9 @@
     // https://github.com/advisories/GHSA-79cf-xcqc-c78w
     // webpack-dev-server cross-origin source code exposure on non-HTTPS origins (CVE-2026-6402)
     //
+    // https://github.com/advisories/GHSA-q8mj-m7cp-5q26
+    // qs has a remotely triggerable DoS in stringify with comma arrays + encodeValuesOnly (CVE-2026-8723)
+    //
     // Reason to ignore: All from @synthetixio/synpress, an E2E test devDependency.
     // Each fix requires a major bump deep in the synpress chain that would risk
     // breaking E2E tooling. Not used in production builds or runtime code.
@@ -118,6 +121,7 @@
     "GHSA-9jgg-88mc-972h",
     "GHSA-4v9v-hfq4-rm2v",
     "GHSA-79cf-xcqc-c78w",
+    "GHSA-q8mj-m7cp-5q26",
     //
     // https://github.com/advisories/GHSA-qjx8-664m-686j
     // js-cookie prototype hijack in assign() enables cookie-attribute injection (CVE-2026-46625)


### PR DESCRIPTION
## Summary
- Adds GHSA-q8mj-m7cp-5q26 (qs DoS in `stringify` with comma arrays + `encodeValuesOnly`, CVE-2026-8723) to the existing `@synthetixio/synpress` allowlist group in `audit-ci.jsonc`.
- Same root path as the other entries in that group — pulled in transitively via cypress / webpack-dev-server / express, E2E test devDependency only. The shared "Reason to ignore" block already applies.

## Test plan
- [x] `pnpm audit:ci` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)