### PR TITLE
perf(e2e): poll every 1s in E2E test environment

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistorySearchResults.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistorySearchResults.tsx
@@ -5,6 +5,7 @@ import { shallow } from 'zustand/shallow';
 
 import { useForceFetchReceived, useTransactionHistory } from '../../hooks/useTransactionHistory';
 import { MergedTransaction } from '../../state/app/state';
+import { e2ePollingInterval } from '../../util/CommonUtils';
 import { TransactionStatusInfo } from '../TransactionHistory/TransactionStatusInfo';
 import { TabButton } from '../common/Tab';
 import { TransactionHistoryDisclaimer } from './TransactionHistoryDisclaimer';
@@ -29,7 +30,7 @@ function useTransactionHistoryUpdater() {
   useEffect(() => {
     const interval = setInterval(() => {
       pendingTransactions.forEach(updatePendingTransaction);
-    }, 10_000);
+    }, e2ePollingInterval(10_000));
 
     return () => clearInterval(interval);
   }, [pendingTransactions, updatePendingTransaction]);

--- a/packages/arb-token-bridge-ui/src/components/syncers/useBalanceUpdater.tsx
+++ b/packages/arb-token-bridge-ui/src/components/syncers/useBalanceUpdater.tsx
@@ -6,6 +6,7 @@ import { useUpdateUsdcBalances } from '../../hooks/CCTP/useUpdateUsdcBalances';
 import { useBalances } from '../../hooks/useBalances';
 import { useSelectedToken } from '../../hooks/useSelectedToken';
 import { useAppState } from '../../state';
+import { e2ePollingInterval } from '../../util/CommonUtils';
 import { isTokenNativeUSDC } from '../../util/TokenUtils';
 
 // Updates all balances periodically
@@ -67,5 +68,5 @@ export function useBalanceUpdater() {
 
       latestTokenBridge?.current?.token?.updateTokenData(selectedToken.address);
     }
-  }, 10000);
+  }, e2ePollingInterval(10_000));
 }

--- a/packages/arb-token-bridge-ui/src/hooks/useBalance.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useBalance.ts
@@ -5,6 +5,7 @@ import useSWR, { Middleware, SWRHook, unstable_serialize, useSWRConfig } from 's
 
 import { getProviderForChainId } from '@/token-bridge-sdk/utils';
 
+import { e2ePollingInterval } from '../util/CommonUtils';
 import { captureSentryErrorWithExtraData } from '../util/SentryUtils';
 
 type Erc20Balances = {
@@ -110,7 +111,7 @@ const useBalance = ({ chainId, walletAddress }: UseBalanceProps) => {
       return _provider.getBalance(_walletAddress);
     },
     {
-      refreshInterval: 15_000,
+      refreshInterval: e2ePollingInterval(15_000),
       shouldRetryOnError: true,
       errorRetryCount: 2,
       errorRetryInterval: 3_000,

--- a/packages/arb-token-bridge-ui/src/hooks/useNativeCurrencyBalanceForChainId.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useNativeCurrencyBalanceForChainId.ts
@@ -4,6 +4,7 @@ import useSWR from 'swr';
 import { getProviderForChainId } from '@/token-bridge-sdk/utils';
 
 import { ether } from '../constants';
+import { e2ePollingInterval } from '../util/CommonUtils';
 import { fetchErc20Data } from '../util/TokenUtils';
 import { getChains } from '../util/networks';
 import { ChainWithRpcUrl } from '../util/networks';
@@ -55,7 +56,7 @@ export const useNativeCurrencyBalanceForChainId = (chainId: number, walletAddres
     walletAddress ? [chainId, walletAddress, 'native-balance-per-chainId'] : null,
     ([_chainId, _walletAddress]) => fetchNativeBalance(_chainId, _walletAddress),
     {
-      refreshInterval: 30_000,
+      refreshInterval: e2ePollingInterval(30_000),
       shouldRetryOnError: true,
       errorRetryCount: 2,
       errorRetryInterval: 3_000,

--- a/packages/arb-token-bridge-ui/src/util/CommonUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/CommonUtils.ts
@@ -36,6 +36,14 @@ export const isE2eTestingEnvironment =
   (typeof window !== 'undefined' && !!window.Cypress) ||
   process.env.NEXT_PUBLIC_IS_E2E_TEST === 'true';
 
+/**
+ * Returns an E2E-friendly polling interval.
+ * In E2E tests, always polls every 1s. Production behavior is unchanged.
+ */
+export function e2ePollingInterval(productionMs: number): number {
+  return isE2eTestingEnvironment ? 1_000 : productionMs;
+}
+
 export const isDevelopmentEnvironment = process.env.NODE_ENV === 'development';
 
 export const isProductionEnvironment = process.env.NODE_ENV === 'production';


### PR DESCRIPTION
## Summary

Adds an `e2ePollingInterval()` helper that returns a 1s polling interval when running under `isE2eTestingEnvironment`, and uses it for balance and transaction-history polling. This speeds up E2E tests (faster balance/tx-history refresh) without changing production behavior.

**Production intervals are unchanged** — the helper returns the original value (10s/15s/30s) whenever not in the E2E environment.

## Changes

- `CommonUtils.ts` — new `e2ePollingInterval(productionMs)` helper
- `useBalance.ts` (15s), `useNativeCurrencyBalanceForChainId.ts` (30s), `useBalanceUpdater.tsx` (10s), `TransactionHistorySearchResults.tsx` (10s) — use the helper

## Context

Split out of #357 (testnode service-container switch) to keep that PR CI/test-only. This is the production-touching half; the env guard makes it a no-op outside E2E.