### PR TITLE
feat(earn): add API key auth

### DIFF
--- a/packages/app/.env.sample
+++ b/packages/app/.env.sample
@@ -98,6 +98,12 @@ NEXT_PUBLIC_SHOW_CLASSIC_DEPOSITS=false
 
 VAULTS_FYI_API_KEY=
 
+# Optional allowlist that gates the Earn API (/api/onchain-actions/v1/earn/*).
+# Comma-separated keys handed out to whitelisted developers. When unset, the
+# Earn API is open (first-party UI behaviour); when set, external callers must
+# send "Authorization: Bearer <key>" or "x-api-key: <key>".
+EARN_API_KEYS=
+
 NEXT_PUBLIC_FEATURE_FLAG_EARN=false
 
 # ----- Indexer -----

--- a/packages/app/src/app/api/onchain-actions/v1/earn/adapters/VaultsAdapter.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/adapters/VaultsAdapter.ts
@@ -1,5 +1,8 @@
-import { type DetailedVault, OpportunityCategory } from '@/app-types/earn/vaults';
-import { ChainId } from '@/bridge/types/ChainId';
+import {
+  type DetailedVault,
+  OpportunityCategory,
+  type VaultsSdkInstance,
+} from '@/app-types/earn/vaults';
 
 import { resolveAdapterWindow } from '../lib/historicalWindow';
 import { parseOptionalNumber, parseOptionalPercentage } from '../lib/metricParsers';
