### PR TITLE
fix(bridge): use keyed RPC for World Mobile Chain

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -61,6 +61,7 @@ const BATCH_FETCH_BLOCKS: { [key: number]: number } = {
   33139: 5_000_000, // ApeChain
   1628: 10_000, // T-REX
   228: 10_000, // Mind Network
+  869: 10_000, // World Mobile Chain
 };
 
 export type UseTransactionHistoryResult = {

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -20,6 +20,7 @@ import {
   defaultL3Network,
 } from './networksNitroTestnode';
 import { getOrbitChains, orbitChains } from './orbitChainsList';
+import { getAuthenticatedAlchemyRpcUrl } from './rpc/alchemy';
 import { getRpcUrl } from './rpc/getRpcUrl';
 
 /** The network that you reference when calling `block.number` in solidity */
@@ -504,7 +505,7 @@ export function mapCustomChainToNetworkData(chain: ChainWithRpcUrl) {
   // custom chain details need to be added to various objects to make it work with the UI
   //
   // add RPC
-  rpcURLs[chain.chainId] = chain.rpcUrl;
+  rpcURLs[chain.chainId] = getAuthenticatedAlchemyRpcUrl(chain.chainId, chain.rpcUrl);
   // explorer URL
   explorerUrls[chain.chainId] = chain.explorerUrl;
 }

--- a/packages/arb-token-bridge-ui/src/util/rpc/alchemy.ts
+++ b/packages/arb-token-bridge-ui/src/util/rpc/alchemy.ts
@@ -2,6 +2,22 @@ import { loadEnvironmentVariableWithFallback } from '..';
 import { ChainId } from '../../types/ChainId';
 import { ProductionChainId } from './getRpcUrl';
 
+// Orbit chains whitelisted to use our authenticated Alchemy RPC instead of their throttled public one.
+const authenticatedAlchemyOrbitRpcUrls: { [chainId: number]: string } = {
+  869: 'https://worldmobilechain-mainnet.g.alchemy.com/v2', // World Mobile Chain
+};
+
+export function getAuthenticatedAlchemyRpcUrl(chainId: number, fallbackRpcUrl: string): string {
+  const baseUrl = authenticatedAlchemyOrbitRpcUrls[chainId];
+  const alchemyKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY;
+
+  if (!baseUrl || !alchemyKey) {
+    return fallbackRpcUrl;
+  }
+
+  return `${baseUrl}/${alchemyKey}`;
+}
+
 export function getAlchemyKeyFromEnv(chainId: ProductionChainId): string {
   const defaultAlchemyKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY;
 

--- a/packages/arb-token-bridge-ui/src/util/rpc/alchemy.ts
+++ b/packages/arb-token-bridge-ui/src/util/rpc/alchemy.ts
@@ -9,9 +9,10 @@ const authenticatedAlchemyOrbitRpcUrls: { [chainId: number]: string } = {
 
 export function getAuthenticatedAlchemyRpcUrl(chainId: number, fallbackRpcUrl: string): string {
   const baseUrl = authenticatedAlchemyOrbitRpcUrls[chainId];
-  const alchemyKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY;
+  const alchemyKey = process.env.NEXT_PUBLIC_ALCHEMY_KEY?.trim();
 
-  if (!baseUrl || !alchemyKey) {
+  // only upgrade the throttled public Alchemy endpoint; leave any custom RPC alone
+  if (!baseUrl || !alchemyKey || !fallbackRpcUrl.includes('.g.alchemy.com/public')) {
     return fallbackRpcUrl;
   }
 


### PR DESCRIPTION
World Mobile Chain (`869`) shipped Alchemy's throttled `/public` RPC, which caps `eth_getLogs` at 100 blocks and rate-limits hard. With no special handling its transfers never loaded in tx history.

Whitelists WMC in `alchemy.ts` to use our authenticated `/v2/${key}` endpoint (now enabled on our Alchemy app); `mapCustomChainToNetworkData` resolves its RPC through that. Also gets a 10k tx-history block range like the other RaaS chains.

Test for address: `0x0118F25D462Cf3cc9f1f1A7698D8cDB55DBe4850`