### PR TITLE
fix(monitoring): pin monitoring step to Node 22

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node and install dependencies
         uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 22
       - run: cd ./arbitrum-monitoring && yarn install
 
       - name: Load configuration

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -50,7 +50,7 @@ jobs:
           path: arbitrum-monitoring
 
       - name: Setup Node and install dependencies
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
       - run: cd ./arbitrum-monitoring && yarn install


### PR DESCRIPTION
The monitoring step used `node-version: latest`, which recently started resolving to Node 26.3.1 on the runners. On that version, every Notion API call in the retryable monitor fails with `ERR_STREAM_PREMATURE_CLOSE`, which crashes the Core run (Orbit is unaffected because it doesn't write to Notion).

The last green run was on Node 26.3.0 — the only thing that changed was the Node patch bump pulled in by `latest`.

Pinning the step to Node 22 fixes it. Verified with a manual run on this branch: the Core job is green again and fetches the Notion records as expected.

**Why 22 and not 26:** 22 is Active LTS and is already the project convention — it's what `.nvmrc` uses and what the other `setup-node` step in this same workflow pins. 26 is the current/bleeding-edge line, and floating on it (or pinning a specific patch like 26.3.0) is exactly what broke us. Pinning to 22 keeps the monitoring step consistent with the rest of the repo. We also generally shouldn't run CI on `latest`.

Also bumped this step's `setup-node` to `@v5` to match the other step in this file and the rest of the repo's workflows.