### PR TITLE
fix(deps): resolve npm audit advisories

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -113,6 +113,12 @@
     // https://github.com/advisories/GHSA-v6wh-96g9-6wx3
     // launch-editor leaks NTLMv2 hashes via unvalidated Windows UNC paths on the dev-server __open-in-editor endpoint (CVE-2026-53632)
     //
+    // https://github.com/advisories/GHSA-mx8g-39q3-5c79
+    // webpack-dev-server HMR WebSocket interception via permissive user proxies leaks credentials (CVE-2026-9595)
+    //
+    // https://github.com/advisories/GHSA-64mm-vxmg-q3vj
+    // http-proxy-middleware host-header-driven backend routing bypass via substring matching in router rules (CVE-2026-55602)
+    //
     // Reason to ignore: All from @synthetixio/synpress, an E2E test devDependency.
     // Each fix requires a major bump deep in the synpress chain that would risk
     // breaking E2E tooling. Not used in production builds or runtime code.
@@ -126,6 +132,8 @@
     "GHSA-79cf-xcqc-c78w",
     "GHSA-q8mj-m7cp-5q26",
     "GHSA-v6wh-96g9-6wx3",
+    "GHSA-mx8g-39q3-5c79",
+    "GHSA-64mm-vxmg-q3vj",
     //
     // https://github.com/advisories/GHSA-qjx8-664m-686j
     // js-cookie prototype hijack in assign() enables cookie-attribute injection (CVE-2026-46625)


### PR DESCRIPTION
Two new `audit-ci` advisories were failing CI. Both are dev-only and come in transitively through the `@synthetixio/synpress` E2E test chain, so they're added to the existing synpress allowlist block in `audit-ci.jsonc` with justifications.

| GHSA | Package | Severity | CVE |
|------|---------|----------|-----|
| GHSA-mx8g-39q3-5c79 | webpack-dev-server | moderate | CVE-2026-9595 |
| GHSA-64mm-vxmg-q3vj | http-proxy-middleware | moderate | CVE-2026-55602 |

Dependency chain: `arb-token-bridge-ui > @synthetixio/synpress > @cypress/webpack-dev-server > webpack-dev-server [> http-proxy-middleware]` — dev-only, not in production builds or runtime. Fixing would require a major bump deep in the synpress chain, matching the rationale already used for the other webpack-dev-server advisories in the same block.

`pnpm audit:ci` now exits 0.