### PR TITLE
fix(bridge): batch transfers updates

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/SourceNetworkBox.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/SourceNetworkBox.tsx
@@ -162,8 +162,6 @@ const Input1 = React.memo(() => {
 Input1.displayName = 'Input1';
 
 const Input2 = React.memo(() => {
-  const { showAmount2Input } = useAmount2InputVisibility();
-
   const [networks] = useNetworks();
   const { childChainProvider } = useNetworksRelationship(networks);
   const nativeCurrency = useNativeCurrency({ provider: childChainProvider });
@@ -172,7 +170,6 @@ const Input2 = React.memo(() => {
   const [{ amount2 }] = useArbQueryParams();
   const { setAmount2 } = useSetInputAmount();
   const { maxAmount2 } = useMaxAmount();
-  const isBatchTransferSupported = useIsBatchTransferSupported();
   const { errorMessages } = useTransferReadiness();
 
   const isMaxAmount2 = amount2 === AmountQueryParamEnum.MAX;
@@ -182,12 +179,6 @@ const Input2 = React.memo(() => {
       setAmount2(maxAmount2);
     }
   }, [amount2, maxAmount2, isMaxAmount2, setAmount2]);
-
-  useEffect(() => {
-    if (isBatchTransferSupported && Number(amount2) > 0) {
-      showAmount2Input();
-    }
-  }, [isBatchTransferSupported, amount2, showAmount2Input]);
 
   const amount2MaxButtonOnClick = useCallback(() => {
     if (typeof maxAmount2 !== 'undefined') {
@@ -266,11 +257,21 @@ export function SourceNetworkBox() {
   const openSourceNetworkSelectionDialog = () => {
     openDialog('source_network_selection');
   };
-  const { isAmount2InputVisible } = useAmount2InputVisibility();
+  const { isAmount2InputVisible, showAmount2Input } = useAmount2InputVisibility();
   const isBatchTransferSupported = useIsBatchTransferSupported();
   const isCctpTransfer = useIsCctpTransfer();
   const isOft = useIsOftV2Transfer();
   const { embedMode } = useMode();
+  const [{ amount2 }] = useArbQueryParams();
+
+  // Must run from an always-mounted component: the input only renders once it's open,
+  // so it can't open itself for an amount2 deep-link (incl. the "max" value).
+  const hasBatchAmount = amount2 === AmountQueryParamEnum.MAX || Number(amount2) > 0;
+  useEffect(() => {
+    if (isBatchTransferSupported && hasBatchAmount && !isAmount2InputVisible) {
+      showAmount2Input();
+    }
+  }, [isBatchTransferSupported, hasBatchAmount, isAmount2InputVisible, showAmount2Input]);
 
   return (
     <>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useRoutesUpdater.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useRoutesUpdater.ts
@@ -7,8 +7,9 @@ import { shallow } from 'zustand/shallow';
 import { Order } from '../../../app/api/crosschain-transfers/lifi';
 import { getTokenOverride } from '../../../app/api/crosschain-transfers/utils';
 import { isValidLifiTransfer } from '../../../app/api/crosschain-transfers/utils';
+import { useIsBatchTransferSupported } from '../../../hooks/TransferPanel/useIsBatchTransferSupported';
 import { ContractStorage, ERC20BridgeToken } from '../../../hooks/arbTokenBridge.types';
-import { useArbQueryParams } from '../../../hooks/useArbQueryParams';
+import { AmountQueryParamEnum, useArbQueryParams } from '../../../hooks/useArbQueryParams';
 import { useDestinationToken } from '../../../hooks/useDestinationToken';
 import { useLifiCrossTransfersRoute } from '../../../hooks/useLifiCrossTransferRoute';
 import { useNetworks } from '../../../hooks/useNetworks';
@@ -71,6 +72,7 @@ function getBestRouteForDefaultSelection(routes: RouteData[]): RouteType | undef
 interface GetEligibleRoutesParams {
   isOftV2Transfer: boolean;
   isNativeUsdcTransfer: boolean;
+  isBatchTransfer: boolean;
   amount: string;
   isDepositMode: boolean;
   sourceChainId: number;
@@ -83,6 +85,7 @@ interface GetEligibleRoutesParams {
 function getEligibleRoutes({
   isOftV2Transfer,
   isNativeUsdcTransfer,
+  isBatchTransfer,
   amount,
   isDepositMode,
   sourceChainId,
@@ -97,6 +100,12 @@ function getEligibleRoutes({
 
   if (Number(amount) === 0) {
     return [];
+  }
+
+  // Only the canonical route can carry the extra native amount (as the retryable's
+  // L2 callvalue), so skip LiFi/CCTP/OFT quotes for batches.
+  if (isBatchTransfer) {
+    return isArbitrumCanonicalTransfer ? ['arbitrum'] : [];
   }
 
   if (isOftV2Transfer) {
@@ -155,9 +164,13 @@ function getEligibleRoutes({
 export function useRoutesUpdater() {
   const [networks] = useNetworks();
   const { isDepositMode } = useNetworksRelationship(networks);
-  const [{ amount }] = useArbQueryParams();
+  const [{ amount, amount2 }] = useArbQueryParams();
   const isNativeUsdcTransfer = useIsCctpTransfer();
   const isOftV2Transfer = useIsOftV2Transfer();
+  const isBatchTransferSupported = useIsBatchTransferSupported();
+  // `amount2` can be the literal "max" deep-link value, which resolves to a positive amount.
+  const isBatchTransfer =
+    isBatchTransferSupported && (amount2 === AmountQueryParamEnum.MAX || Number(amount2) > 0);
   const [selectedToken] = useSelectedToken();
   const destinationToken = useDestinationToken();
   const tokensFromLists = useTokensFromLists();
@@ -187,6 +200,7 @@ export function useRoutesUpdater() {
       getEligibleRoutes({
         isOftV2Transfer,
         isNativeUsdcTransfer,
+        isBatchTransfer,
         amount,
         isDepositMode,
         sourceChainId: networks.sourceChain.id,
@@ -198,6 +212,7 @@ export function useRoutesUpdater() {
     [
       isOftV2Transfer,
       isNativeUsdcTransfer,
+      isBatchTransfer,
       amount,
       isDepositMode,
       networks.sourceChain.id,


### PR DESCRIPTION
Batch transfers (token + ETH in the same tx) were showing LiFi/Across/Mayan routes in the route list, but those only bridge the token and leave the ETH behind. The canonical Arbitrum route is the only one that can actually move both, since the extra ETH goes in as the retryable's L2 callvalue.

<img height="150" alt="image" src="https://github.com/user-attachments/assets/699c2fac-bd21-4606-ae79-a62b41937a7a" />


Couple of changes here:

- When amount2 > 0, only fetch and show the canonical route. We skip the LiFi/CCTP/OFT quotes entirely so you can't pick a route that drops the ETH leg.
- Auto-expand the second input when amount2 comes in from the URL. That effect was living inside Input2, which only renders once the input is already open, so it never fired for deep links / shared URLs.