@@ -8,6 +11,7 @@ import { DEFAULT_ALLOWED_ASSETS, vaultsSdk } from '../lib/vaultsSdk';
 import { fetchAlignedPriceLookup } from '../lib/zerionService';
 import {
   AvailableActions,
+  DEFAULT_EARN_CHAIN_ID,
   type EarnChainId,
   type EarnTransactionAction,
   HISTORICAL_VENDOR_TTL_SECONDS,
@@ -29,10 +33,12 @@ import {
   VaultsAction,
   Vendor,
   VendorAdapter,
-  getEarnNetworkFromChainId,
 } from '../types';
 
-export type VaultsNetwork = 'mainnet' | 'arbitrum';
+// vaults.fyi accepts CAIP-2 network identifiers (`eip155:<chainId>`) in addition
+// to its named networks, so we forward any EVM chain id as CAIP. This is the
+// exact union the SDK expects for `network`/`allowedNetworks` params.
+type VaultsNetwork = NonNullable<Parameters<VaultsSdkInstance['getVault']>[0]['path']>['network'];
 
 export type VaultsProtocol = 'aave' | 'compound' | 'fluid' | 'morpho';
 
@@ -59,18 +65,8 @@ export class VaultsAdapter implements VendorAdapter {
   vendor = Vendor.Vaults;
 
   private toVaultsNetwork(chainId: EarnChainId): VaultsNetwork {
-    return getEarnNetworkFromChainId(chainId) as VaultsNetwork;
-  }
-
-  private toEarnChainId(networkName: string | undefined): EarnChainId {
-    const normalizedNetwork = networkName?.trim().toLowerCase();
-    if (normalizedNetwork === 'mainnet' || normalizedNetwork === 'ethereum') {
-      return ChainId.Ethereum;
-    }
-    if (normalizedNetwork === 'arbitrum' || normalizedNetwork === 'arbitrum one') {
-      return ChainId.ArbitrumOne;
-    }
-    throw new Error(`Unsupported vault network: ${networkName ?? 'undefined'}`);
+    // CAIP-2 lets vaults.fyi resolve any EVM chain without a name mapping.
+    return `eip155:${chainId}` as VaultsNetwork;
   }
 
   private normalizeUsdValue(rawValue: string | undefined): string {
@@ -85,7 +81,7 @@ export class VaultsAdapter implements VendorAdapter {
     const network = filters.chainId ? this.toVaultsNetwork(filters.chainId) : undefined;
     const response = await vaultsSdk.getAllVaults({
       query: {
-        allowedNetworks: network ? ([network] as VaultsNetwork[]) : undefined,
+        allowedNetworks: network ? [network] : undefined,
         allowedProtocols: ['aave', 'compound', 'fluid', 'morpho'] satisfies VaultsProtocol[],
         onlyTransactional: true,
         minTvl: filters.minTvl,
@@ -653,7 +649,9 @@ export class VaultsAdapter implements VendorAdapter {
       : undefined;
     const tvlUsd = parseOptionalNumber(vault.tvl?.usd);
     const networkName = vault.network?.name || '';
-    const chainId = this.toEarnChainId(vault.network?.name);
+    // vaults.fyi returns the numeric chain id directly, so any EVM chain is
+    // represented faithfully (no name→id mapping needed).
+    const chainId: EarnChainId = vault.network?.chainId ?? DEFAULT_EARN_CHAIN_ID;
     const protocolName = vault.protocol?.name || '';
 
     const addressLower = vault.address.toLowerCase();

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/apiKeyAuth.test.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/apiKeyAuth.test.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { requireEarnApiKey } from './apiKeyAuth';
+
+const ORIGINAL_KEYS = process.env.EARN_API_KEYS;
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request('https://example.com/api/onchain-actions/v1/earn/opportunities', { headers });
+}
+
+describe('requireEarnApiKey', () => {
+  beforeEach(() => {
+    process.env.EARN_API_KEYS = 'key_alice, key_bob';
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_KEYS === undefined) {
+      delete process.env.EARN_API_KEYS;
+    } else {
+      process.env.EARN_API_KEYS = ORIGINAL_KEYS;
+    }
+  });
+
+  it('is a no-op when EARN_API_KEYS is unset (auth disabled)', () => {
+    delete process.env.EARN_API_KEYS;
+    const result = requireEarnApiKey(makeRequest());
+    expect(result).not.toBeInstanceOf(NextResponse);
+    expect(result).toEqual({ key: null });
+  });
+
+  it('allows same-origin requests through without a key', () => {
+    const result = requireEarnApiKey(makeRequest({ 'sec-fetch-site': 'same-origin' }));
+    expect(result).toEqual({ key: null });
+  });
+
+  it('rejects external requests with no key (401 MISSING_API_KEY)', async () => {
+    const result = requireEarnApiKey(makeRequest());
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ code: 'MISSING_API_KEY' });
+  });
+
+  it('rejects an unknown key (401 INVALID_API_KEY)', async () => {
+    const result = requireEarnApiKey(makeRequest({ authorization: 'Bearer nope' }));
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ code: 'INVALID_API_KEY' });
+  });
+
+  it('accepts a valid key via Authorization: Bearer and returns it', () => {
+    const result = requireEarnApiKey(makeRequest({ authorization: 'Bearer key_alice' }));
+    expect(result).toEqual({ key: 'key_alice' });
+  });
+
+  it('accepts a valid key via x-api-key header', () => {
+    const result = requireEarnApiKey(makeRequest({ 'x-api-key': 'key_bob' }));
+    expect(result).toEqual({ key: 'key_bob' });
+  });
+});

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/apiKeyAuth.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/apiKeyAuth.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from 'next/server';
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Simple, opt-in API-key gate for the Earn API.
+ *
+ * Intended for preview/internal deployments where the Earn endpoints are shared
+ * with a known set of whitelisted developers who integrate them into their own
+ * workflows (server-to-server). It is bearer-token auth — anyone holding a key
+ * can call the API — which is appropriate for trusted internal/partner access.
+ *
+ * Behaviour:
+ * - Keys are read from the `EARN_API_KEYS` env var (comma-separated allowlist),
+ *   so adding/revoking a developer is a one-line env change + redeploy.
+ * - When `EARN_API_KEYS` is unset (e.g. production, where the first-party UI
+ *   consumes these routes), the gate is a no-op and behaviour is unchanged.
+ * - Same-origin browser requests (the deployment's own UI) are allowed through
+ *   without a key via fetch-metadata, so the preview site keeps working.
+ * - External callers must present the key as `Authorization: Bearer <key>` or
+ *   `x-api-key: <key>`.
+ */
+
+const AUTHORIZATION_BEARER = /^Bearer\s+(.+)$/i;
+
+function getConfiguredKeys(): string[] {
+  return (process.env.EARN_API_KEYS ?? '')
+    .split(',')
+    .map((key) => key.trim())
+    .filter((key) => key.length > 0);
+}
+
+function extractPresentedKey(request: Request): string | null {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader) {
+    const match = AUTHORIZATION_BEARER.exec(authHeader.trim());
+    if (match?.[1]) {
+      return match[1].trim();
+    }
+  }
+
+  const apiKeyHeader = request.headers.get('x-api-key');
+  return apiKeyHeader?.trim() || null;
+}
+
+// Browsers attach `Sec-Fetch-Site` on requests they originate; the deployment's
+// own UI sends `same-origin`/`same-site`. External server-to-server callers
+// don't send it, so they fall through to the key check.
+function isSameOriginRequest(request: Request): boolean {
+  const fetchSite = request.headers.get('sec-fetch-site');
+  return fetchSite === 'same-origin' || fetchSite === 'same-site';
+}
+
+// Hash both inputs to a fixed-length digest so the constant-time comparison
+// doesn't leak key length, then compare without short-circuiting.
+function keysMatch(expected: string, presented: string): boolean {
+  const expectedHash = createHash('sha256').update(expected).digest();
+  const presentedHash = createHash('sha256').update(presented).digest();
+  return timingSafeEqual(expectedHash, presentedHash);
+}
+
+function unauthorized(message: string, code: string): NextResponse {
+  return NextResponse.json(
+    { message, code },
+    { status: 401, headers: { 'Cache-Control': 'private, no-store' } },
+  );
+}
+
+/**
+ * Returns `{ key }` when the request is allowed (the matched key, usable as a
+ * per-developer rate-limit bucket; `null` when auth is disabled or the caller
+ * is same-origin), or a `401` `NextResponse` when it must be rejected.
+ */
+export function requireEarnApiKey(request: Request): { key: string | null } | NextResponse {
+  const configuredKeys = getConfiguredKeys();
+
+  // Auth is opt-in: no keys configured → access unchanged.
+  if (configuredKeys.length === 0) {
+    return { key: null };
+  }
+
+  // Let the deployment's own UI through without shipping a key to the browser.
+  if (isSameOriginRequest(request)) {
+    return { key: null };
+  }
+
+  const presented = extractPresentedKey(request);
+  if (!presented) {
+    return unauthorized(
+      'Missing API key. Provide an "Authorization: Bearer <key>" or "x-api-key" header.',
+      'MISSING_API_KEY',
+    );
+  }
+
+  const matched = configuredKeys.find((key) => keysMatch(key, presented));
+  if (!matched) {
+    return unauthorized('Invalid API key.', 'INVALID_API_KEY');
+  }
+
+  return { key: matched };
+}

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/apiKeyAuth.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/apiKeyAuth.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { createHash, timingSafeEqual } from 'node:crypto';
+import { timingSafeEqual } from 'node:crypto';
 
 /**
  * Simple, opt-in API-key gate for the Earn API.
@@ -50,12 +50,18 @@ function isSameOriginRequest(request: Request): boolean {
   return fetchSite === 'same-origin' || fetchSite === 'same-site';
 }
 
-// Hash both inputs to a fixed-length digest so the constant-time comparison
-// doesn't leak key length, then compare without short-circuiting.
+// Constant-time comparison of the raw bytes. Keys are high-entropy random
+// tokens (not user passwords), so a slow KDF isn't warranted; the only thing
+// that matters is not short-circuiting on the first differing byte. Lengths
+// must match before `timingSafeEqual` (it throws on differing lengths), and a
+// length mismatch on a random token leaks nothing useful.
 function keysMatch(expected: string, presented: string): boolean {
-  const expectedHash = createHash('sha256').update(expected).digest();
-  const presentedHash = createHash('sha256').update(presented).digest();
-  return timingSafeEqual(expectedHash, presentedHash);
+  const expectedBytes = Buffer.from(expected, 'utf8');
+  const presentedBytes = Buffer.from(presented, 'utf8');
+  if (expectedBytes.length !== presentedBytes.length) {
+    return false;
+  }
+  return timingSafeEqual(expectedBytes, presentedBytes);
 }
 
 function unauthorized(message: string, code: string): NextResponse {

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/validation.test.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/validation.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { OpportunityCategory } from '@/app-types/earn/vaults';
+
 import {
   ValidationError,
   assertAddress,
@@ -10,10 +12,13 @@ import {
   assertPlainObject,
   assertPositiveNumberString,
   assertString,
+  parseChainIdForCategory,
   parseEarnChainId,
+  parseEvmChainId,
   parseHistoricalRange,
   parseOpportunityCategory,
   parseOptionalAssetSymbol,
+  parseOptionalChainIdForCategory,
   parseOptionalEarnChainId,
   parseOptionalNumber,
   parseOptionalOpportunityCategory,
@@ -97,6 +102,65 @@ describe('parseOptionalEarnChainId', () => {
 
   it('throws for invalid non-empty value', () => {
     expect(() => parseOptionalEarnChainId('999')).toThrow(ValidationError);
+  });
+});
+
+describe('parseEvmChainId', () => {
+  it('accepts any positive integer EVM chain id', () => {
+    expect(parseEvmChainId('1')).toBe(1);
+    expect(parseEvmChainId('8453')).toBe(8453); // Base
+    expect(parseEvmChainId('137')).toBe(137); // Polygon
+    expect(parseEvmChainId('80094')).toBe(80094); // Berachain
+  });
+
+  it('throws MISSING_CHAIN_ID for null or empty', () => {
+    expect(() => parseEvmChainId(null)).toThrow('chainId is required');
+    expect(() => parseEvmChainId('')).toThrow(ValidationError);
+  });
+
+  it('throws INVALID_CHAIN_ID for non-positive or non-integer values', () => {
+    expect(() => parseEvmChainId('0')).toThrow(ValidationError);
+    expect(() => parseEvmChainId('-1')).toThrow(ValidationError);
+    expect(() => parseEvmChainId('1.5')).toThrow(ValidationError);
+    expect(() => parseEvmChainId('abc')).toThrow(ValidationError);
+  });
+});
+
+describe('parseChainIdForCategory', () => {
+  it('accepts any EVM chain id for Lend (Vaults)', () => {
+    expect(parseChainIdForCategory('8453', OpportunityCategory.Lend)).toBe(8453);
+    expect(parseChainIdForCategory('137', OpportunityCategory.Lend)).toBe(137);
+  });
+
+  it('treats a missing category as permissive (aggregate includes Vaults)', () => {
+    expect(parseChainIdForCategory('8453')).toBe(8453);
+  });
+
+  it('restricts non-vault categories to the Arbitrum/Ethereum allowlist', () => {
+    expect(parseChainIdForCategory('42161', OpportunityCategory.FixedYield)).toBe(42161);
+    expect(() => parseChainIdForCategory('8453', OpportunityCategory.FixedYield)).toThrow(
+      ValidationError,
+    );
+    expect(() => parseChainIdForCategory('8453', OpportunityCategory.LiquidStaking)).toThrow(
+      ValidationError,
+    );
+  });
+});
+
+describe('parseOptionalChainIdForCategory', () => {
+  it('returns undefined for null or empty', () => {
+    expect(parseOptionalChainIdForCategory(null, OpportunityCategory.Lend)).toBeUndefined();
+    expect(parseOptionalChainIdForCategory('', OpportunityCategory.Lend)).toBeUndefined();
+  });
+
+  it('parses any EVM chain id for Lend', () => {
+    expect(parseOptionalChainIdForCategory('8453', OpportunityCategory.Lend)).toBe(8453);
+  });
+
+  it('restricts non-vault categories', () => {
+    expect(() => parseOptionalChainIdForCategory('8453', OpportunityCategory.FixedYield)).toThrow(
+      ValidationError,
+    );
   });
 });
 

--- a/packages/app/src/app/api/onchain-actions/v1/earn/lib/validation.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/lib/validation.ts
@@ -1,13 +1,14 @@
 import { isAddress } from 'viem';
 import { z } from 'zod';
 
-import { OPPORTUNITY_CATEGORIES, type OpportunityCategory } from '@/app-types/earn/vaults';
+import { OPPORTUNITY_CATEGORIES, OpportunityCategory } from '@/app-types/earn/vaults';
 
 import {
   ALLOWED_HISTORICAL_RANGES,
   EARN_CHAIN_IDS,
   type EarnChainId,
   type HistoricalTimeRange,
+  type RestrictedEarnChainId,
 } from '../types';
 
 export class ValidationError extends Error {
@@ -38,9 +39,22 @@ const opportunityCategorySchema = z
 const earnChainIdSchema = z.coerce
   .number()
   .int()
-  .refine((value): value is EarnChainId => EARN_CHAIN_IDS.includes(value as EarnChainId), {
-    message: `Must be one of: ${EARN_CHAIN_IDS.join(', ')}`,
-  })
+  .refine(
+    (value): value is RestrictedEarnChainId =>
+      EARN_CHAIN_IDS.includes(value as RestrictedEarnChainId),
+    {
+      message: `Must be one of: ${EARN_CHAIN_IDS.join(', ')}`,
+    },
+  )
+  .transform((value) => value as EarnChainId);
+
+// Vaults (Lend) opportunities exist on any EVM chain (forwarded to vaults.fyi as
+// a CAIP-2 `eip155:<chainId>` identifier), so we accept any positive-integer
+// chain id rather than the restricted Arbitrum/Ethereum allowlist.
+const evmChainIdSchema = z.coerce
+  .number()
+  .int()
+  .positive()
   .transform((value) => value as EarnChainId);
 
 const historicalRangeSchema = z
@@ -131,6 +145,48 @@ export function parseOptionalEarnChainId(rawValue: string | null): EarnChainId |
     return undefined;
   }
   return parseEarnChainId(rawValue);
+}
+
+export function parseEvmChainId(rawValue: string | null): EarnChainId {
+  const normalized = normalizeQueryValue(rawValue);
+  if (!normalized) {
+    throw new ValidationError('MISSING_CHAIN_ID', 'chainId is required');
+  }
+
+  const parsed = evmChainIdSchema.safeParse(normalized);
+  if (!parsed.success) {
+    throw new ValidationError(
+      'INVALID_CHAIN_ID',
+      'chainId must be a positive integer EVM chain id',
+    );
+  }
+
+  return parsed.data;
+}
+
+// Vaults (Lend) is available on any EVM chain; non-vault vendors are restricted to
+// the Arbitrum/Ethereum allowlist (and guard their supported chains at runtime).
+// A missing category (the aggregate endpoints) includes Vaults, so it is treated
+// as permissive.
+function isAllEvmChainCategory(category?: OpportunityCategory): boolean {
+  return category === undefined || category === OpportunityCategory.Lend;
+}
+
+export function parseChainIdForCategory(
+  rawValue: string | null,
+  category?: OpportunityCategory,
+): EarnChainId {
+  return isAllEvmChainCategory(category) ? parseEvmChainId(rawValue) : parseEarnChainId(rawValue);
+}
+
+export function parseOptionalChainIdForCategory(
+  rawValue: string | null,
+  category?: OpportunityCategory,
+): EarnChainId | undefined {
+  if (!normalizeQueryValue(rawValue)) {
+    return undefined;
+  }
+  return parseChainIdForCategory(rawValue, category);
 }
 
 export function assertAddress(value: string | null, field: string): string {

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunities/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunities/route.ts
@@ -2,11 +2,12 @@ import { unstable_noStore as noStore, unstable_cache } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '../CategoryRouter';
+import { requireEarnApiKey } from '../lib/apiKeyAuth';
 import { EARN_CACHE_SECONDS, earnCacheTags } from '../lib/cache';
 import { enforceEarnRateLimit } from '../lib/rateLimit';
 import {
   ValidationError,
-  parseOptionalEarnChainId,
+  parseOptionalChainIdForCategory,
   parseOptionalNumber,
   parseOptionalOpportunityCategory,
 } from '../lib/validation';
@@ -21,7 +22,10 @@ const router = new CategoryRouter();
 export async function GET(request: NextRequest) {
   noStore();
   try {
-    const rateLimited = await enforceEarnRateLimit(request);
+    const auth = requireEarnApiKey(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const rateLimited = await enforceEarnRateLimit(request, { key: auth.key });
     if (rateLimited) return rateLimited;
 
     const searchParams = request.nextUrl.searchParams;
@@ -44,7 +48,7 @@ export async function GET(request: NextRequest) {
     });
 
     const filters: OpportunityFilters = {
-      chainId: parseOptionalEarnChainId(searchParams.get('chainId')),
+      chainId: parseOptionalChainIdForCategory(searchParams.get('chainId'), category),
       minTvl,
       minApy,
       perPage: MAX_RESULTS,

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/available-actions/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/available-actions/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '../../../../CategoryRouter';
+import { requireEarnApiKey } from '../../../../lib/apiKeyAuth';
 import { enforceEarnRateLimit } from '../../../../lib/rateLimit';
 import {
   assertAddress,
-  parseEarnChainId,
+  parseChainIdForCategory,
   parseOpportunityCategory,
 } from '../../../../lib/validation';
 import { AvailableActions } from '../../../../types';
@@ -16,11 +17,14 @@ export async function GET(
   { params }: { params: Promise<{ category: string; id: string }> },
 ) {
   try {
+    const auth = requireEarnApiKey(request);
+    if (auth instanceof NextResponse) return auth;
+
     const searchParams = request.nextUrl.searchParams;
     const { category: rawCategory, id } = await params;
     const category = parseOpportunityCategory(rawCategory);
     const userAddress = assertAddress(searchParams.get('userAddress'), 'userAddress');
-    const chainId = parseEarnChainId(searchParams.get('chainId'));
+    const chainId = parseChainIdForCategory(searchParams.get('chainId'), category);
     const opportunityId = assertAddress(id, 'opportunityId');
 
     const rateLimited = await enforceEarnRateLimit(request, { key: userAddress });

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/historical-data/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/historical-data/route.ts
@@ -2,6 +2,7 @@ import { unstable_cache } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '@/earn-api/CategoryRouter';
+import { requireEarnApiKey } from '@/earn-api/lib/apiKeyAuth';
 import { EARN_CACHE_SECONDS, earnCacheTags } from '@/earn-api/lib/cache';
 import {
   alignTimestampToGranularity,
@@ -13,7 +14,7 @@ import { enforceEarnRateLimit } from '@/earn-api/lib/rateLimit';
 import {
   ValidationError,
   assertAddress,
-  parseEarnChainId,
+  parseChainIdForCategory,
   parseHistoricalRange,
   parseOpportunityCategory,
   parseOptionalAssetSymbol,
@@ -74,13 +75,16 @@ export async function GET(
   { params }: { params: Promise<{ category: string; id: string }> },
 ) {
   try {
-    const rateLimited = await enforceEarnRateLimit(request);
+    const auth = requireEarnApiKey(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const rateLimited = await enforceEarnRateLimit(request, { key: auth.key });
     if (rateLimited) return rateLimited;
 
     const searchParams = request.nextUrl.searchParams;
     const { category: rawCategory, id } = await params;
     const category = parseOpportunityCategory(rawCategory);
-    const chainId = parseEarnChainId(searchParams.get('chainId'));
+    const chainId = parseChainIdForCategory(searchParams.get('chainId'), category);
     const opportunityId = assertAddress(id, 'opportunityId');
     const range = parseHistoricalRange(searchParams.get('range'));
     const assetSymbol = parseOptionalAssetSymbol(searchParams.get('assetSymbol'));

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/route.ts
@@ -2,11 +2,12 @@ import { unstable_cache } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '@/earn-api/CategoryRouter';
+import { requireEarnApiKey } from '@/earn-api/lib/apiKeyAuth';
 import { EARN_CACHE_SECONDS, earnCacheTags } from '@/earn-api/lib/cache';
 import { enforceEarnRateLimit } from '@/earn-api/lib/rateLimit';
 import {
   assertAddress,
-  parseEarnChainId,
+  parseChainIdForCategory,
   parseOpportunityCategory,
 } from '@/earn-api/lib/validation';
 
@@ -17,13 +18,16 @@ export async function GET(
   { params }: { params: Promise<{ category: string; id: string }> },
 ) {
   try {
-    const rateLimited = await enforceEarnRateLimit(request);
+    const auth = requireEarnApiKey(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const rateLimited = await enforceEarnRateLimit(request, { key: auth.key });
     if (rateLimited) return rateLimited;
 
     const searchParams = request.nextUrl.searchParams;
     const { category: rawCategory, id } = await params;
     const category = parseOpportunityCategory(rawCategory);
-    const chainId = parseEarnChainId(searchParams.get('chainId'));
+    const chainId = parseChainIdForCategory(searchParams.get('chainId'), category);
     const opportunityId = assertAddress(id, 'opportunityId');
 
     const adapter = router.routeToAdapter(category);

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transaction-quote/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transaction-quote/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '../../../../CategoryRouter';
+import { requireEarnApiKey } from '../../../../lib/apiKeyAuth';
 import { enforceEarnRateLimit } from '../../../../lib/rateLimit';
 import {
   ValidationError,
@@ -11,7 +12,7 @@ import {
   assertOptionalString,
   assertPositiveNumberString,
   assertString,
-  parseEarnChainId,
+  parseChainIdForCategory,
   parseOpportunityCategory,
 } from '../../../../lib/validation';
 import { EARN_TRANSACTION_ACTIONS, type EarnTransactionAction } from '../../../../types';
@@ -98,7 +99,10 @@ async function getTransactionQuote(input: {
   if (rawChainId !== undefined && !Number.isInteger(rawChainId)) {
     throw new ValidationError('INVALID_CHAIN_ID', 'chainId must be an integer');
   }
-  const chainId = parseEarnChainId(rawChainId === undefined ? null : String(rawChainId));
+  const chainId = parseChainIdForCategory(
+    rawChainId === undefined ? null : String(rawChainId),
+    pathCategory,
+  );
   const opportunityId = assertAddress(input.opportunityId, 'opportunityId');
   const inputTokenAddress = assertOptionalAddress(rawInputTokenAddress, 'inputTokenAddress');
   const outputTokenAddress = assertOptionalAddress(rawOutputTokenAddress, 'outputTokenAddress');
@@ -135,6 +139,9 @@ export async function GET(
   { params }: { params: Promise<{ category: string; id: string }> },
 ) {
   try {
+    const auth = requireEarnApiKey(request);
+    if (auth instanceof NextResponse) return auth;
+
     const url = new URL(request.url);
     const rateLimited = await enforceEarnRateLimit(request, {
       key: url.searchParams.get('userAddress'),

--- a/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transactions/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/opportunity/[category]/[id]/transactions/route.ts
@@ -2,11 +2,12 @@ import { unstable_cache } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CategoryRouter } from '@/earn-api/CategoryRouter';
+import { requireEarnApiKey } from '@/earn-api/lib/apiKeyAuth';
 import { EARN_CACHE_SECONDS, earnCacheTags } from '@/earn-api/lib/cache';
 import { enforceEarnRateLimit } from '@/earn-api/lib/rateLimit';
 import {
   assertAddress,
-  parseEarnChainId,
+  parseChainIdForCategory,
   parseOpportunityCategory,
 } from '@/earn-api/lib/validation';
 import { TransactionHistoryResponse } from '@/earn-api/types';
@@ -18,10 +19,13 @@ export async function GET(
   { params }: { params: Promise<{ category: string; id: string }> },
 ) {
   try {
+    const auth = requireEarnApiKey(request);
+    if (auth instanceof NextResponse) return auth;
+
     const searchParams = request.nextUrl.searchParams;
     const { category: rawCategory, id } = await params;
     const category = parseOpportunityCategory(rawCategory);
-    const chainId = parseEarnChainId(searchParams.get('chainId'));
+    const chainId = parseChainIdForCategory(searchParams.get('chainId'), category);
     const opportunityId = assertAddress(id, 'opportunityId');
     const userAddress = assertAddress(searchParams.get('userAddress'), 'userAddress');
 

--- a/packages/app/src/app/api/onchain-actions/v1/earn/positions/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/positions/route.ts
@@ -4,11 +4,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { OpportunityCategory } from '@/app-types/earn/vaults';
 
 import { CategoryRouter } from '../CategoryRouter';
+import { requireEarnApiKey } from '../lib/apiKeyAuth';
 import { EARN_CACHE_SECONDS, earnCacheTags } from '../lib/cache';
 import { enforceEarnRateLimit } from '../lib/rateLimit';
 import {
   assertAddress,
-  parseEarnChainId,
+  parseChainIdForCategory,
   parseOptionalOpportunityCategory,
 } from '../lib/validation';
 import { StandardUserPosition, Vendor } from '../types';
@@ -120,10 +121,13 @@ function calculatePositionsSummary(positions: StandardUserPosition[]) {
 export async function GET(request: NextRequest) {
   noStore();
   try {
+    const auth = requireEarnApiKey(request);
+    if (auth instanceof NextResponse) return auth;
+
     const searchParams = request.nextUrl.searchParams;
     const userAddress = assertAddress(searchParams.get('userAddress'), 'userAddress');
     const category = parseOptionalOpportunityCategory(searchParams.get('category'));
-    const chainId = parseEarnChainId(searchParams.get('chainId'));
+    const chainId = parseChainIdForCategory(searchParams.get('chainId'), category);
 
     const rateLimited = await enforceEarnRateLimit(request, { key: userAddress });
     if (rateLimited) return rateLimited;

--- a/packages/app/src/app/api/onchain-actions/v1/earn/revalidate-action/route.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/revalidate-action/route.ts
@@ -2,6 +2,7 @@ import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 import { getAddress } from 'viem';
 
+import { requireEarnApiKey } from '@/earn-api/lib/apiKeyAuth';
 import { earnCacheTags } from '@/earn-api/lib/cache';
 import { enforceEarnRateLimit } from '@/earn-api/lib/rateLimit';
 import { createServerSidePublicClient } from '@/earn-api/lib/serverPublicClient';
@@ -28,6 +29,9 @@ function assertTxHash(value: unknown): `0x${string}` {
 
 export async function POST(request: NextRequest) {
   try {
+    const auth = requireEarnApiKey(request);
+    if (auth instanceof NextResponse) return auth;
+
     const body = assertPlainObject(await request.json());
     const chainId = parseEarnChainId(getRequestString(body, 'chainId'));
     const userAddress = assertAddress(getRequestString(body, 'userAddress'), 'userAddress');

--- a/packages/app/src/app/api/onchain-actions/v1/earn/types.ts
+++ b/packages/app/src/app/api/onchain-actions/v1/earn/types.ts
@@ -14,7 +14,14 @@ export enum Vendor {
 export const EARN_NETWORKS = ['arbitrum', 'mainnet'] as const;
 export type EarnNetwork = (typeof EARN_NETWORKS)[number];
 export const EARN_CHAIN_IDS = [ChainId.ArbitrumOne, ChainId.Ethereum] as const;
-export type EarnChainId = (typeof EARN_CHAIN_IDS)[number];
+/**
+ * Chains supported across every earn vendor (Pendle/LiFi). The Vaults (Lend)
+ * vendor is available on any EVM chain via vaults.fyi, so a vault opportunity's
+ * chainId is widened to `number`; non-vault vendors guard their own chains at
+ * runtime. See `parseChainIdForCategory` in `lib/validation`.
+ */
+export type RestrictedEarnChainId = (typeof EARN_CHAIN_IDS)[number];
+export type EarnChainId = number;
 export const DEFAULT_EARN_CHAIN_ID: EarnChainId = ChainId.ArbitrumOne;
 export const EARN_NETWORK_TO_CHAIN_ID: Record<EarnNetwork, EarnChainId> = {
   arbitrum: ChainId.ArbitrumOne,


### PR DESCRIPTION
Opening this as a draft so we get a preview deployment to share with a few devs who want to integrate the Earn APIs into their own workflows.

Two things here:

### 1. Vaults work on all EVM chains now

Previously vault opportunities were gated to Arbitrum + Ethereum. vaults.fyi actually supports ~15 chains and accepts CAIP-2 (`eip155:<chainId>`) identifiers, so I just forward whatever chain id comes in and read the chain id back from the vault's network metadata. No more hardcoded name→id mapping.

Chain validation is now per-category:
- Lend (vaults) accepts any EVM chain id — e.g. `?category=lend&chainId=8453` returns Base vaults.
- Fixed yield (Pendle) and liquid staking (LiFi) stay restricted to Arbitrum/Ethereum, since they don't support other chains.

### 2. Simple API key auth

Added an opt-in key check on all the Earn routes:
- Keys live in the `EARN_API_KEYS` env var (comma-separated). Adding/removing a dev is a one-line env change.
- Callers pass `Authorization: Bearer <key>` or `x-api-key: <key>`. Comparison is constant-time.
- Same-origin requests (our own UI) pass through without a key, so the site keeps working.
- If `EARN_API_KEYS` is unset (i.e. production), the check is a no-op — nothing changes there.
- The matched key also feeds the existing rate limiter so we get per-dev limits.

### Rollout
- Set `EARN_API_KEYS` on this preview and hand keys to the devs individually.
- Leave it unset on production.

### Notes
- `revalidate-action` stays on Arbitrum/Ethereum since it needs configured RPC clients.
- The same-origin bypass uses `Sec-Fetch-Site` — good enough to keep the public out while letting whitelisted devs in, but it's not a hard security boundary. Can tighten later (rotation/expiry/scopes) if we want.

### Tests
- tsc + eslint clean.
- Earn unit tests pass (110). Added coverage for the new chain-id validators and the auth helper.