### PR TITLE
test(bridge): fix flaky balance hook unit tests

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/useBalance.test.tsx
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/useBalance.test.tsx
@@ -141,6 +141,10 @@ describe.sequential('useBalance', () => {
 });
 
 describe.sequential('ERC20 Balance', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('getter returns ERC20 balance for valid tuple (walletAddress, chainId)', async () => {
     const getBalanceSpy = vi
       .spyOn(provider, 'getBalance')

--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/useSelectedTokenBalances.test.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/useSelectedTokenBalances.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { BigNumber, constants } from 'ethers';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getProviderForChainId } from '@/token-bridge-sdk/utils';
 
@@ -14,6 +14,16 @@ import { useSelectedToken } from '../useSelectedToken';
 type BridgeToken = NonNullable<ReturnType<typeof useSelectedToken>[0]>;
 const Erc20Type = 'ERC20' as BridgeToken['type'];
 
+const defaultSelectedToken = {
+  type: Erc20Type,
+  decimals: 18,
+  name: 'random',
+  symbol: 'RAND',
+  address: '0x123',
+  l2Address: '0x234',
+  listIds: new Set('1'),
+};
+
 vi.mock('../useNetworks', () => ({
   useNetworks: vi.fn(),
 }));
@@ -23,18 +33,7 @@ vi.mock('../useBalances', () => ({
 }));
 
 vi.mock('../useSelectedToken', () => ({
-  useSelectedToken: vi.fn().mockReturnValue([
-    {
-      type: 'ERC20',
-      decimals: 18,
-      name: 'random',
-      symbol: 'RAND',
-      address: '0x123',
-      l2Address: '0x234',
-      listIds: new Set('1'),
-    },
-    vi.fn(),
-  ]),
+  useSelectedToken: vi.fn(),
 }));
 
 vi.mock('wagmi', async () => ({
@@ -48,6 +47,12 @@ describe('useSelectedTokenBalances', () => {
   const mockedUseNetworks = vi.mocked(useNetworks);
   const mockedUseBalances = vi.mocked(useBalances);
   const mockedUseSelectedToken = vi.mocked(useSelectedToken);
+
+  beforeEach(() => {
+    // Reset to the default selected token before each test so leftover async
+    // re-renders (SWR) from a previous test can't leak into this one.
+    mockedUseSelectedToken.mockReturnValue([{ ...defaultSelectedToken }, vi.fn()]);
+  });
 
   beforeAll(() => {
     mockedUseBalances.mockReturnValue({
@@ -102,7 +107,7 @@ describe('useSelectedTokenBalances', () => {
   });
 
   it('should return ERC20 parent balance as source balance and zero as destination balance when source chain is Sepolia and destination chain is Arbitrum Sepolia, and selected token address on Sepolia is 0x222 but without child chain address (unbridged token)', () => {
-    mockedUseSelectedToken.mockReturnValueOnce([
+    mockedUseSelectedToken.mockReturnValue([
       {
         type: Erc20Type,
         decimals: 18,
@@ -132,7 +137,7 @@ describe('useSelectedTokenBalances', () => {
   });
 
   it('should return zero as source balance and ERC20 parent balance as destination balance when source chain is Arbitrum Sepolia and destination chain is Sepolia, and selected token address on Sepolia is 0x222 but without child chain address (unbridged token)', () => {
-    mockedUseSelectedToken.mockReturnValueOnce([
+    mockedUseSelectedToken.mockReturnValue([
       {
         type: Erc20Type,
         decimals: 18,
@@ -162,7 +167,7 @@ describe('useSelectedTokenBalances', () => {
   });
 
   it('should return null as source balance and null as destination balance when source chain is Sepolia and destination chain is Arbitrum Sepolia, and selected token is null', () => {
-    mockedUseSelectedToken.mockReturnValueOnce([null, vi.fn()]);
+    mockedUseSelectedToken.mockReturnValue([null, vi.fn()]);
 
     mockedUseNetworks.mockReturnValue([
       {
@@ -182,7 +187,7 @@ describe('useSelectedTokenBalances', () => {
   });
 
   it('should return null as source balance and null as destination balance when source chain is Arbitrum Sepolia and destination chain is Sepolia, and selected token is null', () => {
-    mockedUseSelectedToken.mockReturnValueOnce([null, vi.fn()]);
+    mockedUseSelectedToken.mockReturnValue([null, vi.fn()]);
 
     mockedUseNetworks.mockReturnValue([
       {

--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/useSelectedTokenBalances.test.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/useSelectedTokenBalances.test.ts
@@ -21,7 +21,7 @@ const defaultSelectedToken = {
   symbol: 'RAND',
   address: '0x123',
   l2Address: '0x234',
-  listIds: new Set('1'),
+  listIds: new Set(['1']),
 };
 
 vi.mock('../useNetworks', () => ({


### PR DESCRIPTION
The latest vitest bump caused our unit tests to fail on ci. This PR fixes them.

---

Make the balance hook test suites deterministic under vitest 4, where SWR-driven async re-renders fire after a test completes and bleed mock state into the next test.

useSelectedTokenBalances.test.ts:
- Replace the one-shot useSelectedToken mockReturnValueOnce calls with mockReturnValue so the value applies to every render in a test, including the stray async re-renders that previously consumed the one-shot queue and broke the final "selected token is null" case.
- Add a beforeEach that resets useSelectedToken to a shared defaultSelectedToken constant, removing cross-test leakage.
- Move the default token out of the vi.mock factory into a reusable top-level constant.

useBalance.test.tsx:
- Add a beforeEach(vi.restoreAllMocks) to the "ERC20 Balance" suite so spies do not leak in from the preceding suite.
