### PR TITLE
chore(bridge): update Mind Network RPC and make it withdraw-only

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadiness.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadiness.ts
@@ -42,7 +42,9 @@ import {
 export const DISABLED_CHAIN_IDS: number[] = [];
 
 // withdraw-only chains (will also display error message in the transfer panel)
-const WITHDRAW_ONLY_CHAIN_IDS: number[] = [];
+const WITHDRAW_ONLY_CHAIN_IDS: number[] = [
+  228, // Mind Network - being sunset, withdrawals supported until end of June
+];
 
 type ErrorMessages = {
   inputAmount1?: string | TransferReadinessRichErrorMessage;

--- a/packages/arb-token-bridge-ui/src/util/orbitChainsData.json
+++ b/packages/arb-token-bridge-ui/src/util/orbitChainsData.json
@@ -146,7 +146,7 @@
         "sequencerInbox": "0xD00d2ef101d86C570dA8f38801f236b79a7a2A93"
       },
       "explorerUrl": "https://explorer.mindnetwork.xyz",
-      "rpcUrl": "https://rpc-mainnet.mindnetwork.xyz",
+      "rpcUrl": "https://rpc-mainnet-internal.mindnetwork.xyz",
       "isCustom": true,
       "isTestnet": false,
       "name": "Mind Network",


### PR DESCRIPTION
Mind Network is being sunset but withdrawals are supported until end of June. Updates the chain to the new internal RPC endpoint and makes it withdraw-only (deposits blocked, in-panel notice shown).

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f3878f37-fa83-4ea2-8291-2e083994437d" />


Closes FS-2257