### PR TITLE
feat(bridge): enhance OFT token detection

### DIFF
--- a/packages/app/src/app/api/layerzero-metadata/route.ts
+++ b/packages/app/src/app/api/layerzero-metadata/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/bridge/app/api/layerzero-metadata';

--- a/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
@@ -5,8 +5,6 @@ import { isRecord } from '../../util/isRecord';
 
 const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
 
-// LayerZero token/chain metadata changes rarely, so cache it for an hour to
-// avoid hammering the upstream API on every client request.
 const CACHE_SECONDS = 60 * 60;
 
 type TrimmedTokenMetadata = {
@@ -15,14 +13,12 @@ type TrimmedTokenMetadata = {
 };
 
 type TrimmedChainMetadata = {
-  chainDetails: { nativeChainId: unknown };
+  chainDetails: { nativeChainId: number };
   tokens: Record<string, TrimmedTokenMetadata>;
 };
 
-// The upstream payload is ~3.8MB; the client only needs each chain's
-// `nativeChainId` and, per token, its `type` and whether it is pegged. Trimming
-// here keeps the cached response small (well under the data cache size limit)
-// and avoids shipping the full payload to every client.
+// The upstream payload is ~3.8MB; keep only what the client needs so the cached
+// response stays under the data cache size limit and isn't shipped in full.
 function trimLayerZeroMetadata(metadata: unknown): Record<string, TrimmedChainMetadata> {
   const trimmed: Record<string, TrimmedChainMetadata> = {};
 
@@ -46,14 +42,19 @@ function trimLayerZeroMetadata(metadata: unknown): Record<string, TrimmedChainMe
         continue;
       }
 
-      trimmedTokens[tokenAddress] = {
+      // Lower-case the key so the client can look tokens up by address.
+      trimmedTokens[tokenAddress.toLowerCase()] = {
         type: tokenMetadata.type,
         peggedTo: Boolean(tokenMetadata.peggedTo),
       };
     }
 
+    // Coerce so the client's strict `=== chainId` holds even if upstream sends a
+    // numeric string; a non-numeric value becomes NaN and never matches.
+    const nativeChainId = Number(chainDetails.nativeChainId);
+
     trimmed[chainKey] = {
-      chainDetails: { nativeChainId: chainDetails.nativeChainId },
+      chainDetails: { nativeChainId },
       tokens: trimmedTokens,
     };
   }
@@ -61,9 +62,8 @@ function trimLayerZeroMetadata(metadata: unknown): Record<string, TrimmedChainMe
   return trimmed;
 }
 
-// Cache the trimmed metadata in the Next.js data cache so the upstream API is
-// hit at most once per `CACHE_SECONDS` across the whole deployment. A failed
-// fetch throws and is not cached, so the next request retries.
+// Cache in the data cache so upstream is hit at most once per `CACHE_SECONDS`
+// across the deployment. Failures throw (below) and aren't cached, so they retry.
 const getCachedLayerZeroMetadata = unstable_cache(
   async () => {
     const response = await fetch(LAYERZERO_METADATA_URL, { cache: 'no-store' });
@@ -74,10 +74,8 @@ const getCachedLayerZeroMetadata = unstable_cache(
 
     const trimmed = trimLayerZeroMetadata(await response.json());
 
-    // An empty result means the upstream payload was missing or in an
-    // unexpected shape. Throw so it isn't cached — otherwise a single bad
-    // response would disable native-OFT detection for the whole revalidate
-    // window. The next request then retries.
+    // Empty means a missing/unexpected payload — throw so it isn't cached for
+    // the whole revalidate window.
     if (Object.keys(trimmed).length === 0) {
       throw new Error('LayerZero metadata response was empty or malformed');
     }
@@ -89,9 +87,7 @@ const getCachedLayerZeroMetadata = unstable_cache(
 );
 
 export async function GET(): Promise<NextResponse> {
-  // Opt out of static rendering so the handler runs per request and the
-  // `unstable_cache` revalidation/retry above is the source of truth (matches
-  // the other unstable_cache-backed routes in this app).
+  // Opt out of static rendering so `unstable_cache` above stays the source of truth.
   noStore();
 
   try {

--- a/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
@@ -1,5 +1,7 @@
-import { unstable_cache } from 'next/cache';
+import { unstable_noStore as noStore, unstable_cache } from 'next/cache';
 import { NextResponse } from 'next/server';
+
+import { isRecord } from '../../util/isRecord';
 
 const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
 
@@ -16,10 +18,6 @@ type TrimmedChainMetadata = {
   chainDetails: { nativeChainId: unknown };
   tokens: Record<string, TrimmedTokenMetadata>;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
 
 // The upstream payload is ~3.8MB; the client only needs each chain's
 // `nativeChainId` and, per token, its `type` and whether it is pegged. Trimming
@@ -74,13 +72,28 @@ const getCachedLayerZeroMetadata = unstable_cache(
       throw new Error(`LayerZero metadata request failed with status ${response.status}`);
     }
 
-    return trimLayerZeroMetadata(await response.json());
+    const trimmed = trimLayerZeroMetadata(await response.json());
+
+    // An empty result means the upstream payload was missing or in an
+    // unexpected shape. Throw so it isn't cached — otherwise a single bad
+    // response would disable native-OFT detection for the whole revalidate
+    // window. The next request then retries.
+    if (Object.keys(trimmed).length === 0) {
+      throw new Error('LayerZero metadata response was empty or malformed');
+    }
+
+    return trimmed;
   },
   ['layerzero-metadata'],
   { revalidate: CACHE_SECONDS },
 );
 
 export async function GET(): Promise<NextResponse> {
+  // Opt out of static rendering so the handler runs per request and the
+  // `unstable_cache` revalidation/retry above is the source of truth (matches
+  // the other unstable_cache-backed routes in this app).
+  noStore();
+
   try {
     const metadata = await getCachedLayerZeroMetadata();
 

--- a/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
@@ -7,7 +7,6 @@ const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
 
 const CACHE_SECONDS = 60 * 60;
 
-// `peggedTo` links a representation token back to its native chain + address.
 type TrimmedTokenMetadata = {
   peggedTo?: { address: string; chainName: string };
 };

--- a/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
@@ -1,48 +1,66 @@
 import { unstable_noStore as noStore, unstable_cache } from 'next/cache';
 import { NextResponse } from 'next/server';
 
+import { ChainId } from '../../types/ChainId';
 import { isRecord } from '../../util';
 
 const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
 
 const CACHE_SECONDS = 60 * 60;
 
+// LayerZero's `nativeChainId` is not unique (e.g. both Aptos and Ethereum report
+// `1`), so we map each chain we bridge to its `chainKey` explicitly — dropping the
+// chains we don't care about and avoiding that ambiguity.
+const LZ_CHAIN_KEY_BY_CHAIN_ID: { chainId: number; chainKey: string }[] = [
+  { chainId: ChainId.Ethereum, chainKey: 'ethereum' },
+  { chainId: ChainId.Sepolia, chainKey: 'sepolia-testnet' },
+  { chainId: ChainId.ArbitrumOne, chainKey: 'arbitrum' },
+  { chainId: ChainId.ArbitrumNova, chainKey: 'nova' },
+  { chainId: ChainId.ArbitrumSepolia, chainKey: 'arbitrum-sepolia' },
+  { chainId: ChainId.Base, chainKey: 'base' },
+  { chainId: ChainId.BaseSepolia, chainKey: 'base-sepolia' },
+  { chainId: ChainId.ApeChain, chainKey: 'ape' },
+  { chainId: ChainId.RobinhoodChain, chainKey: 'robinhood' },
+  { chainId: ChainId.Superposition, chainKey: 'superposition' },
+  { chainId: 98866, chainKey: 'plumephoenix' }, // Plume
+  { chainId: 1625, chainKey: 'gravity' }, // Gravity Alpha
+  { chainId: 1380012617, chainKey: 'rarible' }, // RARI
+  { chainId: 41923, chainKey: 'edu' }, // Edu Chain
+  { chainId: 660279, chainKey: 'xai' }, // Xai
+  { chainId: 6985385, chainKey: 'humanity' }, // Humanity
+];
+
 type TrimmedTokenMetadata = {
   peggedTo?: { address: string; chainName: string };
 };
 
 type TrimmedChainMetadata = {
-  chainDetails: { nativeChainId: number };
+  chainKey: string;
   tokens: Record<string, TrimmedTokenMetadata>;
 };
 
-// The upstream payload is ~3.8MB; keep only what the client needs so the cached
-// response stays under the data cache size limit and isn't shipped in full.
-function trimLayerZeroMetadata(metadata: unknown): Record<string, TrimmedChainMetadata> {
-  const trimmed: Record<string, TrimmedChainMetadata> = {};
+// Reduce the ~3.8MB LayerZero payload to the chains we bridge, keyed by our chain id.
+export function trimLayerZeroMetadata(metadata: unknown): Record<number, TrimmedChainMetadata> {
+  const trimmed: Record<number, TrimmedChainMetadata> = {};
 
   if (!isRecord(metadata)) {
     return trimmed;
   }
 
-  for (const [chainKey, chainMetadata] of Object.entries(metadata)) {
-    if (!isRecord(chainMetadata)) {
+  for (const { chainId, chainKey } of LZ_CHAIN_KEY_BY_CHAIN_ID) {
+    const chainMetadata = metadata[chainKey];
+    if (!isRecord(chainMetadata) || !isRecord(chainMetadata.tokens)) {
       continue;
     }
 
-    const { chainDetails, tokens } = chainMetadata;
-    if (!isRecord(chainDetails) || !isRecord(tokens)) {
-      continue;
-    }
-
-    const trimmedTokens: Record<string, TrimmedTokenMetadata> = {};
-    for (const [tokenAddress, tokenMetadata] of Object.entries(tokens)) {
+    const tokens: Record<string, TrimmedTokenMetadata> = {};
+    for (const [tokenAddress, tokenMetadata] of Object.entries(chainMetadata.tokens)) {
       if (!isRecord(tokenMetadata)) {
         continue;
       }
 
       const { peggedTo } = tokenMetadata;
-      trimmedTokens[tokenAddress.toLowerCase()] =
+      tokens[tokenAddress.toLowerCase()] =
         isRecord(peggedTo) &&
         typeof peggedTo.address === 'string' &&
         typeof peggedTo.chainName === 'string'
@@ -50,12 +68,7 @@ function trimLayerZeroMetadata(metadata: unknown): Record<string, TrimmedChainMe
           : {};
     }
 
-    const nativeChainId = Number(chainDetails.nativeChainId);
-
-    trimmed[chainKey] = {
-      chainDetails: { nativeChainId },
-      tokens: trimmedTokens,
-    };
+    trimmed[chainId] = { chainKey, tokens };
   }
 
   return trimmed;

--- a/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
@@ -1,0 +1,96 @@
+import { unstable_cache } from 'next/cache';
+import { NextResponse } from 'next/server';
+
+const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
+
+// LayerZero token/chain metadata changes rarely, so cache it for an hour to
+// avoid hammering the upstream API on every client request.
+const CACHE_SECONDS = 60 * 60;
+
+type TrimmedTokenMetadata = {
+  type?: unknown;
+  peggedTo: boolean;
+};
+
+type TrimmedChainMetadata = {
+  chainDetails: { nativeChainId: unknown };
+  tokens: Record<string, TrimmedTokenMetadata>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+// The upstream payload is ~3.8MB; the client only needs each chain's
+// `nativeChainId` and, per token, its `type` and whether it is pegged. Trimming
+// here keeps the cached response small (well under the data cache size limit)
+// and avoids shipping the full payload to every client.
+function trimLayerZeroMetadata(metadata: unknown): Record<string, TrimmedChainMetadata> {
+  const trimmed: Record<string, TrimmedChainMetadata> = {};
+
+  if (!isRecord(metadata)) {
+    return trimmed;
+  }
+
+  for (const [chainKey, chainMetadata] of Object.entries(metadata)) {
+    if (!isRecord(chainMetadata)) {
+      continue;
+    }
+
+    const { chainDetails, tokens } = chainMetadata;
+    if (!isRecord(chainDetails) || !isRecord(tokens)) {
+      continue;
+    }
+
+    const trimmedTokens: Record<string, TrimmedTokenMetadata> = {};
+    for (const [tokenAddress, tokenMetadata] of Object.entries(tokens)) {
+      if (!isRecord(tokenMetadata)) {
+        continue;
+      }
+
+      trimmedTokens[tokenAddress] = {
+        type: tokenMetadata.type,
+        peggedTo: Boolean(tokenMetadata.peggedTo),
+      };
+    }
+
+    trimmed[chainKey] = {
+      chainDetails: { nativeChainId: chainDetails.nativeChainId },
+      tokens: trimmedTokens,
+    };
+  }
+
+  return trimmed;
+}
+
+// Cache the trimmed metadata in the Next.js data cache so the upstream API is
+// hit at most once per `CACHE_SECONDS` across the whole deployment. A failed
+// fetch throws and is not cached, so the next request retries.
+const getCachedLayerZeroMetadata = unstable_cache(
+  async () => {
+    const response = await fetch(LAYERZERO_METADATA_URL, { cache: 'no-store' });
+
+    if (!response.ok) {
+      throw new Error(`LayerZero metadata request failed with status ${response.status}`);
+    }
+
+    return trimLayerZeroMetadata(await response.json());
+  },
+  ['layerzero-metadata'],
+  { revalidate: CACHE_SECONDS },
+);
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const metadata = await getCachedLayerZeroMetadata();
+
+    return NextResponse.json(metadata, {
+      status: 200,
+      headers: {
+        'Cache-Control': `public, max-age=0, s-maxage=${CACHE_SECONDS}, stale-while-revalidate=${CACHE_SECONDS}`,
+      },
+    });
+  } catch {
+    return NextResponse.json(null, { status: 502 });
+  }
+}

--- a/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
@@ -1,6 +1,8 @@
 import { unstable_noStore as noStore, unstable_cache } from 'next/cache';
 import { NextResponse } from 'next/server';
 
+import { isRecord } from '../../util';
+
 const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
 
 const CACHE_SECONDS = 60 * 60;
@@ -14,10 +16,6 @@ type TrimmedChainMetadata = {
   chainDetails: { nativeChainId: number };
   tokens: Record<string, TrimmedTokenMetadata>;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
 
 // The upstream payload is ~3.8MB; keep only what the client needs so the cached
 // response stays under the data cache size limit and isn't shipped in full.

--- a/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
@@ -1,8 +1,6 @@
 import { unstable_noStore as noStore, unstable_cache } from 'next/cache';
 import { NextResponse } from 'next/server';
 
-import { isRecord } from '../../util/isRecord';
-
 const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
 
 const CACHE_SECONDS = 60 * 60;
@@ -16,6 +14,10 @@ type TrimmedChainMetadata = {
   chainDetails: { nativeChainId: number };
   tokens: Record<string, TrimmedTokenMetadata>;
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
 
 // The upstream payload is ~3.8MB; keep only what the client needs so the cached
 // response stays under the data cache size limit and isn't shipped in full.

--- a/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
@@ -42,15 +42,12 @@ function trimLayerZeroMetadata(metadata: unknown): Record<string, TrimmedChainMe
         continue;
       }
 
-      // Lower-case the key so the client can look tokens up by address.
       trimmedTokens[tokenAddress.toLowerCase()] = {
         type: tokenMetadata.type,
         peggedTo: Boolean(tokenMetadata.peggedTo),
       };
     }
 
-    // Coerce so the client's strict `=== chainId` holds even if upstream sends a
-    // numeric string; a non-numeric value becomes NaN and never matches.
     const nativeChainId = Number(chainDetails.nativeChainId);
 
     trimmed[chainKey] = {

--- a/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
@@ -7,9 +7,9 @@ const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
 
 const CACHE_SECONDS = 60 * 60;
 
+// `peggedTo` links a representation token back to its native chain + address.
 type TrimmedTokenMetadata = {
-  type?: unknown;
-  peggedTo: boolean;
+  peggedTo?: { address: string; chainName: string };
 };
 
 type TrimmedChainMetadata = {
@@ -42,10 +42,13 @@ function trimLayerZeroMetadata(metadata: unknown): Record<string, TrimmedChainMe
         continue;
       }
 
-      trimmedTokens[tokenAddress.toLowerCase()] = {
-        type: tokenMetadata.type,
-        peggedTo: Boolean(tokenMetadata.peggedTo),
-      };
+      const { peggedTo } = tokenMetadata;
+      trimmedTokens[tokenAddress.toLowerCase()] =
+        isRecord(peggedTo) &&
+        typeof peggedTo.address === 'string' &&
+        typeof peggedTo.chainName === 'string'
+          ? { peggedTo: { address: peggedTo.address.toLowerCase(), chainName: peggedTo.chainName } }
+          : {};
     }
 
     const nativeChainId = Number(chainDetails.nativeChainId);

--- a/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/layerzero-metadata.ts
@@ -30,7 +30,12 @@ const LZ_CHAIN_KEY_BY_CHAIN_ID: { chainId: number; chainKey: string }[] = [
   { chainId: 6985385, chainKey: 'humanity' }, // Humanity
 ];
 
+// LayerZero `type` values that denote an actual OFT deployment, as opposed to a
+// plain ERC20/NativeToken canonical representation that LayerZero merely tracks.
+const OFT_TOKEN_TYPES = new Set(['OFT', 'NativeOFT', 'ProxyOFT']);
+
 type TrimmedTokenMetadata = {
+  isOft: boolean;
   peggedTo?: { address: string; chainName: string };
 };
 
@@ -59,13 +64,17 @@ export function trimLayerZeroMetadata(metadata: unknown): Record<number, Trimmed
         continue;
       }
 
-      const { peggedTo } = tokenMetadata;
+      const { peggedTo, type } = tokenMetadata;
+      const isOft = typeof type === 'string' && OFT_TOKEN_TYPES.has(type);
       tokens[tokenAddress.toLowerCase()] =
         isRecord(peggedTo) &&
         typeof peggedTo.address === 'string' &&
         typeof peggedTo.chainName === 'string'
-          ? { peggedTo: { address: peggedTo.address.toLowerCase(), chainName: peggedTo.chainName } }
-          : {};
+          ? {
+              isOft,
+              peggedTo: { address: peggedTo.address.toLowerCase(), chainName: peggedTo.chainName },
+            }
+          : { isOft };
     }
 
     trimmed[chainId] = { chainKey, tokens };

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
@@ -21,8 +21,7 @@ describe('isCanonicalDepositBlocked', () => {
     expect(
       isCanonicalDepositBlocked({
         childTokenAddresses: [USDC_E_ARB],
-        // returned checksummed to prove the comparison is case-insensitive
-        canonicalChildTokenAddress: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
+        canonicalChildTokenAddress: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8', // checksummed
       }),
     ).toBe(false);
   });

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
@@ -2,40 +2,40 @@ import { describe, expect, it } from 'vitest';
 
 import { isCanonicalDepositBlocked } from './WithdrawOnlyUtils';
 
-const ENA_ARB = '0x58538e6a46e07434d7e7375bc268d3cb839c0133'; // ENA OFT on Arbitrum
 const CANONICAL_ENA_ARB = '0xdf8f0c63d9335a0abd89f9f752d293a98ea977d8'; // standard-gateway address
 const USDC_E_ARB = '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8';
-const FRAX_ARB = '0x17fc002b466eec40dae837fc4be5c67993ddbd6f'; // plain ERC20 rep, not an OFT
 const CANONICAL_FRAX_ARB = '0x7468a5d8e02245b00e8c0217fce021c70bc51305'; // standard-gateway address
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 describe('isCanonicalDepositBlocked', () => {
-  it('blocks when canonical bridging lands elsewhere than the OFT deployment (ENA)', () => {
+  it('blocks when canonical bridging lands on a token LayerZero does not recognize (ENA)', () => {
     expect(
       isCanonicalDepositBlocked({
-        childTokenAddresses: [ENA_ARB],
-        hasOftChildDeployment: true,
         canonicalChildTokenAddress: CANONICAL_ENA_ARB,
+        canonicalIsKnownLayerZeroToken: false,
+        hasOftChildDeployment: true,
       }),
     ).toBe(true);
   });
 
-  it('allows when canonical bridging lands on a recognized representation (USDC.e)', () => {
+  it('allows when canonical bridging lands on a recognized token (USDC.e)', () => {
     expect(
       isCanonicalDepositBlocked({
-        childTokenAddresses: [USDC_E_ARB],
+        canonicalChildTokenAddress: USDC_E_ARB,
+        canonicalIsKnownLayerZeroToken: true,
         hasOftChildDeployment: false,
-        canonicalChildTokenAddress: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8', // checksummed
       }),
     ).toBe(false);
   });
 
-  it('allows a recognized representation even when an OFT deployment also exists', () => {
+  it('allows a recognized canonical token even when an OFT deployment also exists (ARB)', () => {
+    // ARB's canonical L2 token is a real, listed token; a separate OFT ARB exists,
+    // but the canonical route lands on the correct token, so it must stay allowed.
     expect(
       isCanonicalDepositBlocked({
-        childTokenAddresses: [ENA_ARB, USDC_E_ARB],
+        canonicalChildTokenAddress: '0x912CE59144191C1204E64559FE8253a0e49E6548',
+        canonicalIsKnownLayerZeroToken: true,
         hasOftChildDeployment: true,
-        canonicalChildTokenAddress: USDC_E_ARB,
       }),
     ).toBe(false);
   });
@@ -43,9 +43,9 @@ describe('isCanonicalDepositBlocked', () => {
   it('blocks when there is no canonical route (zero address, e.g. USDT)', () => {
     expect(
       isCanonicalDepositBlocked({
-        childTokenAddresses: [ENA_ARB],
-        hasOftChildDeployment: true,
         canonicalChildTokenAddress: ZERO_ADDRESS,
+        canonicalIsKnownLayerZeroToken: false,
+        hasOftChildDeployment: true,
       }),
     ).toBe(true);
   });
@@ -53,31 +53,21 @@ describe('isCanonicalDepositBlocked', () => {
   it('blocks when the canonical address could not be resolved', () => {
     expect(
       isCanonicalDepositBlocked({
-        childTokenAddresses: [ENA_ARB],
-        hasOftChildDeployment: true,
         canonicalChildTokenAddress: null,
+        canonicalIsKnownLayerZeroToken: false,
+        hasOftChildDeployment: true,
       }),
     ).toBe(true);
   });
 
-  it('allows a plain ERC20 with no OFT deployment even when canonical lands elsewhere (FRAX)', () => {
+  it('allows a plain ERC20 with no OFT deployment even when canonical is unrecognized (FRAX)', () => {
     // FRAX is merely tracked by LayerZero as an ERC20; there is no OFT route to
     // force it onto, so a canonical deposit must stay allowed.
     expect(
       isCanonicalDepositBlocked({
-        childTokenAddresses: [FRAX_ARB],
-        hasOftChildDeployment: false,
         canonicalChildTokenAddress: CANONICAL_FRAX_ARB,
-      }),
-    ).toBe(false);
-  });
-
-  it('allows when the token has no representation on the destination', () => {
-    expect(
-      isCanonicalDepositBlocked({
-        childTokenAddresses: [],
+        canonicalIsKnownLayerZeroToken: false,
         hasOftChildDeployment: false,
-        canonicalChildTokenAddress: CANONICAL_ENA_ARB,
       }),
     ).toBe(false);
   });

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { isCanonicalDepositBlocked } from './WithdrawOnlyUtils';
+
+const ENA_ARB = '0x58538e6a46e07434d7e7375bc268d3cb839c0133'; // ENA OFT on Arbitrum
+const CANONICAL_ENA_ARB = '0xdf8f0c63d9335a0abd89f9f752d293a98ea977d8'; // standard-gateway address
+const USDC_E_ARB = '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+describe('isCanonicalDepositBlocked', () => {
+  it('blocks when canonical bridging lands on a different token than the OFT (ENA)', () => {
+    expect(
+      isCanonicalDepositBlocked({
+        childTokenAddresses: [ENA_ARB],
+        canonicalChildTokenAddress: CANONICAL_ENA_ARB,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows when canonical bridging lands on the OFT token itself (USDC.e)', () => {
+    expect(
+      isCanonicalDepositBlocked({
+        childTokenAddresses: [USDC_E_ARB],
+        // returned checksummed to prove the comparison is case-insensitive
+        canonicalChildTokenAddress: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
+      }),
+    ).toBe(false);
+  });
+
+  it('blocks when there is no canonical route (zero address, e.g. USDT)', () => {
+    expect(
+      isCanonicalDepositBlocked({
+        childTokenAddresses: [ENA_ARB],
+        canonicalChildTokenAddress: ZERO_ADDRESS,
+      }),
+    ).toBe(true);
+  });
+
+  it('blocks when the canonical address could not be resolved', () => {
+    expect(
+      isCanonicalDepositBlocked({
+        childTokenAddresses: [ENA_ARB],
+        canonicalChildTokenAddress: null,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows when the token has no OFT deployment on the destination', () => {
+    expect(
+      isCanonicalDepositBlocked({
+        childTokenAddresses: [],
+        canonicalChildTokenAddress: CANONICAL_ENA_ARB,
+      }),
+    ).toBe(false);
+  });
+
+  it('matches against any of the destination deployments', () => {
+    expect(
+      isCanonicalDepositBlocked({
+        childTokenAddresses: [ENA_ARB, USDC_E_ARB],
+        canonicalChildTokenAddress: USDC_E_ARB,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
@@ -5,23 +5,37 @@ import { isCanonicalDepositBlocked } from './WithdrawOnlyUtils';
 const ENA_ARB = '0x58538e6a46e07434d7e7375bc268d3cb839c0133'; // ENA OFT on Arbitrum
 const CANONICAL_ENA_ARB = '0xdf8f0c63d9335a0abd89f9f752d293a98ea977d8'; // standard-gateway address
 const USDC_E_ARB = '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8';
+const FRAX_ARB = '0x17fc002b466eec40dae837fc4be5c67993ddbd6f'; // plain ERC20 rep, not an OFT
+const CANONICAL_FRAX_ARB = '0x7468a5d8e02245b00e8c0217fce021c70bc51305'; // standard-gateway address
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 describe('isCanonicalDepositBlocked', () => {
-  it('blocks when canonical bridging lands on a different token than the OFT (ENA)', () => {
+  it('blocks when canonical bridging lands elsewhere than the OFT deployment (ENA)', () => {
     expect(
       isCanonicalDepositBlocked({
         childTokenAddresses: [ENA_ARB],
+        hasOftChildDeployment: true,
         canonicalChildTokenAddress: CANONICAL_ENA_ARB,
       }),
     ).toBe(true);
   });
 
-  it('allows when canonical bridging lands on the OFT token itself (USDC.e)', () => {
+  it('allows when canonical bridging lands on a recognized representation (USDC.e)', () => {
     expect(
       isCanonicalDepositBlocked({
         childTokenAddresses: [USDC_E_ARB],
+        hasOftChildDeployment: false,
         canonicalChildTokenAddress: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8', // checksummed
+      }),
+    ).toBe(false);
+  });
+
+  it('allows a recognized representation even when an OFT deployment also exists', () => {
+    expect(
+      isCanonicalDepositBlocked({
+        childTokenAddresses: [ENA_ARB, USDC_E_ARB],
+        hasOftChildDeployment: true,
+        canonicalChildTokenAddress: USDC_E_ARB,
       }),
     ).toBe(false);
   });
@@ -30,6 +44,7 @@ describe('isCanonicalDepositBlocked', () => {
     expect(
       isCanonicalDepositBlocked({
         childTokenAddresses: [ENA_ARB],
+        hasOftChildDeployment: true,
         canonicalChildTokenAddress: ZERO_ADDRESS,
       }),
     ).toBe(true);
@@ -39,25 +54,30 @@ describe('isCanonicalDepositBlocked', () => {
     expect(
       isCanonicalDepositBlocked({
         childTokenAddresses: [ENA_ARB],
+        hasOftChildDeployment: true,
         canonicalChildTokenAddress: null,
       }),
     ).toBe(true);
   });
 
-  it('allows when the token has no OFT deployment on the destination', () => {
+  it('allows a plain ERC20 with no OFT deployment even when canonical lands elsewhere (FRAX)', () => {
+    // FRAX is merely tracked by LayerZero as an ERC20; there is no OFT route to
+    // force it onto, so a canonical deposit must stay allowed.
     expect(
       isCanonicalDepositBlocked({
-        childTokenAddresses: [],
-        canonicalChildTokenAddress: CANONICAL_ENA_ARB,
+        childTokenAddresses: [FRAX_ARB],
+        hasOftChildDeployment: false,
+        canonicalChildTokenAddress: CANONICAL_FRAX_ARB,
       }),
     ).toBe(false);
   });
 
-  it('matches against any of the destination deployments', () => {
+  it('allows when the token has no representation on the destination', () => {
     expect(
       isCanonicalDepositBlocked({
-        childTokenAddresses: [ENA_ARB, USDC_E_ARB],
-        canonicalChildTokenAddress: USDC_E_ARB,
+        childTokenAddresses: [],
+        hasOftChildDeployment: false,
+        canonicalChildTokenAddress: CANONICAL_ENA_ARB,
       }),
     ).toBe(false);
   });

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -13,7 +13,7 @@ import {
   isTokenArbitrumOneUSDCe,
   isTokenArbitrumSepoliaUSDCe,
 } from './TokenUtils';
-import { getLayerZeroOftInfo } from './layerZeroMetadata';
+import { getLayerZeroOftInfo, isKnownLayerZeroToken } from './layerZeroMetadata';
 
 export type WithdrawOnlyToken = {
   symbol: string;
@@ -329,18 +329,20 @@ async function getCanonicalChildTokenAddress({
   }
 }
 
-// Allow when the canonical deposit lands on a representation LayerZero recognizes
-// (e.g. WETH, USDC.e). If it lands somewhere unrecognized, block only when a real
-// OFT deployment exists to route through instead — a plain ERC20 LayerZero merely
-// tracks (e.g. FRAX) has no OFT alternative, so blocking would just strand it.
+// Allow when the canonical deposit lands on a token LayerZero recognizes on the
+// destination (this token's own deployment, or another real listed token — e.g.
+// ARB, whose L2 token LayerZero lists but doesn't peg to its L1 address). Block
+// only when it lands on an unrecognized counterfactual AND a real OFT deployment
+// exists to route through instead; a plain ERC20 LayerZero merely tracks (e.g.
+// FRAX) has no OFT alternative, so blocking would just strand it.
 export function isCanonicalDepositBlocked({
-  childTokenAddresses,
-  hasOftChildDeployment,
   canonicalChildTokenAddress,
+  canonicalIsKnownLayerZeroToken,
+  hasOftChildDeployment,
 }: {
-  childTokenAddresses: string[];
-  hasOftChildDeployment: boolean;
   canonicalChildTokenAddress: string | null;
+  canonicalIsKnownLayerZeroToken: boolean;
+  hasOftChildDeployment: boolean;
 }): boolean {
   // No canonical route to the destination (e.g. USDT has no gateway).
   if (
@@ -350,8 +352,8 @@ export function isCanonicalDepositBlocked({
     return true;
   }
 
-  // Canonical deposit lands on a recognized representation → safe to allow.
-  if (childTokenAddresses.some((address) => addressesEqual(address, canonicalChildTokenAddress))) {
+  // Canonical deposit lands on a token LayerZero recognizes → safe to allow.
+  if (canonicalIsKnownLayerZeroToken) {
     return false;
   }
 
@@ -367,7 +369,7 @@ async function isBlockedOftDeposit({
   parentChainId: number;
   childChainId: number;
 }) {
-  const { isOft, childTokenAddresses, hasOftChildDeployment } = await getLayerZeroOftInfo({
+  const { isOft, hasOftChildDeployment } = await getLayerZeroOftInfo({
     parentChainId,
     parentTokenAddress: parentChainErc20Address,
     childChainId,
@@ -384,10 +386,17 @@ async function isBlockedOftDeposit({
     childChainId,
   });
 
+  const canonicalIsKnownLayerZeroToken = canonicalChildTokenAddress
+    ? await isKnownLayerZeroToken({
+        chainId: childChainId,
+        tokenAddress: canonicalChildTokenAddress,
+      })
+    : false;
+
   return isCanonicalDepositBlocked({
-    childTokenAddresses,
-    hasOftChildDeployment,
     canonicalChildTokenAddress,
+    canonicalIsKnownLayerZeroToken,
+    hasOftChildDeployment,
   });
 }
 

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -329,14 +329,17 @@ async function getCanonicalChildTokenAddress({
   }
 }
 
-// A canonical deposit of an OFT token is safe only when it lands on the OFT
-// token itself (adapter over the canonical token, e.g. WETH, USDC.e); otherwise
-// it must move via OFT/LiFi.
+// Allow when the canonical deposit lands on a representation LayerZero recognizes
+// (e.g. WETH, USDC.e). If it lands somewhere unrecognized, block only when a real
+// OFT deployment exists to route through instead — a plain ERC20 LayerZero merely
+// tracks (e.g. FRAX) has no OFT alternative, so blocking would just strand it.
 export function isCanonicalDepositBlocked({
   childTokenAddresses,
+  hasOftChildDeployment,
   canonicalChildTokenAddress,
 }: {
   childTokenAddresses: string[];
+  hasOftChildDeployment: boolean;
   canonicalChildTokenAddress: string | null;
 }): boolean {
   // No canonical route to the destination (e.g. USDT has no gateway).
@@ -347,14 +350,12 @@ export function isCanonicalDepositBlocked({
     return true;
   }
 
-  // No OFT deployment on the destination — canonical is the only path.
-  if (childTokenAddresses.length === 0) {
+  // Canonical deposit lands on a recognized representation → safe to allow.
+  if (childTokenAddresses.some((address) => addressesEqual(address, canonicalChildTokenAddress))) {
     return false;
   }
 
-  return !childTokenAddresses.some((address) =>
-    addressesEqual(address, canonicalChildTokenAddress),
-  );
+  return hasOftChildDeployment;
 }
 
 async function isBlockedOftDeposit({
@@ -366,7 +367,7 @@ async function isBlockedOftDeposit({
   parentChainId: number;
   childChainId: number;
 }) {
-  const { isOft, childTokenAddresses } = await getLayerZeroOftInfo({
+  const { isOft, childTokenAddresses, hasOftChildDeployment } = await getLayerZeroOftInfo({
     parentChainId,
     parentTokenAddress: parentChainErc20Address,
     childChainId,
@@ -383,7 +384,11 @@ async function isBlockedOftDeposit({
     childChainId,
   });
 
-  return isCanonicalDepositBlocked({ childTokenAddresses, canonicalChildTokenAddress });
+  return isCanonicalDepositBlocked({
+    childTokenAddresses,
+    hasOftChildDeployment,
+    canonicalChildTokenAddress,
+  });
 }
 
 /**

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -309,7 +309,6 @@ async function isOftTokenOnChain(parentChainErc20Address: string, parentChainId:
   }
 }
 
-// The address a canonical deposit would land on; null when unresolvable (e.g. no gateway).
 async function getCanonicalChildTokenAddress({
   parentChainErc20Address,
   parentChainId,

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -8,6 +8,7 @@ import { ChainId } from '../types/ChainId';
 import { isNetwork } from '../util/networks';
 import { CommonAddress } from './CommonAddressUtils';
 import { isTokenArbitrumOneUSDCe, isTokenArbitrumSepoliaUSDCe } from './TokenUtils';
+import { getLayerZeroNativeTokenStatus } from './layerZeroMetadata';
 
 export type WithdrawOnlyToken = {
   symbol: string;
@@ -285,6 +286,15 @@ export const withdrawOnlyTokens: { [chainId: number]: WithdrawOnlyToken[] } = {
 };
 
 async function isLayerZeroToken(parentChainErc20Address: string, parentChainId: number) {
+  const layerZeroNativeTokenStatus = await getLayerZeroNativeTokenStatus({
+    chainId: parentChainId,
+    tokenAddress: parentChainErc20Address,
+  });
+
+  if (layerZeroNativeTokenStatus !== null) {
+    return layerZeroNativeTokenStatus;
+  }
+
   const parentProvider = getProviderForChainId(parentChainId);
 
   // https://github.com/LayerZero-Labs/LayerZero-v2/blob/592625b9e5967643853476445ffe0e777360b906/packages/layerzero-v2/evm/oapp/contracts/oft/OFT.sol#L37

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -6,9 +6,14 @@ import { getProviderForChainId } from '@/token-bridge-sdk/utils';
 
 import { ChainId } from '../types/ChainId';
 import { isNetwork } from '../util/networks';
+import { addressesEqual } from './AddressUtils';
 import { CommonAddress } from './CommonAddressUtils';
-import { isTokenArbitrumOneUSDCe, isTokenArbitrumSepoliaUSDCe } from './TokenUtils';
-import { getLayerZeroNativeTokenStatus } from './layerZeroMetadata';
+import {
+  getL2ERC20Address,
+  isTokenArbitrumOneUSDCe,
+  isTokenArbitrumSepoliaUSDCe,
+} from './TokenUtils';
+import { getLayerZeroOftInfo } from './layerZeroMetadata';
 
 export type WithdrawOnlyToken = {
   symbol: string;
@@ -285,16 +290,8 @@ export const withdrawOnlyTokens: { [chainId: number]: WithdrawOnlyToken[] } = {
   ],
 };
 
-async function isLayerZeroToken(parentChainErc20Address: string, parentChainId: number) {
-  const layerZeroNativeTokenStatus = await getLayerZeroNativeTokenStatus({
-    chainId: parentChainId,
-    tokenAddress: parentChainErc20Address,
-  });
-
-  if (layerZeroNativeTokenStatus !== null) {
-    return layerZeroNativeTokenStatus;
-  }
-
+// On-chain OFT probe — fallback for tokens not yet in the LayerZero metadata.
+async function isOftTokenOnChain(parentChainErc20Address: string, parentChainId: number) {
   const parentProvider = getProviderForChainId(parentChainId);
 
   // https://github.com/LayerZero-Labs/LayerZero-v2/blob/592625b9e5967643853476445ffe0e777360b906/packages/layerzero-v2/evm/oapp/contracts/oft/OFT.sol#L37
@@ -310,6 +307,84 @@ async function isLayerZeroToken(parentChainErc20Address: string, parentChainId: 
   } catch (error) {
     return false;
   }
+}
+
+// The address a canonical deposit would land on; null when unresolvable (e.g. no gateway).
+async function getCanonicalChildTokenAddress({
+  parentChainErc20Address,
+  parentChainId,
+  childChainId,
+}: {
+  parentChainErc20Address: string;
+  parentChainId: number;
+  childChainId: number;
+}): Promise<string | null> {
+  try {
+    return await getL2ERC20Address({
+      erc20L1Address: parentChainErc20Address,
+      l1Provider: getProviderForChainId(parentChainId),
+      l2Provider: getProviderForChainId(childChainId),
+    });
+  } catch (error) {
+    return null;
+  }
+}
+
+// A canonical deposit of an OFT token is safe only when it lands on the OFT
+// token itself (adapter over the canonical token, e.g. WETH, USDC.e); otherwise
+// it must move via OFT/LiFi.
+export function isCanonicalDepositBlocked({
+  childTokenAddresses,
+  canonicalChildTokenAddress,
+}: {
+  childTokenAddresses: string[];
+  canonicalChildTokenAddress: string | null;
+}): boolean {
+  // No canonical route to the destination (e.g. USDT has no gateway).
+  if (
+    !canonicalChildTokenAddress ||
+    addressesEqual(canonicalChildTokenAddress, ethers.constants.AddressZero)
+  ) {
+    return true;
+  }
+
+  // No OFT deployment on the destination — canonical is the only path.
+  if (childTokenAddresses.length === 0) {
+    return false;
+  }
+
+  return !childTokenAddresses.some((address) =>
+    addressesEqual(address, canonicalChildTokenAddress),
+  );
+}
+
+async function isBlockedOftDeposit({
+  parentChainErc20Address,
+  parentChainId,
+  childChainId,
+}: {
+  parentChainErc20Address: string;
+  parentChainId: number;
+  childChainId: number;
+}) {
+  const { isOft, childTokenAddresses } = await getLayerZeroOftInfo({
+    parentChainId,
+    parentTokenAddress: parentChainErc20Address,
+    childChainId,
+  });
+
+  // Not listed in the LayerZero metadata — fall back to the on-chain probe.
+  if (!isOft) {
+    return isOftTokenOnChain(parentChainErc20Address, parentChainId);
+  }
+
+  const canonicalChildTokenAddress = await getCanonicalChildTokenAddress({
+    parentChainErc20Address,
+    parentChainId,
+    childChainId,
+  });
+
+  return isCanonicalDepositBlocked({ childTokenAddresses, canonicalChildTokenAddress });
 }
 
 /**
@@ -343,7 +418,7 @@ export async function isWithdrawOnlyToken({
     return true;
   }
 
-  if (await isLayerZeroToken(parentChainErc20Address, parentChainId)) {
+  if (await isBlockedOftDeposit({ parentChainErc20Address, parentChainId, childChainId })) {
     return true;
   }
 

--- a/packages/arb-token-bridge-ui/src/util/index.ts
+++ b/packages/arb-token-bridge-ui/src/util/index.ts
@@ -35,7 +35,7 @@ export const sanitizeQueryParams = (data: any) => {
 };
 
 export const isRecord = (value: unknown): value is Record<string, unknown> => {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 };
 
 export const getAPIBaseUrl = () => {

--- a/packages/arb-token-bridge-ui/src/util/index.ts
+++ b/packages/arb-token-bridge-ui/src/util/index.ts
@@ -34,6 +34,10 @@ export const sanitizeQueryParams = (data: any) => {
   return JSON.parse(JSON.stringify(data));
 };
 
+export const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null;
+};
+
 export const getAPIBaseUrl = () => {
   // if dev environment, eg. tests, then prepend actual running environment
   // Resolves: next-js-error-only-absolute-urls-are-supported in test:ci

--- a/packages/arb-token-bridge-ui/src/util/isRecord.ts
+++ b/packages/arb-token-bridge-ui/src/util/isRecord.ts
@@ -1,3 +1,0 @@
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}

--- a/packages/arb-token-bridge-ui/src/util/isRecord.ts
+++ b/packages/arb-token-bridge-ui/src/util/isRecord.ts
@@ -1,0 +1,3 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.integration.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.integration.test.ts
@@ -27,7 +27,6 @@ describe('layerZeroMetadata against live LayerZero metadata', () => {
 
     expect(isOft).toBe(true);
     expect(childTokenAddresses.length).toBeGreaterThan(0);
-    // every resolved deployment is a well-formed, lower-cased address
     expect(childTokenAddresses.every((address) => /^0x[0-9a-f]{40}$/.test(address))).toBe(true);
   });
 

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.integration.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.integration.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { getLayerZeroOftInfoFromMetadata } from './layerZeroMetadata';
+
+// Hits the live LayerZero metadata endpoint (excluded from the unit suite via
+// vitest.integration.config.ts). Guards against upstream schema drift breaking
+// our OFT detection, and validates the parser against real data.
+const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
+
+// Ethena's ENA — a stable, flagship LayerZero OFT (native on Ethereum, OFT on Arbitrum).
+const ENA_ETHEREUM = '0x57e114b691db790c35207b2e685d4a43181e6061';
+
+describe('layerZeroMetadata against live LayerZero metadata', () => {
+  it('detects a known OFT and its destination deployment from live metadata', async () => {
+    const response = await fetch(LAYERZERO_METADATA_URL);
+    expect(response.ok).toBe(true);
+
+    const metadata = await response.json();
+    expect(typeof metadata).toBe('object');
+    expect(metadata).not.toBeNull();
+
+    const { isOft, childTokenAddresses } = getLayerZeroOftInfoFromMetadata(metadata, {
+      parentChainId: 1, // Ethereum
+      parentTokenAddress: ENA_ETHEREUM,
+      childChainId: 42161, // Arbitrum One
+    });
+
+    expect(isOft).toBe(true);
+    expect(childTokenAddresses.length).toBeGreaterThan(0);
+    // every resolved deployment is a well-formed, lower-cased address
+    expect(childTokenAddresses.every((address) => /^0x[0-9a-f]{40}$/.test(address))).toBe(true);
+  });
+
+  it('reports a non-listed token as not OFT from live metadata', async () => {
+    const response = await fetch(LAYERZERO_METADATA_URL);
+    const metadata = await response.json();
+
+    expect(
+      getLayerZeroOftInfoFromMetadata(metadata, {
+        parentChainId: 1,
+        parentTokenAddress: '0x1111111111111111111111111111111111111111',
+        childChainId: 42161,
+      }),
+    ).toEqual({ isOft: false, childTokenAddresses: [] });
+  });
+});

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.integration.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.integration.test.ts
@@ -1,24 +1,26 @@
 import { describe, expect, it } from 'vitest';
 
+import { trimLayerZeroMetadata } from '../app/api/layerzero-metadata';
 import { getLayerZeroOftInfoFromMetadata } from './layerZeroMetadata';
 
 // Hits the live LayerZero metadata endpoint (excluded from the unit suite via
-// vitest.integration.config.ts). Guards against upstream schema drift breaking
-// our OFT detection, and validates the parser against real data.
+// vitest.integration.config.ts). Runs the real trim + parse pipeline against live
+// data, guarding against upstream schema/chainKey drift breaking OFT detection.
 const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
 
 // Ethena's ENA — a stable, flagship LayerZero OFT (native on Ethereum, OFT on Arbitrum).
 const ENA_ETHEREUM = '0x57e114b691db790c35207b2e685d4a43181e6061';
 const ENA_ARBITRUM_OFT = '0x58538e6a46e07434d7e7375bc268d3cb839c0133';
 
+async function fetchTrimmedMetadata() {
+  const response = await fetch(LAYERZERO_METADATA_URL);
+  expect(response.ok).toBe(true);
+  return trimLayerZeroMetadata(await response.json());
+}
+
 describe('layerZeroMetadata against live LayerZero metadata', () => {
   it('flags a known OFT and returns its real Arbitrum deployment from live metadata', async () => {
-    const response = await fetch(LAYERZERO_METADATA_URL);
-    expect(response.ok).toBe(true);
-
-    const metadata = await response.json();
-    expect(typeof metadata).toBe('object');
-    expect(metadata).not.toBeNull();
+    const metadata = await fetchTrimmedMetadata();
 
     const { isOft, childTokenAddresses } = getLayerZeroOftInfoFromMetadata(metadata, {
       parentChainId: 1, // Ethereum
@@ -32,8 +34,7 @@ describe('layerZeroMetadata against live LayerZero metadata', () => {
   });
 
   it('reports a non-listed token as not OFT from live metadata', async () => {
-    const response = await fetch(LAYERZERO_METADATA_URL);
-    const metadata = await response.json();
+    const metadata = await fetchTrimmedMetadata();
 
     expect(
       getLayerZeroOftInfoFromMetadata(metadata, {

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.integration.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.integration.test.ts
@@ -12,6 +12,9 @@ const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
 const ENA_ETHEREUM = '0x57e114b691db790c35207b2e685d4a43181e6061';
 const ENA_ARBITRUM_OFT = '0x58538e6a46e07434d7e7375bc268d3cb839c0133';
 
+// FRAX — tracked by LayerZero on both chains as a plain ERC20, not an OFT.
+const FRAX_ETHEREUM = '0x853d955acef822db058eb8505911ed77f175b99e';
+
 async function fetchTrimmedMetadata() {
   const response = await fetch(LAYERZERO_METADATA_URL);
   expect(response.ok).toBe(true);
@@ -22,15 +25,34 @@ describe('layerZeroMetadata against live LayerZero metadata', () => {
   it('flags a known OFT and returns its real Arbitrum deployment from live metadata', async () => {
     const metadata = await fetchTrimmedMetadata();
 
-    const { isOft, childTokenAddresses } = getLayerZeroOftInfoFromMetadata(metadata, {
-      parentChainId: 1, // Ethereum
-      parentTokenAddress: ENA_ETHEREUM,
-      childChainId: 42161, // Arbitrum One
-    });
+    const { isOft, childTokenAddresses, hasOftChildDeployment } = getLayerZeroOftInfoFromMetadata(
+      metadata,
+      {
+        parentChainId: 1, // Ethereum
+        parentTokenAddress: ENA_ETHEREUM,
+        childChainId: 42161, // Arbitrum One
+      },
+    );
 
     expect(isOft).toBe(true);
+    expect(hasOftChildDeployment).toBe(true);
     expect(childTokenAddresses).toContain(ENA_ARBITRUM_OFT);
     expect(childTokenAddresses.every((address) => /^0x[0-9a-f]{40}$/.test(address))).toBe(true);
+  });
+
+  it('reports no OFT child deployment for a plain ERC20 (FRAX) from live metadata', async () => {
+    const metadata = await fetchTrimmedMetadata();
+
+    const { isOft, hasOftChildDeployment } = getLayerZeroOftInfoFromMetadata(metadata, {
+      parentChainId: 1,
+      parentTokenAddress: FRAX_ETHEREUM,
+      childChainId: 42161,
+    });
+
+    // Listed by LayerZero, but with no OFT deployment on Arbitrum, so the caller
+    // must not force it off the canonical route.
+    expect(isOft).toBe(true);
+    expect(hasOftChildDeployment).toBe(false);
   });
 
   it('reports a non-listed token as not OFT from live metadata', async () => {
@@ -42,6 +64,6 @@ describe('layerZeroMetadata against live LayerZero metadata', () => {
         parentTokenAddress: '0x1111111111111111111111111111111111111111',
         childChainId: 42161,
       }),
-    ).toEqual({ isOft: false, childTokenAddresses: [] });
+    ).toEqual({ isOft: false, childTokenAddresses: [], hasOftChildDeployment: false });
   });
 });

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.integration.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.integration.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import { trimLayerZeroMetadata } from '../app/api/layerzero-metadata';
-import { getLayerZeroOftInfoFromMetadata } from './layerZeroMetadata';
+import {
+  getLayerZeroOftInfoFromMetadata,
+  isKnownLayerZeroTokenFromMetadata,
+} from './layerZeroMetadata';
 
 // Hits the live LayerZero metadata endpoint (excluded from the unit suite via
 // vitest.integration.config.ts). Runs the real trim + parse pipeline against live
@@ -14,6 +17,11 @@ const ENA_ARBITRUM_OFT = '0x58538e6a46e07434d7e7375bc268d3cb839c0133';
 
 // FRAX — tracked by LayerZero on both chains as a plain ERC20, not an OFT.
 const FRAX_ETHEREUM = '0x853d955acef822db058eb8505911ed77f175b99e';
+
+// ARB's real Arbitrum token: LayerZero lists it (so a canonical deposit lands on a
+// recognized token), unlike ENA's standard-gateway counterfactual.
+const ARB_ON_ARBITRUM = '0x912ce59144191c1204e64559fe8253a0e49e6548';
+const ENA_ARBITRUM_CANONICAL = '0xdf8f0c63d9335a0abd89f9f752d293a98ea977d8';
 
 async function fetchTrimmedMetadata() {
   const response = await fetch(LAYERZERO_METADATA_URL);
@@ -53,6 +61,26 @@ describe('layerZeroMetadata against live LayerZero metadata', () => {
     // must not force it off the canonical route.
     expect(isOft).toBe(true);
     expect(hasOftChildDeployment).toBe(false);
+  });
+
+  it('recognizes a real listed token but not a gateway counterfactual from live metadata', async () => {
+    const metadata = await fetchTrimmedMetadata();
+
+    // ARB's canonical L2 token is listed → a canonical deposit lands on a real token.
+    expect(
+      isKnownLayerZeroTokenFromMetadata(metadata, {
+        chainId: 42161,
+        tokenAddress: ARB_ON_ARBITRUM,
+      }),
+    ).toBe(true);
+
+    // ENA's standard-gateway counterfactual is not a token LayerZero lists.
+    expect(
+      isKnownLayerZeroTokenFromMetadata(metadata, {
+        chainId: 42161,
+        tokenAddress: ENA_ARBITRUM_CANONICAL,
+      }),
+    ).toBe(false);
   });
 
   it('reports a non-listed token as not OFT from live metadata', async () => {

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.integration.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.integration.test.ts
@@ -9,9 +9,10 @@ const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
 
 // Ethena's ENA — a stable, flagship LayerZero OFT (native on Ethereum, OFT on Arbitrum).
 const ENA_ETHEREUM = '0x57e114b691db790c35207b2e685d4a43181e6061';
+const ENA_ARBITRUM_OFT = '0x58538e6a46e07434d7e7375bc268d3cb839c0133';
 
 describe('layerZeroMetadata against live LayerZero metadata', () => {
-  it('detects a known OFT and its destination deployment from live metadata', async () => {
+  it('flags a known OFT and returns its real Arbitrum deployment from live metadata', async () => {
     const response = await fetch(LAYERZERO_METADATA_URL);
     expect(response.ok).toBe(true);
 
@@ -26,7 +27,7 @@ describe('layerZeroMetadata against live LayerZero metadata', () => {
     });
 
     expect(isOft).toBe(true);
-    expect(childTokenAddresses.length).toBeGreaterThan(0);
+    expect(childTokenAddresses).toContain(ENA_ARBITRUM_OFT);
     expect(childTokenAddresses.every((address) => /^0x[0-9a-f]{40}$/.test(address))).toBe(true);
   });
 

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getLayerZeroNativeTokenStatusFromMetadata } from './layerZeroMetadata';
+
+let getLayerZeroNativeTokenStatus: typeof import('./layerZeroMetadata').getLayerZeroNativeTokenStatus;
+let resetLayerZeroMetadataCache: typeof import('./layerZeroMetadata').resetLayerZeroMetadataCache;
+
+describe('getLayerZeroNativeTokenStatus', () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+
+    ({ getLayerZeroNativeTokenStatus, resetLayerZeroMetadataCache } = await import(
+      './layerZeroMetadata'
+    ));
+
+    resetLayerZeroMetadataCache();
+  });
+
+  it('returns true for a native OFT token on the matching chain', () => {
+    expect(
+      getLayerZeroNativeTokenStatusFromMetadata(
+        {
+          ethereum: {
+            chainDetails: { nativeChainId: 1 },
+            tokens: {
+              '0x6c3ea9036406852006290770bedfcaba0e23a0e8': {},
+            },
+          },
+        },
+        {
+          chainId: 1,
+          tokenAddress: '0x6C3EA9036406852006290770BEdFcAbA0e23A0e8',
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a non-native OFT representation token', () => {
+    expect(
+      getLayerZeroNativeTokenStatusFromMetadata(
+        {
+          arbitrum: {
+            chainDetails: { nativeChainId: 42161 },
+            tokens: {
+              '0x46850ad61c2b7d64d08c9c754f45254596696984': {
+                peggedTo: {
+                  eid: 30101,
+                  address: '0x6c3ea9036406852006290770bedfcaba0e23a0e8',
+                },
+              },
+            },
+          },
+        },
+        {
+          chainId: 42161,
+          tokenAddress: '0x46850AD61C2b7D64d08C9C754F45254596696984',
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('returns null when the token is not present in metadata', () => {
+    expect(
+      getLayerZeroNativeTokenStatusFromMetadata(
+        {
+          ethereum: {
+            chainDetails: { nativeChainId: 1 },
+            tokens: {},
+          },
+        },
+        {
+          chainId: 1,
+          tokenAddress: '0x6C3EA9036406852006290770BEdFcAbA0e23A0e8',
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it('caches the metadata response', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ethereum: {
+          chainDetails: { nativeChainId: 1 },
+          tokens: {
+            '0x6c3ea9036406852006290770bedfcaba0e23a0e8': {},
+          },
+        },
+      }),
+    } as Response);
+
+    await getLayerZeroNativeTokenStatus({
+      chainId: 1,
+      tokenAddress: '0x6C3EA9036406852006290770BEdFcAbA0e23A0e8',
+    });
+    await getLayerZeroNativeTokenStatus({
+      chainId: 1,
+      tokenAddress: '0x6C3EA9036406852006290770BEdFcAbA0e23A0e8',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
@@ -6,27 +6,33 @@ import {
   resetLayerZeroMetadataCache,
 } from './layerZeroMetadata';
 
-// Trimmed-metadata shape returned by /api/layerzero-metadata, using real addresses.
-const ENA_L1 = '0x57e114b691db790c35207b2e685d4a43181e6061';
-const ENA_ARB = '0x58538e6a46e07434d7e7375bc268d3cb839c0133';
-const USDC_L1 = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-const USDC_E_ARB = '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8';
-const USDC_NATIVE_ARB = '0xaf88d065e77c8cc2239327c5edb3a432268e5831';
+// Synthetic trimmed-metadata fixtures — these exercise the parsing/root-linking
+// logic against controlled input. Real-token, live-network behavior is covered
+// in layerZeroMetadata.integration.test.ts.
+const PARENT_CHAIN_ID = 111;
+const CHILD_CHAIN_ID = 222;
+
+const NATIVE_TOKEN = '0x00000000000000000000000000000000000000a1'; // native on parent chain
+const NATIVE_TOKEN_ON_CHILD = '0x00000000000000000000000000000000000000b1';
+const MULTI_TOKEN = '0x00000000000000000000000000000000000000a2'; // native, with 2 child deployments
+const MULTI_TOKEN_ON_CHILD_1 = '0x00000000000000000000000000000000000000b2';
+const MULTI_TOKEN_ON_CHILD_2 = '0x00000000000000000000000000000000000000b3';
+const UNLISTED_TOKEN = '0x00000000000000000000000000000000000000ff';
 
 const metadata = {
-  ethereum: {
-    chainDetails: { nativeChainId: 1 },
+  parent: {
+    chainDetails: { nativeChainId: PARENT_CHAIN_ID },
     tokens: {
-      [ENA_L1]: {}, // native ENA (no peggedTo)
-      [USDC_L1]: {}, // native USDC
+      [NATIVE_TOKEN]: {}, // no peggedTo → native/home token
+      [MULTI_TOKEN]: {},
     },
   },
-  arbitrum: {
-    chainDetails: { nativeChainId: 42161 },
+  child: {
+    chainDetails: { nativeChainId: CHILD_CHAIN_ID },
     tokens: {
-      [ENA_ARB]: { peggedTo: { address: ENA_L1, chainName: 'ethereum' } },
-      [USDC_E_ARB]: { peggedTo: { address: USDC_L1, chainName: 'ethereum' } },
-      [USDC_NATIVE_ARB]: { peggedTo: { address: USDC_L1, chainName: 'ethereum' } },
+      [NATIVE_TOKEN_ON_CHILD]: { peggedTo: { address: NATIVE_TOKEN, chainName: 'parent' } },
+      [MULTI_TOKEN_ON_CHILD_1]: { peggedTo: { address: MULTI_TOKEN, chainName: 'parent' } },
+      [MULTI_TOKEN_ON_CHILD_2]: { peggedTo: { address: MULTI_TOKEN, chainName: 'parent' } },
     },
   },
 };
@@ -41,53 +47,55 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
     it('reports a token that is not in the metadata as not OFT', () => {
       expect(
         getLayerZeroOftInfoFromMetadata(metadata, {
-          parentChainId: 1,
-          parentTokenAddress: '0x1111111111111111111111111111111111111111',
-          childChainId: 42161,
+          parentChainId: PARENT_CHAIN_ID,
+          parentTokenAddress: UNLISTED_TOKEN,
+          childChainId: CHILD_CHAIN_ID,
         }),
       ).toEqual({ isOft: false, childTokenAddresses: [] });
     });
 
     it('finds every child deployment linked to the same native token', () => {
       const { isOft, childTokenAddresses } = getLayerZeroOftInfoFromMetadata(metadata, {
-        parentChainId: 1,
-        parentTokenAddress: USDC_L1,
-        childChainId: 42161,
+        parentChainId: PARENT_CHAIN_ID,
+        parentTokenAddress: MULTI_TOKEN,
+        childChainId: CHILD_CHAIN_ID,
       });
 
       expect(isOft).toBe(true);
-      expect([...childTokenAddresses].sort()).toEqual([USDC_NATIVE_ARB, USDC_E_ARB].sort());
+      expect([...childTokenAddresses].sort()).toEqual(
+        [MULTI_TOKEN_ON_CHILD_1, MULTI_TOKEN_ON_CHILD_2].sort(),
+      );
     });
 
     it('matches the parent token case-insensitively', () => {
       expect(
         getLayerZeroOftInfoFromMetadata(metadata, {
-          parentChainId: 1,
-          parentTokenAddress: ENA_L1.toUpperCase().replace('0X', '0x'),
-          childChainId: 42161,
+          parentChainId: PARENT_CHAIN_ID,
+          parentTokenAddress: NATIVE_TOKEN.toUpperCase().replace('0X', '0x'),
+          childChainId: CHILD_CHAIN_ID,
         }),
-      ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
+      ).toEqual({ isOft: true, childTokenAddresses: [NATIVE_TOKEN_ON_CHILD] });
     });
 
     it('reports OFT with no child deployments when the destination chain is unknown', () => {
       expect(
         getLayerZeroOftInfoFromMetadata(metadata, {
-          parentChainId: 1,
-          parentTokenAddress: ENA_L1,
+          parentChainId: PARENT_CHAIN_ID,
+          parentTokenAddress: NATIVE_TOKEN,
           childChainId: 999999, // not in metadata
         }),
       ).toEqual({ isOft: true, childTokenAddresses: [] });
     });
 
     it('resolves the native root when the parent token is itself a representation', () => {
-      // parent = ENA on Arbitrum (pegged to ethereum), child = ethereum → the root token itself
+      // parent = the child-chain representation, child = the home chain → the root token itself
       expect(
         getLayerZeroOftInfoFromMetadata(metadata, {
-          parentChainId: 42161,
-          parentTokenAddress: ENA_ARB,
-          childChainId: 1,
+          parentChainId: CHILD_CHAIN_ID,
+          parentTokenAddress: NATIVE_TOKEN_ON_CHILD,
+          childChainId: PARENT_CHAIN_ID,
         }),
-      ).toEqual({ isOft: true, childTokenAddresses: [ENA_L1] });
+      ).toEqual({ isOft: true, childTokenAddresses: [NATIVE_TOKEN] });
     });
   });
 
@@ -96,9 +104,9 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
     it.each([null, undefined, 42, 'not-an-object', []])('treats %p as not OFT', (badMetadata) => {
       expect(
         getLayerZeroOftInfoFromMetadata(badMetadata, {
-          parentChainId: 1,
-          parentTokenAddress: ENA_L1,
-          childChainId: 42161,
+          parentChainId: PARENT_CHAIN_ID,
+          parentTokenAddress: NATIVE_TOKEN,
+          childChainId: CHILD_CHAIN_ID,
         }),
       ).toEqual({ isOft: false, childTokenAddresses: [] });
     });
@@ -107,22 +115,34 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
       expect(
         getLayerZeroOftInfoFromMetadata(
           {
-            ethereum: { chainDetails: { nativeChainId: '1' }, tokens: { [ENA_L1]: {} } },
-            arbitrum: {
-              chainDetails: { nativeChainId: '42161' },
-              tokens: { [ENA_ARB]: { peggedTo: { address: ENA_L1, chainName: 'ethereum' } } },
+            parent: { chainDetails: { nativeChainId: '111' }, tokens: { [NATIVE_TOKEN]: {} } },
+            child: {
+              chainDetails: { nativeChainId: '222' },
+              tokens: {
+                [NATIVE_TOKEN_ON_CHILD]: {
+                  peggedTo: { address: NATIVE_TOKEN, chainName: 'parent' },
+                },
+              },
             },
           },
-          { parentChainId: 1, parentTokenAddress: ENA_L1, childChainId: 42161 },
+          {
+            parentChainId: PARENT_CHAIN_ID,
+            parentTokenAddress: NATIVE_TOKEN,
+            childChainId: CHILD_CHAIN_ID,
+          },
         ),
-      ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
+      ).toEqual({ isOft: true, childTokenAddresses: [NATIVE_TOKEN_ON_CHILD] });
     });
 
     it('ignores chains with missing or invalid chainDetails', () => {
       expect(
         getLayerZeroOftInfoFromMetadata(
-          { ethereum: { tokens: { [ENA_L1]: {} } } }, // no chainDetails
-          { parentChainId: 1, parentTokenAddress: ENA_L1, childChainId: 42161 },
+          { parent: { tokens: { [NATIVE_TOKEN]: {} } } }, // no chainDetails
+          {
+            parentChainId: PARENT_CHAIN_ID,
+            parentTokenAddress: NATIVE_TOKEN,
+            childChainId: CHILD_CHAIN_ID,
+          },
         ),
       ).toEqual({ isOft: false, childTokenAddresses: [] });
     });
@@ -131,19 +151,28 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
       expect(
         getLayerZeroOftInfoFromMetadata(
           {
-            ethereum: { chainDetails: { nativeChainId: 1 }, tokens: { [ENA_L1]: {} } },
-            arbitrum: {
-              chainDetails: { nativeChainId: 42161 },
+            parent: {
+              chainDetails: { nativeChainId: PARENT_CHAIN_ID },
+              tokens: { [NATIVE_TOKEN]: {} },
+            },
+            child: {
+              chainDetails: { nativeChainId: CHILD_CHAIN_ID },
               tokens: {
-                [ENA_ARB]: { peggedTo: { address: ENA_L1, chainName: 'ethereum' } },
-                '0x000000000000000000000000000000000000dead': null, // malformed entry
-                '0x000000000000000000000000000000000000beef': { peggedTo: { address: ENA_L1 } }, // missing chainName
+                [NATIVE_TOKEN_ON_CHILD]: {
+                  peggedTo: { address: NATIVE_TOKEN, chainName: 'parent' },
+                },
+                [MULTI_TOKEN_ON_CHILD_1]: null, // malformed entry
+                [MULTI_TOKEN_ON_CHILD_2]: { peggedTo: { address: NATIVE_TOKEN } }, // missing chainName
               },
             },
           },
-          { parentChainId: 1, parentTokenAddress: ENA_L1, childChainId: 42161 },
+          {
+            parentChainId: PARENT_CHAIN_ID,
+            parentTokenAddress: NATIVE_TOKEN,
+            childChainId: CHILD_CHAIN_ID,
+          },
         ),
-      ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
+      ).toEqual({ isOft: true, childTokenAddresses: [NATIVE_TOKEN_ON_CHILD] });
     });
   });
 });
@@ -161,14 +190,14 @@ describe.sequential('getLayerZeroOftInfo (fetch + cache)', () => {
     });
 
     await getLayerZeroOftInfo({
-      parentChainId: 1,
-      parentTokenAddress: ENA_L1,
-      childChainId: 42161,
+      parentChainId: PARENT_CHAIN_ID,
+      parentTokenAddress: NATIVE_TOKEN,
+      childChainId: CHILD_CHAIN_ID,
     });
     await getLayerZeroOftInfo({
-      parentChainId: 1,
-      parentTokenAddress: USDC_L1,
-      childChainId: 42161,
+      parentChainId: PARENT_CHAIN_ID,
+      parentTokenAddress: MULTI_TOKEN,
+      childChainId: CHILD_CHAIN_ID,
     });
 
     expect(fetchCallCount).toBe(1);
@@ -185,18 +214,18 @@ describe.sequential('getLayerZeroOftInfo (fetch + cache)', () => {
     });
 
     const first = await getLayerZeroOftInfo({
-      parentChainId: 1,
-      parentTokenAddress: ENA_L1,
-      childChainId: 42161,
+      parentChainId: PARENT_CHAIN_ID,
+      parentTokenAddress: NATIVE_TOKEN,
+      childChainId: CHILD_CHAIN_ID,
     });
     const second = await getLayerZeroOftInfo({
-      parentChainId: 1,
-      parentTokenAddress: ENA_L1,
-      childChainId: 42161,
+      parentChainId: PARENT_CHAIN_ID,
+      parentTokenAddress: NATIVE_TOKEN,
+      childChainId: CHILD_CHAIN_ID,
     });
 
     expect(first).toEqual({ isOft: false, childTokenAddresses: [] }); // null metadata → not found
-    expect(second).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
+    expect(second).toEqual({ isOft: true, childTokenAddresses: [NATIVE_TOKEN_ON_CHILD] });
     expect(fetchCallCount).toBe(2);
   });
 });

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
@@ -9,8 +9,8 @@ describe('getLayerZeroNativeTokenStatus', () => {
     vi.restoreAllMocks();
     vi.resetModules();
 
-    // Import every export from the same freshly-reset module instance so the
-    // module-level cache is consistent across the pure and cached helpers.
+    // Import everything from the same freshly-reset module instance so the
+    // module-level cache is shared across the helpers under test.
     ({
       getLayerZeroNativeTokenStatus,
       getLayerZeroNativeTokenStatusFromMetadata,

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
@@ -1,169 +1,154 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-let getLayerZeroNativeTokenStatus: typeof import('./layerZeroMetadata').getLayerZeroNativeTokenStatus;
-let getLayerZeroNativeTokenStatusFromMetadata: typeof import('./layerZeroMetadata').getLayerZeroNativeTokenStatusFromMetadata;
-let resetLayerZeroMetadataCache: typeof import('./layerZeroMetadata').resetLayerZeroMetadataCache;
+import {
+  getLayerZeroOftInfo,
+  getLayerZeroOftInfoFromMetadata,
+  resetLayerZeroMetadataCache,
+} from './layerZeroMetadata';
 
-describe('getLayerZeroNativeTokenStatus', () => {
-  beforeEach(async () => {
-    vi.restoreAllMocks();
-    vi.resetModules();
+// Trimmed-metadata shape returned by /api/layerzero-metadata, using real addresses.
+const ENA_L1 = '0x57e114b691db790c35207b2e685d4a43181e6061';
+const ENA_ARB = '0x58538e6a46e07434d7e7375bc268d3cb839c0133';
+const USDC_L1 = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const USDC_E_ARB = '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8';
+const USDC_NATIVE_ARB = '0xaf88d065e77c8cc2239327c5edb3a432268e5831';
 
-    // Import everything from the same freshly-reset module instance so the
-    // module-level cache is shared across the helpers under test.
-    ({
-      getLayerZeroNativeTokenStatus,
-      getLayerZeroNativeTokenStatusFromMetadata,
-      resetLayerZeroMetadataCache,
-    } = await import('./layerZeroMetadata'));
+const metadata = {
+  ethereum: {
+    chainDetails: { nativeChainId: 1 },
+    tokens: {
+      [ENA_L1]: {}, // native ENA (no peggedTo)
+      [USDC_L1]: {}, // native USDC
+    },
+  },
+  arbitrum: {
+    chainDetails: { nativeChainId: 42161 },
+    tokens: {
+      [ENA_ARB]: { peggedTo: { address: ENA_L1, chainName: 'ethereum' } },
+      [USDC_E_ARB]: { peggedTo: { address: USDC_L1, chainName: 'ethereum' } },
+      [USDC_NATIVE_ARB]: { peggedTo: { address: USDC_L1, chainName: 'ethereum' } },
+    },
+  },
+};
 
-    resetLayerZeroMetadataCache();
-  });
+beforeEach(() => {
+  vi.restoreAllMocks();
+  resetLayerZeroMetadataCache();
+});
 
-  it('returns true for a native OFT token on the matching chain', () => {
+describe('getLayerZeroOftInfoFromMetadata', () => {
+  it('reports a token that is not in the metadata as not OFT', () => {
     expect(
-      getLayerZeroNativeTokenStatusFromMetadata(
-        {
-          ethereum: {
-            chainDetails: { nativeChainId: 1 },
-            tokens: {
-              '0x6c3ea9036406852006290770bedfcaba0e23a0e8': { type: 'NativeOFT' },
-            },
-          },
-        },
-        {
-          chainId: 1,
-          tokenAddress: '0x6C3EA9036406852006290770BEdFcAbA0e23A0e8',
-        },
-      ),
-    ).toBe(true);
-  });
-
-  it('returns null for a non-pegged ERC20 that uses an OFT Adapter (defers to on-chain check)', () => {
-    expect(
-      getLayerZeroNativeTokenStatusFromMetadata(
-        {
-          ethereum: {
-            chainDetails: { nativeChainId: 1 },
-            tokens: {
-              // e.g. SUSHI — listed in metadata but the token itself is not an
-              // OFT, so it must not be classified as a native OFT.
-              '0x6b3595068778dd592e39a122f4f5a5cf09c90fe2': {
-                type: 'ERC20',
-                proxyAddresses: ['0x0000000000000000000000000000000000000001'],
-              },
-            },
-          },
-        },
-        {
-          chainId: 1,
-          tokenAddress: '0x6B3595068778DD592e39A122f4f5a5cf09C90fE2',
-        },
-      ),
-    ).toBeNull();
-  });
-
-  it('returns false for a non-native OFT representation token', () => {
-    expect(
-      getLayerZeroNativeTokenStatusFromMetadata(
-        {
-          arbitrum: {
-            chainDetails: { nativeChainId: 42161 },
-            tokens: {
-              '0x46850ad61c2b7d64d08c9c754f45254596696984': {
-                peggedTo: {
-                  eid: 30101,
-                  address: '0x6c3ea9036406852006290770bedfcaba0e23a0e8',
-                },
-              },
-            },
-          },
-        },
-        {
-          chainId: 42161,
-          tokenAddress: '0x46850AD61C2b7D64d08C9C754F45254596696984',
-        },
-      ),
-    ).toBe(false);
-  });
-
-  it('returns null when the token is not present in metadata', () => {
-    expect(
-      getLayerZeroNativeTokenStatusFromMetadata(
-        {
-          ethereum: {
-            chainDetails: { nativeChainId: 1 },
-            tokens: {},
-          },
-        },
-        {
-          chainId: 1,
-          tokenAddress: '0x6C3EA9036406852006290770BEdFcAbA0e23A0e8',
-        },
-      ),
-    ).toBeNull();
-  });
-
-  it('caches the metadata response', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        ethereum: {
-          chainDetails: { nativeChainId: 1 },
-          tokens: {
-            '0x6c3ea9036406852006290770bedfcaba0e23a0e8': {},
-          },
-        },
+      getLayerZeroOftInfoFromMetadata(metadata, {
+        parentChainId: 1,
+        parentTokenAddress: '0x1111111111111111111111111111111111111111',
+        childChainId: 42161,
       }),
-    } as Response);
-
-    await getLayerZeroNativeTokenStatus({
-      chainId: 1,
-      tokenAddress: '0x6C3EA9036406852006290770BEdFcAbA0e23A0e8',
-    });
-    await getLayerZeroNativeTokenStatus({
-      chainId: 1,
-      tokenAddress: '0x6C3EA9036406852006290770BEdFcAbA0e23A0e8',
-    });
-
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    ).toEqual({ isOft: false, childTokenAddresses: [] });
   });
 
-  it('retries the fetch after a failed response instead of caching the failure', async () => {
-    // Local counter rather than the spy's call count, which can carry over
-    // from a previous test's `vi.spyOn(globalThis, 'fetch')`.
+  it('finds the single child deployment of a native OFT (ENA)', () => {
+    expect(
+      getLayerZeroOftInfoFromMetadata(metadata, {
+        parentChainId: 1,
+        parentTokenAddress: ENA_L1,
+        childChainId: 42161,
+      }),
+    ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
+  });
+
+  it('finds every child deployment linked to the same native token (USDC)', () => {
+    const { isOft, childTokenAddresses } = getLayerZeroOftInfoFromMetadata(metadata, {
+      parentChainId: 1,
+      parentTokenAddress: USDC_L1,
+      childChainId: 42161,
+    });
+
+    expect(isOft).toBe(true);
+    expect([...childTokenAddresses].sort()).toEqual([USDC_NATIVE_ARB, USDC_E_ARB].sort());
+  });
+
+  it('matches the parent token case-insensitively', () => {
+    expect(
+      getLayerZeroOftInfoFromMetadata(metadata, {
+        parentChainId: 1,
+        parentTokenAddress: '0x57E114B691DB790C35207B2E685D4A43181E6061',
+        childChainId: 42161,
+      }),
+    ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
+  });
+
+  it('reports OFT with no child deployments when the destination chain is unknown', () => {
+    expect(
+      getLayerZeroOftInfoFromMetadata(metadata, {
+        parentChainId: 1,
+        parentTokenAddress: ENA_L1,
+        childChainId: 999999, // not in metadata
+      }),
+    ).toEqual({ isOft: true, childTokenAddresses: [] });
+  });
+
+  it('resolves the native root when the parent token is itself a representation', () => {
+    // parent = ENA on Arbitrum (pegged to ethereum), child = ethereum → the root token itself
+    expect(
+      getLayerZeroOftInfoFromMetadata(metadata, {
+        parentChainId: 42161,
+        parentTokenAddress: ENA_ARB,
+        childChainId: 1,
+      }),
+    ).toEqual({ isOft: true, childTokenAddresses: [ENA_L1] });
+  });
+});
+
+describe('getLayerZeroOftInfo (cached fetch)', () => {
+  it('caches the metadata response across calls', async () => {
+    resetLayerZeroMetadataCache();
+    // Local counter rather than the spy's call count, which can carry over from
+    // another test's `vi.spyOn(globalThis, 'fetch')`.
     let fetchCallCount = 0;
     vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
       fetchCallCount += 1;
+      return { ok: true, json: async () => metadata } as Response;
+    });
 
+    await getLayerZeroOftInfo({
+      parentChainId: 1,
+      parentTokenAddress: ENA_L1,
+      childChainId: 42161,
+    });
+    await getLayerZeroOftInfo({
+      parentChainId: 1,
+      parentTokenAddress: USDC_L1,
+      childChainId: 42161,
+    });
+
+    expect(fetchCallCount).toBe(1);
+  });
+
+  it('retries the fetch after a failed response instead of caching the failure', async () => {
+    resetLayerZeroMetadataCache();
+    let fetchCallCount = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      fetchCallCount += 1;
       if (fetchCallCount === 1) {
         return { ok: false } as Response;
       }
-
-      return {
-        ok: true,
-        json: async () => ({
-          ethereum: {
-            chainDetails: { nativeChainId: 1 },
-            tokens: {
-              '0x6c3ea9036406852006290770bedfcaba0e23a0e8': { type: 'NativeOFT' },
-            },
-          },
-        }),
-      } as Response;
+      return { ok: true, json: async () => metadata } as Response;
     });
 
-    const first = await getLayerZeroNativeTokenStatus({
-      chainId: 1,
-      tokenAddress: '0x6C3EA9036406852006290770BEdFcAbA0e23A0e8',
+    const first = await getLayerZeroOftInfo({
+      parentChainId: 1,
+      parentTokenAddress: ENA_L1,
+      childChainId: 42161,
     });
-    const second = await getLayerZeroNativeTokenStatus({
-      chainId: 1,
-      tokenAddress: '0x6C3EA9036406852006290770BEdFcAbA0e23A0e8',
+    const second = await getLayerZeroOftInfo({
+      parentChainId: 1,
+      parentTokenAddress: ENA_L1,
+      childChainId: 42161,
     });
 
-    expect(first).toBeNull();
-    expect(second).toBe(true);
+    expect(first).toEqual({ isOft: false, childTokenAddresses: [] }); // null metadata → not found
+    expect(second).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
     expect(fetchCallCount).toBe(2);
   });
 });

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
@@ -37,72 +37,63 @@ beforeEach(() => {
 });
 
 describe('getLayerZeroOftInfoFromMetadata', () => {
-  it('reports a token that is not in the metadata as not OFT', () => {
-    expect(
-      getLayerZeroOftInfoFromMetadata(metadata, {
-        parentChainId: 1,
-        parentTokenAddress: '0x1111111111111111111111111111111111111111',
-        childChainId: 42161,
-      }),
-    ).toEqual({ isOft: false, childTokenAddresses: [] });
-  });
-
-  it('finds the single child deployment of a native OFT (ENA)', () => {
-    expect(
-      getLayerZeroOftInfoFromMetadata(metadata, {
-        parentChainId: 1,
-        parentTokenAddress: ENA_L1,
-        childChainId: 42161,
-      }),
-    ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
-  });
-
-  it('finds every child deployment linked to the same native token (USDC)', () => {
-    const { isOft, childTokenAddresses } = getLayerZeroOftInfoFromMetadata(metadata, {
-      parentChainId: 1,
-      parentTokenAddress: USDC_L1,
-      childChainId: 42161,
+  describe('valid metadata', () => {
+    it('reports a token that is not in the metadata as not OFT', () => {
+      expect(
+        getLayerZeroOftInfoFromMetadata(metadata, {
+          parentChainId: 1,
+          parentTokenAddress: '0x1111111111111111111111111111111111111111',
+          childChainId: 42161,
+        }),
+      ).toEqual({ isOft: false, childTokenAddresses: [] });
     });
 
-    expect(isOft).toBe(true);
-    expect([...childTokenAddresses].sort()).toEqual([USDC_NATIVE_ARB, USDC_E_ARB].sort());
-  });
-
-  it('matches the parent token case-insensitively', () => {
-    expect(
-      getLayerZeroOftInfoFromMetadata(metadata, {
+    it('finds every child deployment linked to the same native token', () => {
+      const { isOft, childTokenAddresses } = getLayerZeroOftInfoFromMetadata(metadata, {
         parentChainId: 1,
-        parentTokenAddress: '0x57E114B691DB790C35207B2E685D4A43181E6061',
+        parentTokenAddress: USDC_L1,
         childChainId: 42161,
-      }),
-    ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
-  });
+      });
 
-  it('reports OFT with no child deployments when the destination chain is unknown', () => {
-    expect(
-      getLayerZeroOftInfoFromMetadata(metadata, {
-        parentChainId: 1,
-        parentTokenAddress: ENA_L1,
-        childChainId: 999999, // not in metadata
-      }),
-    ).toEqual({ isOft: true, childTokenAddresses: [] });
-  });
+      expect(isOft).toBe(true);
+      expect([...childTokenAddresses].sort()).toEqual([USDC_NATIVE_ARB, USDC_E_ARB].sort());
+    });
 
-  it('resolves the native root when the parent token is itself a representation', () => {
-    // parent = ENA on Arbitrum (pegged to ethereum), child = ethereum → the root token itself
-    expect(
-      getLayerZeroOftInfoFromMetadata(metadata, {
-        parentChainId: 42161,
-        parentTokenAddress: ENA_ARB,
-        childChainId: 1,
-      }),
-    ).toEqual({ isOft: true, childTokenAddresses: [ENA_L1] });
+    it('matches the parent token case-insensitively', () => {
+      expect(
+        getLayerZeroOftInfoFromMetadata(metadata, {
+          parentChainId: 1,
+          parentTokenAddress: ENA_L1.toUpperCase().replace('0X', '0x'),
+          childChainId: 42161,
+        }),
+      ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
+    });
+
+    it('reports OFT with no child deployments when the destination chain is unknown', () => {
+      expect(
+        getLayerZeroOftInfoFromMetadata(metadata, {
+          parentChainId: 1,
+          parentTokenAddress: ENA_L1,
+          childChainId: 999999, // not in metadata
+        }),
+      ).toEqual({ isOft: true, childTokenAddresses: [] });
+    });
+
+    it('resolves the native root when the parent token is itself a representation', () => {
+      // parent = ENA on Arbitrum (pegged to ethereum), child = ethereum → the root token itself
+      expect(
+        getLayerZeroOftInfoFromMetadata(metadata, {
+          parentChainId: 42161,
+          parentTokenAddress: ENA_ARB,
+          childChainId: 1,
+        }),
+      ).toEqual({ isOft: true, childTokenAddresses: [ENA_L1] });
+    });
   });
 
   // The metadata is untrusted external JSON, so malformed shapes must be tolerated.
-  it.each([null, undefined, 42, 'not-an-object', []])(
-    'treats malformed metadata (%p) as not OFT',
-    (badMetadata) => {
+  describe('malformed metadata', () => {
+    it.each([null, undefined, 42, 'not-an-object', []])('treats %p as not OFT', (badMetadata) => {
       expect(
         getLayerZeroOftInfoFromMetadata(badMetadata, {
           parentChainId: 1,
@@ -110,58 +101,59 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
           childChainId: 42161,
         }),
       ).toEqual({ isOft: false, childTokenAddresses: [] });
-    },
-  );
+    });
 
-  it('matches chains whose nativeChainId is a numeric string', () => {
-    expect(
-      getLayerZeroOftInfoFromMetadata(
-        {
-          ethereum: { chainDetails: { nativeChainId: '1' }, tokens: { [ENA_L1]: {} } },
-          arbitrum: {
-            chainDetails: { nativeChainId: '42161' },
-            tokens: { [ENA_ARB]: { peggedTo: { address: ENA_L1, chainName: 'ethereum' } } },
-          },
-        },
-        { parentChainId: 1, parentTokenAddress: ENA_L1, childChainId: 42161 },
-      ),
-    ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
-  });
-
-  it('ignores chains with missing or invalid chainDetails', () => {
-    expect(
-      getLayerZeroOftInfoFromMetadata(
-        { ethereum: { tokens: { [ENA_L1]: {} } } }, // no chainDetails
-        { parentChainId: 1, parentTokenAddress: ENA_L1, childChainId: 42161 },
-      ),
-    ).toEqual({ isOft: false, childTokenAddresses: [] });
-  });
-
-  it('skips malformed token entries and incomplete pegged links on the child chain', () => {
-    expect(
-      getLayerZeroOftInfoFromMetadata(
-        {
-          ethereum: { chainDetails: { nativeChainId: 1 }, tokens: { [ENA_L1]: {} } },
-          arbitrum: {
-            chainDetails: { nativeChainId: 42161 },
-            tokens: {
-              [ENA_ARB]: { peggedTo: { address: ENA_L1, chainName: 'ethereum' } },
-              '0x000000000000000000000000000000000000dead': null, // malformed entry
-              '0x000000000000000000000000000000000000beef': { peggedTo: { address: ENA_L1 } }, // missing chainName
+    it('matches chains whose nativeChainId is a numeric string', () => {
+      expect(
+        getLayerZeroOftInfoFromMetadata(
+          {
+            ethereum: { chainDetails: { nativeChainId: '1' }, tokens: { [ENA_L1]: {} } },
+            arbitrum: {
+              chainDetails: { nativeChainId: '42161' },
+              tokens: { [ENA_ARB]: { peggedTo: { address: ENA_L1, chainName: 'ethereum' } } },
             },
           },
-        },
-        { parentChainId: 1, parentTokenAddress: ENA_L1, childChainId: 42161 },
-      ),
-    ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
+          { parentChainId: 1, parentTokenAddress: ENA_L1, childChainId: 42161 },
+        ),
+      ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
+    });
+
+    it('ignores chains with missing or invalid chainDetails', () => {
+      expect(
+        getLayerZeroOftInfoFromMetadata(
+          { ethereum: { tokens: { [ENA_L1]: {} } } }, // no chainDetails
+          { parentChainId: 1, parentTokenAddress: ENA_L1, childChainId: 42161 },
+        ),
+      ).toEqual({ isOft: false, childTokenAddresses: [] });
+    });
+
+    it('skips malformed token entries and incomplete pegged links on the child chain', () => {
+      expect(
+        getLayerZeroOftInfoFromMetadata(
+          {
+            ethereum: { chainDetails: { nativeChainId: 1 }, tokens: { [ENA_L1]: {} } },
+            arbitrum: {
+              chainDetails: { nativeChainId: 42161 },
+              tokens: {
+                [ENA_ARB]: { peggedTo: { address: ENA_L1, chainName: 'ethereum' } },
+                '0x000000000000000000000000000000000000dead': null, // malformed entry
+                '0x000000000000000000000000000000000000beef': { peggedTo: { address: ENA_L1 } }, // missing chainName
+              },
+            },
+          },
+          { parentChainId: 1, parentTokenAddress: ENA_L1, childChainId: 42161 },
+        ),
+      ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
+    });
   });
 });
 
-describe('getLayerZeroOftInfo (cached fetch)', () => {
-  it('caches the metadata response across calls', async () => {
-    resetLayerZeroMetadataCache();
-    // Local counter rather than the spy's call count, which can carry over from
-    // another test's `vi.spyOn(globalThis, 'fetch')`.
+// Sequential: these share the module-level metadata cache, so they must not run
+// concurrently (the suite runs tests concurrently by default).
+describe.sequential('getLayerZeroOftInfo (fetch + cache)', () => {
+  // Local fetch counter rather than the spy's call count, which can carry over
+  // from another test's `vi.spyOn(globalThis, 'fetch')`.
+  it('fetches once and caches the response across calls', async () => {
     let fetchCallCount = 0;
     vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
       fetchCallCount += 1;
@@ -183,7 +175,6 @@ describe('getLayerZeroOftInfo (cached fetch)', () => {
   });
 
   it('retries the fetch after a failed response instead of caching the failure', async () => {
-    resetLayerZeroMetadataCache();
     let fetchCallCount = 0;
     vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
       fetchCallCount += 1;

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getLayerZeroOftInfo,
   getLayerZeroOftInfoFromMetadata,
+  isKnownLayerZeroTokenFromMetadata,
   resetLayerZeroMetadataCache,
 } from './layerZeroMetadata';
 
@@ -196,6 +197,35 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
         hasOftChildDeployment: true,
       });
     });
+  });
+});
+
+describe('isKnownLayerZeroTokenFromMetadata', () => {
+  it('returns true for a token LayerZero lists on the chain', () => {
+    expect(
+      isKnownLayerZeroTokenFromMetadata(metadata, {
+        chainId: CHILD_CHAIN_ID,
+        tokenAddress: NATIVE_TOKEN_ON_CHILD.toUpperCase().replace('0X', '0x'),
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for an address LayerZero does not list on the chain', () => {
+    expect(
+      isKnownLayerZeroTokenFromMetadata(metadata, {
+        chainId: CHILD_CHAIN_ID,
+        tokenAddress: UNLISTED_TOKEN,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when the chain is not in the metadata', () => {
+    expect(
+      isKnownLayerZeroTokenFromMetadata(metadata, {
+        chainId: 999999,
+        tokenAddress: NATIVE_TOKEN_ON_CHILD,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
@@ -1,8 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getLayerZeroNativeTokenStatusFromMetadata } from './layerZeroMetadata';
-
 let getLayerZeroNativeTokenStatus: typeof import('./layerZeroMetadata').getLayerZeroNativeTokenStatus;
+let getLayerZeroNativeTokenStatusFromMetadata: typeof import('./layerZeroMetadata').getLayerZeroNativeTokenStatusFromMetadata;
 let resetLayerZeroMetadataCache: typeof import('./layerZeroMetadata').resetLayerZeroMetadataCache;
 
 describe('getLayerZeroNativeTokenStatus', () => {
@@ -10,9 +9,13 @@ describe('getLayerZeroNativeTokenStatus', () => {
     vi.restoreAllMocks();
     vi.resetModules();
 
-    ({ getLayerZeroNativeTokenStatus, resetLayerZeroMetadataCache } = await import(
-      './layerZeroMetadata'
-    ));
+    // Import every export from the same freshly-reset module instance so the
+    // module-level cache is consistent across the pure and cached helpers.
+    ({
+      getLayerZeroNativeTokenStatus,
+      getLayerZeroNativeTokenStatusFromMetadata,
+      resetLayerZeroMetadataCache,
+    } = await import('./layerZeroMetadata'));
 
     resetLayerZeroMetadataCache();
   });
@@ -24,7 +27,7 @@ describe('getLayerZeroNativeTokenStatus', () => {
           ethereum: {
             chainDetails: { nativeChainId: 1 },
             tokens: {
-              '0x6c3ea9036406852006290770bedfcaba0e23a0e8': {},
+              '0x6c3ea9036406852006290770bedfcaba0e23a0e8': { type: 'NativeOFT' },
             },
           },
         },
@@ -34,6 +37,30 @@ describe('getLayerZeroNativeTokenStatus', () => {
         },
       ),
     ).toBe(true);
+  });
+
+  it('returns null for a non-pegged ERC20 that uses an OFT Adapter (defers to on-chain check)', () => {
+    expect(
+      getLayerZeroNativeTokenStatusFromMetadata(
+        {
+          ethereum: {
+            chainDetails: { nativeChainId: 1 },
+            tokens: {
+              // e.g. SUSHI — listed in metadata but the token itself is not an
+              // OFT, so it must not be classified as a native OFT.
+              '0x6b3595068778dd592e39a122f4f5a5cf09c90fe2': {
+                type: 'ERC20',
+                proxyAddresses: ['0x0000000000000000000000000000000000000001'],
+              },
+            },
+          },
+        },
+        {
+          chainId: 1,
+          tokenAddress: '0x6B3595068778DD592e39A122f4f5a5cf09C90fE2',
+        },
+      ),
+    ).toBeNull();
   });
 
   it('returns false for a non-native OFT representation token', () => {
@@ -100,5 +127,43 @@ describe('getLayerZeroNativeTokenStatus', () => {
     });
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries the fetch after a failed response instead of caching the failure', async () => {
+    // Local counter rather than the spy's call count, which can carry over
+    // from a previous test's `vi.spyOn(globalThis, 'fetch')`.
+    let fetchCallCount = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      fetchCallCount += 1;
+
+      if (fetchCallCount === 1) {
+        return { ok: false } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          ethereum: {
+            chainDetails: { nativeChainId: 1 },
+            tokens: {
+              '0x6c3ea9036406852006290770bedfcaba0e23a0e8': { type: 'NativeOFT' },
+            },
+          },
+        }),
+      } as Response;
+    });
+
+    const first = await getLayerZeroNativeTokenStatus({
+      chainId: 1,
+      tokenAddress: '0x6C3EA9036406852006290770BEdFcAbA0e23A0e8',
+    });
+    const second = await getLayerZeroNativeTokenStatus({
+      chainId: 1,
+      tokenAddress: '0x6C3EA9036406852006290770BEdFcAbA0e23A0e8',
+    });
+
+    expect(first).toBeNull();
+    expect(second).toBe(true);
+    expect(fetchCallCount).toBe(2);
   });
 });

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
@@ -6,9 +6,10 @@ import {
   resetLayerZeroMetadataCache,
 } from './layerZeroMetadata';
 
-// Synthetic trimmed-metadata fixtures — these exercise the parsing/root-linking
-// logic against controlled input. Real-token, live-network behavior is covered
-// in layerZeroMetadata.integration.test.ts.
+// Synthetic trimmed-metadata fixtures (the shape produced by trimLayerZeroMetadata:
+// keyed by chain id, with the LayerZero chainKey + tokens). These exercise the
+// parsing/root-linking logic; real-token, live-network behavior is covered in
+// layerZeroMetadata.integration.test.ts.
 const PARENT_CHAIN_ID = 111;
 const CHILD_CHAIN_ID = 222;
 
@@ -20,15 +21,15 @@ const MULTI_TOKEN_ON_CHILD_2 = '0x00000000000000000000000000000000000000b3';
 const UNLISTED_TOKEN = '0x00000000000000000000000000000000000000ff';
 
 const metadata = {
-  parent: {
-    chainDetails: { nativeChainId: PARENT_CHAIN_ID },
+  [PARENT_CHAIN_ID]: {
+    chainKey: 'parent',
     tokens: {
       [NATIVE_TOKEN]: {}, // no peggedTo → native/home token
       [MULTI_TOKEN]: {},
     },
   },
-  child: {
-    chainDetails: { nativeChainId: CHILD_CHAIN_ID },
+  [CHILD_CHAIN_ID]: {
+    chainKey: 'child',
     tokens: {
       [NATIVE_TOKEN_ON_CHILD]: { peggedTo: { address: NATIVE_TOKEN, chainName: 'parent' } },
       [MULTI_TOKEN_ON_CHILD_1]: { peggedTo: { address: MULTI_TOKEN, chainName: 'parent' } },
@@ -111,33 +112,10 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
       ).toEqual({ isOft: false, childTokenAddresses: [] });
     });
 
-    it('matches chains whose nativeChainId is a numeric string', () => {
+    it('ignores a chain entry that is missing its chainKey', () => {
       expect(
         getLayerZeroOftInfoFromMetadata(
-          {
-            parent: { chainDetails: { nativeChainId: '111' }, tokens: { [NATIVE_TOKEN]: {} } },
-            child: {
-              chainDetails: { nativeChainId: '222' },
-              tokens: {
-                [NATIVE_TOKEN_ON_CHILD]: {
-                  peggedTo: { address: NATIVE_TOKEN, chainName: 'parent' },
-                },
-              },
-            },
-          },
-          {
-            parentChainId: PARENT_CHAIN_ID,
-            parentTokenAddress: NATIVE_TOKEN,
-            childChainId: CHILD_CHAIN_ID,
-          },
-        ),
-      ).toEqual({ isOft: true, childTokenAddresses: [NATIVE_TOKEN_ON_CHILD] });
-    });
-
-    it('ignores chains with missing or invalid chainDetails', () => {
-      expect(
-        getLayerZeroOftInfoFromMetadata(
-          { parent: { tokens: { [NATIVE_TOKEN]: {} } } }, // no chainDetails
+          { [PARENT_CHAIN_ID]: { tokens: { [NATIVE_TOKEN]: {} } } }, // no chainKey
           {
             parentChainId: PARENT_CHAIN_ID,
             parentTokenAddress: NATIVE_TOKEN,
@@ -151,12 +129,9 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
       expect(
         getLayerZeroOftInfoFromMetadata(
           {
-            parent: {
-              chainDetails: { nativeChainId: PARENT_CHAIN_ID },
-              tokens: { [NATIVE_TOKEN]: {} },
-            },
-            child: {
-              chainDetails: { nativeChainId: CHILD_CHAIN_ID },
+            [PARENT_CHAIN_ID]: { chainKey: 'parent', tokens: { [NATIVE_TOKEN]: {} } },
+            [CHILD_CHAIN_ID]: {
+              chainKey: 'child',
               tokens: {
                 [NATIVE_TOKEN_ON_CHILD]: {
                   peggedTo: { address: NATIVE_TOKEN, chainName: 'parent' },

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
@@ -98,6 +98,63 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
       }),
     ).toEqual({ isOft: true, childTokenAddresses: [ENA_L1] });
   });
+
+  // The metadata is untrusted external JSON, so malformed shapes must be tolerated.
+  it.each([null, undefined, 42, 'not-an-object', []])(
+    'treats malformed metadata (%p) as not OFT',
+    (badMetadata) => {
+      expect(
+        getLayerZeroOftInfoFromMetadata(badMetadata, {
+          parentChainId: 1,
+          parentTokenAddress: ENA_L1,
+          childChainId: 42161,
+        }),
+      ).toEqual({ isOft: false, childTokenAddresses: [] });
+    },
+  );
+
+  it('matches chains whose nativeChainId is a numeric string', () => {
+    expect(
+      getLayerZeroOftInfoFromMetadata(
+        {
+          ethereum: { chainDetails: { nativeChainId: '1' }, tokens: { [ENA_L1]: {} } },
+          arbitrum: {
+            chainDetails: { nativeChainId: '42161' },
+            tokens: { [ENA_ARB]: { peggedTo: { address: ENA_L1, chainName: 'ethereum' } } },
+          },
+        },
+        { parentChainId: 1, parentTokenAddress: ENA_L1, childChainId: 42161 },
+      ),
+    ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
+  });
+
+  it('ignores chains with missing or invalid chainDetails', () => {
+    expect(
+      getLayerZeroOftInfoFromMetadata(
+        { ethereum: { tokens: { [ENA_L1]: {} } } }, // no chainDetails
+        { parentChainId: 1, parentTokenAddress: ENA_L1, childChainId: 42161 },
+      ),
+    ).toEqual({ isOft: false, childTokenAddresses: [] });
+  });
+
+  it('skips malformed token entries and incomplete pegged links on the child chain', () => {
+    expect(
+      getLayerZeroOftInfoFromMetadata(
+        {
+          ethereum: { chainDetails: { nativeChainId: 1 }, tokens: { [ENA_L1]: {} } },
+          arbitrum: {
+            chainDetails: { nativeChainId: 42161 },
+            tokens: {
+              [ENA_ARB]: { peggedTo: { address: ENA_L1, chainName: 'ethereum' } },
+              '0x000000000000000000000000000000000000dead': null, // malformed entry
+              '0x000000000000000000000000000000000000beef': { peggedTo: { address: ENA_L1 } }, // missing chainName
+            },
+          },
+        },
+        { parentChainId: 1, parentTokenAddress: ENA_L1, childChainId: 42161 },
+      ),
+    ).toEqual({ isOft: true, childTokenAddresses: [ENA_ARB] });
+  });
 });
 
 describe('getLayerZeroOftInfo (cached fetch)', () => {

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.test.ts
@@ -7,9 +7,9 @@ import {
 } from './layerZeroMetadata';
 
 // Synthetic trimmed-metadata fixtures (the shape produced by trimLayerZeroMetadata:
-// keyed by chain id, with the LayerZero chainKey + tokens). These exercise the
-// parsing/root-linking logic; real-token, live-network behavior is covered in
-// layerZeroMetadata.integration.test.ts.
+// keyed by chain id, with the LayerZero chainKey + tokens carrying an `isOft` flag
+// and optional `peggedTo`). These exercise the parsing/root-linking logic; real-token,
+// live-network behavior is covered in layerZeroMetadata.integration.test.ts.
 const PARENT_CHAIN_ID = 111;
 const CHILD_CHAIN_ID = 222;
 
@@ -18,22 +18,38 @@ const NATIVE_TOKEN_ON_CHILD = '0x00000000000000000000000000000000000000b1';
 const MULTI_TOKEN = '0x00000000000000000000000000000000000000a2'; // native, with 2 child deployments
 const MULTI_TOKEN_ON_CHILD_1 = '0x00000000000000000000000000000000000000b2';
 const MULTI_TOKEN_ON_CHILD_2 = '0x00000000000000000000000000000000000000b3';
+const ERC20_TOKEN = '0x00000000000000000000000000000000000000a3'; // tracked by LZ but not an OFT
+const ERC20_TOKEN_ON_CHILD = '0x00000000000000000000000000000000000000b4';
 const UNLISTED_TOKEN = '0x00000000000000000000000000000000000000ff';
 
 const metadata = {
   [PARENT_CHAIN_ID]: {
     chainKey: 'parent',
     tokens: {
-      [NATIVE_TOKEN]: {}, // no peggedTo → native/home token
-      [MULTI_TOKEN]: {},
+      [NATIVE_TOKEN]: { isOft: true }, // no peggedTo → native/home token
+      [MULTI_TOKEN]: { isOft: true },
+      [ERC20_TOKEN]: { isOft: false },
     },
   },
   [CHILD_CHAIN_ID]: {
     chainKey: 'child',
     tokens: {
-      [NATIVE_TOKEN_ON_CHILD]: { peggedTo: { address: NATIVE_TOKEN, chainName: 'parent' } },
-      [MULTI_TOKEN_ON_CHILD_1]: { peggedTo: { address: MULTI_TOKEN, chainName: 'parent' } },
-      [MULTI_TOKEN_ON_CHILD_2]: { peggedTo: { address: MULTI_TOKEN, chainName: 'parent' } },
+      [NATIVE_TOKEN_ON_CHILD]: {
+        isOft: true,
+        peggedTo: { address: NATIVE_TOKEN, chainName: 'parent' },
+      },
+      [MULTI_TOKEN_ON_CHILD_1]: {
+        isOft: true,
+        peggedTo: { address: MULTI_TOKEN, chainName: 'parent' },
+      },
+      [MULTI_TOKEN_ON_CHILD_2]: {
+        isOft: true,
+        peggedTo: { address: MULTI_TOKEN, chainName: 'parent' },
+      },
+      [ERC20_TOKEN_ON_CHILD]: {
+        isOft: false,
+        peggedTo: { address: ERC20_TOKEN, chainName: 'parent' },
+      },
     },
   },
 };
@@ -52,20 +68,38 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
           parentTokenAddress: UNLISTED_TOKEN,
           childChainId: CHILD_CHAIN_ID,
         }),
-      ).toEqual({ isOft: false, childTokenAddresses: [] });
+      ).toEqual({ isOft: false, childTokenAddresses: [], hasOftChildDeployment: false });
     });
 
     it('finds every child deployment linked to the same native token', () => {
-      const { isOft, childTokenAddresses } = getLayerZeroOftInfoFromMetadata(metadata, {
-        parentChainId: PARENT_CHAIN_ID,
-        parentTokenAddress: MULTI_TOKEN,
-        childChainId: CHILD_CHAIN_ID,
-      });
+      const { isOft, childTokenAddresses, hasOftChildDeployment } = getLayerZeroOftInfoFromMetadata(
+        metadata,
+        {
+          parentChainId: PARENT_CHAIN_ID,
+          parentTokenAddress: MULTI_TOKEN,
+          childChainId: CHILD_CHAIN_ID,
+        },
+      );
 
       expect(isOft).toBe(true);
+      expect(hasOftChildDeployment).toBe(true);
       expect([...childTokenAddresses].sort()).toEqual(
         [MULTI_TOKEN_ON_CHILD_1, MULTI_TOKEN_ON_CHILD_2].sort(),
       );
+    });
+
+    it('reports hasOftChildDeployment false when the only child rep is a plain ERC20', () => {
+      expect(
+        getLayerZeroOftInfoFromMetadata(metadata, {
+          parentChainId: PARENT_CHAIN_ID,
+          parentTokenAddress: ERC20_TOKEN,
+          childChainId: CHILD_CHAIN_ID,
+        }),
+      ).toEqual({
+        isOft: true,
+        childTokenAddresses: [ERC20_TOKEN_ON_CHILD],
+        hasOftChildDeployment: false,
+      });
     });
 
     it('matches the parent token case-insensitively', () => {
@@ -75,7 +109,11 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
           parentTokenAddress: NATIVE_TOKEN.toUpperCase().replace('0X', '0x'),
           childChainId: CHILD_CHAIN_ID,
         }),
-      ).toEqual({ isOft: true, childTokenAddresses: [NATIVE_TOKEN_ON_CHILD] });
+      ).toEqual({
+        isOft: true,
+        childTokenAddresses: [NATIVE_TOKEN_ON_CHILD],
+        hasOftChildDeployment: true,
+      });
     });
 
     it('reports OFT with no child deployments when the destination chain is unknown', () => {
@@ -85,7 +123,7 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
           parentTokenAddress: NATIVE_TOKEN,
           childChainId: 999999, // not in metadata
         }),
-      ).toEqual({ isOft: true, childTokenAddresses: [] });
+      ).toEqual({ isOft: true, childTokenAddresses: [], hasOftChildDeployment: false });
     });
 
     it('resolves the native root when the parent token is itself a representation', () => {
@@ -96,7 +134,11 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
           parentTokenAddress: NATIVE_TOKEN_ON_CHILD,
           childChainId: PARENT_CHAIN_ID,
         }),
-      ).toEqual({ isOft: true, childTokenAddresses: [NATIVE_TOKEN] });
+      ).toEqual({
+        isOft: true,
+        childTokenAddresses: [NATIVE_TOKEN],
+        hasOftChildDeployment: true,
+      });
     });
   });
 
@@ -109,31 +151,32 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
           parentTokenAddress: NATIVE_TOKEN,
           childChainId: CHILD_CHAIN_ID,
         }),
-      ).toEqual({ isOft: false, childTokenAddresses: [] });
+      ).toEqual({ isOft: false, childTokenAddresses: [], hasOftChildDeployment: false });
     });
 
     it('ignores a chain entry that is missing its chainKey', () => {
       expect(
         getLayerZeroOftInfoFromMetadata(
-          { [PARENT_CHAIN_ID]: { tokens: { [NATIVE_TOKEN]: {} } } }, // no chainKey
+          { [PARENT_CHAIN_ID]: { tokens: { [NATIVE_TOKEN]: { isOft: true } } } }, // no chainKey
           {
             parentChainId: PARENT_CHAIN_ID,
             parentTokenAddress: NATIVE_TOKEN,
             childChainId: CHILD_CHAIN_ID,
           },
         ),
-      ).toEqual({ isOft: false, childTokenAddresses: [] });
+      ).toEqual({ isOft: false, childTokenAddresses: [], hasOftChildDeployment: false });
     });
 
     it('skips malformed token entries and incomplete pegged links on the child chain', () => {
       expect(
         getLayerZeroOftInfoFromMetadata(
           {
-            [PARENT_CHAIN_ID]: { chainKey: 'parent', tokens: { [NATIVE_TOKEN]: {} } },
+            [PARENT_CHAIN_ID]: { chainKey: 'parent', tokens: { [NATIVE_TOKEN]: { isOft: true } } },
             [CHILD_CHAIN_ID]: {
               chainKey: 'child',
               tokens: {
                 [NATIVE_TOKEN_ON_CHILD]: {
+                  isOft: true,
                   peggedTo: { address: NATIVE_TOKEN, chainName: 'parent' },
                 },
                 [MULTI_TOKEN_ON_CHILD_1]: null, // malformed entry
@@ -147,7 +190,11 @@ describe('getLayerZeroOftInfoFromMetadata', () => {
             childChainId: CHILD_CHAIN_ID,
           },
         ),
-      ).toEqual({ isOft: true, childTokenAddresses: [NATIVE_TOKEN_ON_CHILD] });
+      ).toEqual({
+        isOft: true,
+        childTokenAddresses: [NATIVE_TOKEN_ON_CHILD],
+        hasOftChildDeployment: true,
+      });
     });
   });
 });
@@ -199,8 +246,12 @@ describe.sequential('getLayerZeroOftInfo (fetch + cache)', () => {
       childChainId: CHILD_CHAIN_ID,
     });
 
-    expect(first).toEqual({ isOft: false, childTokenAddresses: [] }); // null metadata → not found
-    expect(second).toEqual({ isOft: true, childTokenAddresses: [NATIVE_TOKEN_ON_CHILD] });
+    expect(first).toEqual({ isOft: false, childTokenAddresses: [], hasOftChildDeployment: false }); // null metadata → not found
+    expect(second).toEqual({
+      isOft: true,
+      childTokenAddresses: [NATIVE_TOKEN_ON_CHILD],
+      hasOftChildDeployment: true,
+    });
     expect(fetchCallCount).toBe(2);
   });
 });

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
@@ -1,6 +1,13 @@
 const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
 
+// LayerZero classifies a token whose own contract implements the OFT interface
+// (i.e. responds to `oftVersion()` on-chain) as `NativeOFT`. Plain ERC20s that
+// are bridged through a separate OFT Adapter are typed `ERC20` and do NOT
+// implement `oftVersion()` themselves, so they must not be treated as native OFTs.
+const LAYERZERO_NATIVE_OFT_TYPE = 'NativeOFT';
+
 type LayerZeroTokenMetadata = {
+  type?: unknown;
   peggedTo?: unknown;
 };
 
@@ -54,17 +61,10 @@ function getLayerZeroTokenMetadata(
     return null;
   }
 
-  const tokenAddressLowerCase = tokenAddress.toLowerCase();
+  // The metadata keys tokens by their lower-cased address, so look it up directly.
+  const tokenMetadata = chainMetadata.tokens[tokenAddress.toLowerCase()];
 
-  for (const [metadataTokenAddress, tokenMetadata] of Object.entries(chainMetadata.tokens)) {
-    if (metadataTokenAddress.toLowerCase() !== tokenAddressLowerCase || !isRecord(tokenMetadata)) {
-      continue;
-    }
-
-    return tokenMetadata;
-  }
-
-  return null;
+  return isRecord(tokenMetadata) ? tokenMetadata : null;
 }
 
 async function getLayerZeroMetadata() {
@@ -74,7 +74,15 @@ async function getLayerZeroMetadata() {
       .catch(() => null);
   }
 
-  return layerZeroMetadataPromise;
+  const metadata = await layerZeroMetadataPromise;
+
+  // Don't cache a failed/empty response — clear the cache so the next caller
+  // retries instead of being stuck with `null` for the rest of the session.
+  if (metadata === null) {
+    layerZeroMetadataPromise = null;
+  }
+
+  return metadata;
 }
 
 export async function getLayerZeroNativeTokenStatus({
@@ -107,7 +115,19 @@ export function getLayerZeroNativeTokenStatusFromMetadata(
     return null;
   }
 
-  return !tokenMetadata.peggedTo;
+  // A pegged token is a representation of an OFT that lives natively on another
+  // chain, so it is explicitly not a native OFT here.
+  if (tokenMetadata.peggedTo) {
+    return false;
+  }
+
+  // Only tokens whose own contract is the OFT count as native. Anything else
+  // (e.g. plain ERC20s using an OFT Adapter) is left to the on-chain fallback.
+  if (tokenMetadata.type === LAYERZERO_NATIVE_OFT_TYPE) {
+    return true;
+  }
+
+  return null;
 }
 
 export function resetLayerZeroMetadataCache() {

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
@@ -1,0 +1,115 @@
+const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
+
+type LayerZeroTokenMetadata = {
+  peggedTo?: unknown;
+};
+
+type LayerZeroChainMetadata = {
+  chainDetails?: {
+    nativeChainId?: unknown;
+  };
+  tokens?: Record<string, LayerZeroTokenMetadata>;
+};
+
+let layerZeroMetadataPromise: Promise<unknown> | null = null;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getLayerZeroChainMetadata(
+  metadata: unknown,
+  chainId: number,
+): LayerZeroChainMetadata | null {
+  if (!isRecord(metadata)) {
+    return null;
+  }
+
+  for (const chainMetadata of Object.values(metadata)) {
+    if (!isRecord(chainMetadata)) {
+      continue;
+    }
+
+    const chainDetails = chainMetadata.chainDetails;
+    if (!isRecord(chainDetails)) {
+      continue;
+    }
+
+    if (chainDetails.nativeChainId === chainId) {
+      return chainMetadata;
+    }
+  }
+
+  return null;
+}
+
+function getLayerZeroTokenMetadata(
+  metadata: unknown,
+  chainId: number,
+  tokenAddress: string,
+): LayerZeroTokenMetadata | null {
+  const chainMetadata = getLayerZeroChainMetadata(metadata, chainId);
+
+  if (!chainMetadata?.tokens || !isRecord(chainMetadata.tokens)) {
+    return null;
+  }
+
+  const tokenAddressLowerCase = tokenAddress.toLowerCase();
+
+  for (const [metadataTokenAddress, tokenMetadata] of Object.entries(chainMetadata.tokens)) {
+    if (metadataTokenAddress.toLowerCase() !== tokenAddressLowerCase || !isRecord(tokenMetadata)) {
+      continue;
+    }
+
+    return tokenMetadata;
+  }
+
+  return null;
+}
+
+async function getLayerZeroMetadata() {
+  if (!layerZeroMetadataPromise) {
+    layerZeroMetadataPromise = fetch(LAYERZERO_METADATA_URL)
+      .then((response) => (response.ok ? response.json() : null))
+      .catch(() => null);
+  }
+
+  return layerZeroMetadataPromise;
+}
+
+export async function getLayerZeroNativeTokenStatus({
+  chainId,
+  tokenAddress,
+}: {
+  chainId: number;
+  tokenAddress: string;
+}) {
+  const metadata = await getLayerZeroMetadata();
+  return getLayerZeroNativeTokenStatusFromMetadata(metadata, {
+    chainId,
+    tokenAddress,
+  });
+}
+
+export function getLayerZeroNativeTokenStatusFromMetadata(
+  metadata: unknown,
+  {
+    chainId,
+    tokenAddress,
+  }: {
+    chainId: number;
+    tokenAddress: string;
+  },
+) {
+  const tokenMetadata = getLayerZeroTokenMetadata(metadata, chainId, tokenAddress);
+
+  if (!tokenMetadata) {
+    return null;
+  }
+
+  return !tokenMetadata.peggedTo;
+}
+
+export function resetLayerZeroMetadataCache() {
+  layerZeroMetadataPromise = null;
+}

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
@@ -1,4 +1,5 @@
 import { getAPIBaseUrl } from '.';
+import { isRecord } from './isRecord';
 
 // Served by our own cached route handler (see app/api/layerzero-metadata) rather
 // than hitting the LayerZero API directly, so responses are cached server-side.
@@ -23,10 +24,6 @@ type LayerZeroChainMetadata = {
 };
 
 let layerZeroMetadataPromise: Promise<unknown> | null = null;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
 
 function getLayerZeroChainMetadata(
   metadata: unknown,

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
@@ -3,65 +3,108 @@ import { getAPIBaseUrl, isRecord } from '.';
 // Our own cached route handler, not the LayerZero API directly (see app/api/layerzero-metadata).
 const LAYERZERO_METADATA_URL = `${getAPIBaseUrl()}/api/layerzero-metadata`;
 
-// `NativeOFT` is a token whose own contract implements the OFT interface (responds to
-// `oftVersion()` on-chain). Plain ERC20s bridged via a separate OFT Adapter are typed
-// `ERC20` and don't, so they must not be treated as native OFTs.
-const LAYERZERO_NATIVE_OFT_TYPE = 'NativeOFT';
-
-type LayerZeroTokenMetadata = {
-  type?: unknown;
-  peggedTo?: unknown;
+type LayerZeroPeggedTo = {
+  address: string;
+  chainName: string;
 };
 
-type LayerZeroChainMetadata = {
-  chainDetails?: {
-    nativeChainId?: unknown;
-  };
-  tokens?: Record<string, LayerZeroTokenMetadata>;
+export type LayerZeroOftInfo = {
+  // Whether the token has a LayerZero OFT deployment on the parent chain.
+  isOft: boolean;
+  // Lower-cased addresses of the same token's OFT deployments on the child chain.
+  childTokenAddresses: string[];
 };
 
 let layerZeroMetadataPromise: Promise<unknown> | null = null;
 
-function getLayerZeroChainMetadata(
+// The chain + address a token is natively deployed on (its own address if native,
+// else its `peggedTo` target).
+type TokenRoot = LayerZeroPeggedTo;
+
+function getChainByNativeChainId(
   metadata: unknown,
   chainId: number,
-): LayerZeroChainMetadata | null {
+): { chainName: string; tokens: Record<string, unknown> } | null {
   if (!isRecord(metadata)) {
     return null;
   }
 
-  for (const chainMetadata of Object.values(metadata)) {
-    if (!isRecord(chainMetadata)) {
+  for (const [chainName, chainMetadata] of Object.entries(metadata)) {
+    if (!isRecord(chainMetadata) || !isRecord(chainMetadata.chainDetails)) {
       continue;
     }
 
-    const chainDetails = chainMetadata.chainDetails;
-    if (!isRecord(chainDetails)) {
-      continue;
-    }
-
-    if (Number(chainDetails.nativeChainId) === chainId) {
-      return chainMetadata;
+    if (Number(chainMetadata.chainDetails.nativeChainId) === chainId) {
+      return {
+        chainName,
+        tokens: isRecord(chainMetadata.tokens) ? chainMetadata.tokens : {},
+      };
     }
   }
 
   return null;
 }
 
-function getLayerZeroTokenMetadata(
-  metadata: unknown,
-  chainId: number,
-  tokenAddress: string,
-): LayerZeroTokenMetadata | null {
-  const chainMetadata = getLayerZeroChainMetadata(metadata, chainId);
-
-  if (!chainMetadata?.tokens || !isRecord(chainMetadata.tokens)) {
+function getPeggedTo(tokenMetadata: unknown): LayerZeroPeggedTo | null {
+  if (!isRecord(tokenMetadata) || !isRecord(tokenMetadata.peggedTo)) {
     return null;
   }
 
-  const tokenMetadata = chainMetadata.tokens[tokenAddress.toLowerCase()];
+  const { address, chainName } = tokenMetadata.peggedTo;
+  if (typeof address !== 'string' || typeof chainName !== 'string') {
+    return null;
+  }
 
-  return isRecord(tokenMetadata) ? tokenMetadata : null;
+  return { address: address.toLowerCase(), chainName };
+}
+
+export function getLayerZeroOftInfoFromMetadata(
+  metadata: unknown,
+  {
+    parentChainId,
+    parentTokenAddress,
+    childChainId,
+  }: {
+    parentChainId: number;
+    parentTokenAddress: string;
+    childChainId: number;
+  },
+): LayerZeroOftInfo {
+  const notOft: LayerZeroOftInfo = { isOft: false, childTokenAddresses: [] };
+
+  const parentChain = getChainByNativeChainId(metadata, parentChainId);
+  if (!parentChain) {
+    return notOft;
+  }
+
+  const parentTokenMetadata = parentChain.tokens[parentTokenAddress.toLowerCase()];
+  if (!isRecord(parentTokenMetadata)) {
+    return notOft;
+  }
+
+  const root: TokenRoot = getPeggedTo(parentTokenMetadata) ?? {
+    chainName: parentChain.chainName,
+    address: parentTokenAddress.toLowerCase(),
+  };
+
+  const childChain = getChainByNativeChainId(metadata, childChainId);
+  if (!childChain) {
+    return { isOft: true, childTokenAddresses: [] };
+  }
+
+  const childTokenAddresses: string[] = [];
+  for (const [address, tokenMetadata] of Object.entries(childChain.tokens)) {
+    const peggedTo = getPeggedTo(tokenMetadata);
+    const matchesRoot = peggedTo
+      ? peggedTo.chainName === root.chainName && peggedTo.address === root.address
+      : childChain.chainName === root.chainName && address.toLowerCase() === root.address;
+
+    if (matchesRoot) {
+      childTokenAddresses.push(address.toLowerCase());
+    }
+  }
+
+  return { isOft: true, childTokenAddresses };
 }
 
 async function getLayerZeroMetadata() {
@@ -81,47 +124,13 @@ async function getLayerZeroMetadata() {
   return metadata;
 }
 
-export async function getLayerZeroNativeTokenStatus({
-  chainId,
-  tokenAddress,
-}: {
-  chainId: number;
-  tokenAddress: string;
-}) {
+export async function getLayerZeroOftInfo(params: {
+  parentChainId: number;
+  parentTokenAddress: string;
+  childChainId: number;
+}): Promise<LayerZeroOftInfo> {
   const metadata = await getLayerZeroMetadata();
-  return getLayerZeroNativeTokenStatusFromMetadata(metadata, {
-    chainId,
-    tokenAddress,
-  });
-}
-
-export function getLayerZeroNativeTokenStatusFromMetadata(
-  metadata: unknown,
-  {
-    chainId,
-    tokenAddress,
-  }: {
-    chainId: number;
-    tokenAddress: string;
-  },
-) {
-  const tokenMetadata = getLayerZeroTokenMetadata(metadata, chainId, tokenAddress);
-
-  if (!tokenMetadata) {
-    return null;
-  }
-
-  // A pegged token is a representation of an OFT native to another chain.
-  if (tokenMetadata.peggedTo) {
-    return false;
-  }
-
-  if (tokenMetadata.type === LAYERZERO_NATIVE_OFT_TYPE) {
-    return true;
-  }
-
-  // Unknown (e.g. an ERC20 using an OFT Adapter) — defer to the on-chain check.
-  return null;
+  return getLayerZeroOftInfoFromMetadata(metadata, params);
 }
 
 export function resetLayerZeroMetadataCache() {

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
@@ -1,4 +1,5 @@
 import { getAPIBaseUrl, isRecord } from '.';
+import { addressesEqual } from './AddressUtils';
 
 // Our own cached route handler, not the LayerZero API directly (see app/api/layerzero-metadata).
 const LAYERZERO_METADATA_URL = `${getAPIBaseUrl()}/api/layerzero-metadata`;
@@ -96,8 +97,8 @@ export function getLayerZeroOftInfoFromMetadata(
   for (const [address, tokenMetadata] of Object.entries(childChain.tokens)) {
     const peggedTo = getPeggedTo(tokenMetadata);
     const matchesRoot = peggedTo
-      ? peggedTo.chainName === root.chainName && peggedTo.address === root.address
-      : childChain.chainName === root.chainName && address.toLowerCase() === root.address;
+      ? peggedTo.chainName === root.chainName && addressesEqual(peggedTo.address, root.address)
+      : childChain.chainName === root.chainName && addressesEqual(address, root.address);
 
     if (matchesRoot) {
       childTokenAddresses.push(address.toLowerCase());

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
@@ -1,4 +1,8 @@
-const LAYERZERO_METADATA_URL = 'https://metadata.layerzero-api.com/v1/metadata';
+import { getAPIBaseUrl } from '.';
+
+// Served by our own cached route handler (see app/api/layerzero-metadata) rather
+// than hitting the LayerZero API directly, so responses are cached server-side.
+const LAYERZERO_METADATA_URL = `${getAPIBaseUrl()}/api/layerzero-metadata`;
 
 // LayerZero classifies a token whose own contract implements the OFT interface
 // (i.e. responds to `oftVersion()` on-chain) as `NativeOFT`. Plain ERC20s that

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
@@ -41,7 +41,7 @@ function getLayerZeroChainMetadata(
       continue;
     }
 
-    if (chainDetails.nativeChainId === chainId) {
+    if (Number(chainDetails.nativeChainId) === chainId) {
       return chainMetadata;
     }
   }

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
@@ -1,5 +1,4 @@
 import { getAPIBaseUrl } from '.';
-import { isRecord } from './isRecord';
 
 // Our own cached route handler, not the LayerZero API directly (see app/api/layerzero-metadata).
 const LAYERZERO_METADATA_URL = `${getAPIBaseUrl()}/api/layerzero-metadata`;
@@ -22,6 +21,10 @@ type LayerZeroChainMetadata = {
 };
 
 let layerZeroMetadataPromise: Promise<unknown> | null = null;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
 
 function getLayerZeroChainMetadata(
   metadata: unknown,

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
@@ -1,7 +1,7 @@
 import { getAPIBaseUrl, isRecord } from '.';
 import { addressesEqual } from './AddressUtils';
 
-// Our own cached route handler, not the LayerZero API directly (see app/api/layerzero-metadata).
+// Our own cached route handler (already trimmed + chain-id-keyed), not the LayerZero API directly.
 const LAYERZERO_METADATA_URL = `${getAPIBaseUrl()}/api/layerzero-metadata`;
 
 type LayerZeroPeggedTo = {
@@ -10,40 +10,34 @@ type LayerZeroPeggedTo = {
 };
 
 export type LayerZeroOftInfo = {
-  // Whether the token has a LayerZero OFT deployment on the parent chain.
   isOft: boolean;
-  // Lower-cased addresses of the same token's OFT deployments on the child chain.
   childTokenAddresses: string[];
 };
 
 let layerZeroMetadataPromise: Promise<unknown> | null = null;
 
-// The chain + address a token is natively deployed on (its own address if native,
-// else its `peggedTo` target).
+// The chain + address a token is natively deployed on (`chainName` = LayerZero chainKey).
 type TokenRoot = LayerZeroPeggedTo;
 
-function getChainByNativeChainId(
+// The metadata is keyed by our own chain id (see trimLayerZeroMetadata), so we
+// look it up directly rather than scanning LayerZero's non-unique `nativeChainId`.
+function getChainMetadata(
   metadata: unknown,
   chainId: number,
-): { chainName: string; tokens: Record<string, unknown> } | null {
+): { chainKey: string; tokens: Record<string, unknown> } | null {
   if (!isRecord(metadata)) {
     return null;
   }
 
-  for (const [chainName, chainMetadata] of Object.entries(metadata)) {
-    if (!isRecord(chainMetadata) || !isRecord(chainMetadata.chainDetails)) {
-      continue;
-    }
-
-    if (Number(chainMetadata.chainDetails.nativeChainId) === chainId) {
-      return {
-        chainName,
-        tokens: isRecord(chainMetadata.tokens) ? chainMetadata.tokens : {},
-      };
-    }
+  const chainMetadata = metadata[chainId];
+  if (!isRecord(chainMetadata) || typeof chainMetadata.chainKey !== 'string') {
+    return null;
   }
 
-  return null;
+  return {
+    chainKey: chainMetadata.chainKey,
+    tokens: isRecord(chainMetadata.tokens) ? chainMetadata.tokens : {},
+  };
 }
 
 function getPeggedTo(tokenMetadata: unknown): LayerZeroPeggedTo | null {
@@ -73,7 +67,7 @@ export function getLayerZeroOftInfoFromMetadata(
 ): LayerZeroOftInfo {
   const notOft: LayerZeroOftInfo = { isOft: false, childTokenAddresses: [] };
 
-  const parentChain = getChainByNativeChainId(metadata, parentChainId);
+  const parentChain = getChainMetadata(metadata, parentChainId);
   if (!parentChain) {
     return notOft;
   }
@@ -84,11 +78,13 @@ export function getLayerZeroOftInfoFromMetadata(
   }
 
   const root: TokenRoot = getPeggedTo(parentTokenMetadata) ?? {
-    chainName: parentChain.chainName,
+    chainName: parentChain.chainKey,
     address: parentTokenAddress.toLowerCase(),
   };
 
-  const childChain = getChainByNativeChainId(metadata, childChainId);
+  // No OFT deployment data for the destination → no OFT alternative there, so the
+  // caller allows the canonical route (blocking would strand a token with no other path).
+  const childChain = getChainMetadata(metadata, childChainId);
   if (!childChain) {
     return { isOft: true, childTokenAddresses: [] };
   }
@@ -98,7 +94,7 @@ export function getLayerZeroOftInfoFromMetadata(
     const peggedTo = getPeggedTo(tokenMetadata);
     const matchesRoot = peggedTo
       ? peggedTo.chainName === root.chainName && addressesEqual(peggedTo.address, root.address)
-      : childChain.chainName === root.chainName && addressesEqual(address, root.address);
+      : childChain.chainKey === root.chainName && addressesEqual(address, root.address);
 
     if (matchesRoot) {
       childTokenAddresses.push(address.toLowerCase());

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
@@ -1,4 +1,4 @@
-import { getAPIBaseUrl } from '.';
+import { getAPIBaseUrl, isRecord } from '.';
 
 // Our own cached route handler, not the LayerZero API directly (see app/api/layerzero-metadata).
 const LAYERZERO_METADATA_URL = `${getAPIBaseUrl()}/api/layerzero-metadata`;
@@ -21,10 +21,6 @@ type LayerZeroChainMetadata = {
 };
 
 let layerZeroMetadataPromise: Promise<unknown> | null = null;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
 
 function getLayerZeroChainMetadata(
   metadata: unknown,

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
@@ -114,6 +114,17 @@ export function getLayerZeroOftInfoFromMetadata(
   return { isOft: true, childTokenAddresses, hasOftChildDeployment };
 }
 
+// Whether LayerZero lists `tokenAddress` as a real token on `chainId` (regardless
+// of what it's pegged to) — i.e. a canonical deposit landing there hits a token
+// LayerZero recognizes, not a dead counterfactual.
+export function isKnownLayerZeroTokenFromMetadata(
+  metadata: unknown,
+  { chainId, tokenAddress }: { chainId: number; tokenAddress: string },
+): boolean {
+  const chain = getChainMetadata(metadata, chainId);
+  return !!chain && Boolean(chain.tokens[tokenAddress.toLowerCase()]);
+}
+
 async function getLayerZeroMetadata() {
   if (!layerZeroMetadataPromise) {
     layerZeroMetadataPromise = fetch(LAYERZERO_METADATA_URL)
@@ -138,6 +149,14 @@ export async function getLayerZeroOftInfo(params: {
 }): Promise<LayerZeroOftInfo> {
   const metadata = await getLayerZeroMetadata();
   return getLayerZeroOftInfoFromMetadata(metadata, params);
+}
+
+export async function isKnownLayerZeroToken(params: {
+  chainId: number;
+  tokenAddress: string;
+}): Promise<boolean> {
+  const metadata = await getLayerZeroMetadata();
+  return isKnownLayerZeroTokenFromMetadata(metadata, params);
 }
 
 export function resetLayerZeroMetadataCache() {

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
@@ -12,6 +12,9 @@ type LayerZeroPeggedTo = {
 export type LayerZeroOftInfo = {
   isOft: boolean;
   childTokenAddresses: string[];
+  // Whether any child representation is a real OFT deployment (vs a plain ERC20
+  // LayerZero merely tracks) — i.e. an OFT route actually exists on the destination.
+  hasOftChildDeployment: boolean;
 };
 
 let layerZeroMetadataPromise: Promise<unknown> | null = null;
@@ -65,7 +68,11 @@ export function getLayerZeroOftInfoFromMetadata(
     childChainId: number;
   },
 ): LayerZeroOftInfo {
-  const notOft: LayerZeroOftInfo = { isOft: false, childTokenAddresses: [] };
+  const notOft: LayerZeroOftInfo = {
+    isOft: false,
+    childTokenAddresses: [],
+    hasOftChildDeployment: false,
+  };
 
   const parentChain = getChainMetadata(metadata, parentChainId);
   if (!parentChain) {
@@ -82,14 +89,14 @@ export function getLayerZeroOftInfoFromMetadata(
     address: parentTokenAddress.toLowerCase(),
   };
 
-  // No OFT deployment data for the destination → no OFT alternative there, so the
-  // caller allows the canonical route (blocking would strand a token with no other path).
+  // No metadata for the destination → we can't tell whether an OFT route exists there.
   const childChain = getChainMetadata(metadata, childChainId);
   if (!childChain) {
-    return { isOft: true, childTokenAddresses: [] };
+    return { isOft: true, childTokenAddresses: [], hasOftChildDeployment: false };
   }
 
   const childTokenAddresses: string[] = [];
+  let hasOftChildDeployment = false;
   for (const [address, tokenMetadata] of Object.entries(childChain.tokens)) {
     const peggedTo = getPeggedTo(tokenMetadata);
     const matchesRoot = peggedTo
@@ -98,10 +105,13 @@ export function getLayerZeroOftInfoFromMetadata(
 
     if (matchesRoot) {
       childTokenAddresses.push(address.toLowerCase());
+      if (isRecord(tokenMetadata) && tokenMetadata.isOft === true) {
+        hasOftChildDeployment = true;
+      }
     }
   }
 
-  return { isOft: true, childTokenAddresses };
+  return { isOft: true, childTokenAddresses, hasOftChildDeployment };
 }
 
 async function getLayerZeroMetadata() {

--- a/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
+++ b/packages/arb-token-bridge-ui/src/util/layerZeroMetadata.ts
@@ -1,14 +1,12 @@
 import { getAPIBaseUrl } from '.';
 import { isRecord } from './isRecord';
 
-// Served by our own cached route handler (see app/api/layerzero-metadata) rather
-// than hitting the LayerZero API directly, so responses are cached server-side.
+// Our own cached route handler, not the LayerZero API directly (see app/api/layerzero-metadata).
 const LAYERZERO_METADATA_URL = `${getAPIBaseUrl()}/api/layerzero-metadata`;
 
-// LayerZero classifies a token whose own contract implements the OFT interface
-// (i.e. responds to `oftVersion()` on-chain) as `NativeOFT`. Plain ERC20s that
-// are bridged through a separate OFT Adapter are typed `ERC20` and do NOT
-// implement `oftVersion()` themselves, so they must not be treated as native OFTs.
+// `NativeOFT` is a token whose own contract implements the OFT interface (responds to
+// `oftVersion()` on-chain). Plain ERC20s bridged via a separate OFT Adapter are typed
+// `ERC20` and don't, so they must not be treated as native OFTs.
 const LAYERZERO_NATIVE_OFT_TYPE = 'NativeOFT';
 
 type LayerZeroTokenMetadata = {
@@ -62,7 +60,6 @@ function getLayerZeroTokenMetadata(
     return null;
   }
 
-  // The metadata keys tokens by their lower-cased address, so look it up directly.
   const tokenMetadata = chainMetadata.tokens[tokenAddress.toLowerCase()];
 
   return isRecord(tokenMetadata) ? tokenMetadata : null;
@@ -77,8 +74,7 @@ async function getLayerZeroMetadata() {
 
   const metadata = await layerZeroMetadataPromise;
 
-  // Don't cache a failed/empty response — clear the cache so the next caller
-  // retries instead of being stuck with `null` for the rest of the session.
+  // Don't cache a failed response — let the next caller retry.
   if (metadata === null) {
     layerZeroMetadataPromise = null;
   }
@@ -116,18 +112,16 @@ export function getLayerZeroNativeTokenStatusFromMetadata(
     return null;
   }
 
-  // A pegged token is a representation of an OFT that lives natively on another
-  // chain, so it is explicitly not a native OFT here.
+  // A pegged token is a representation of an OFT native to another chain.
   if (tokenMetadata.peggedTo) {
     return false;
   }
 
-  // Only tokens whose own contract is the OFT count as native. Anything else
-  // (e.g. plain ERC20s using an OFT Adapter) is left to the on-chain fallback.
   if (tokenMetadata.type === LAYERZERO_NATIVE_OFT_TYPE) {
     return true;
   }
 
+  // Unknown (e.g. an ERC20 using an OFT Adapter) — defer to the on-chain check.
   return null;
 }
 


### PR DESCRIPTION
## Summary

LayerZero OFT tokens must not be moved through the canonical Arbitrum bridge. A canonical deposit lands at the deterministic gateway-derived address on the destination chain, which differs from the token's real OFT deployment — so the funds end up in the wrong token and are effectively stranded. These tokens are meant to move via OFT / LiFi instead.

This PR detects whether a selected token is a LayerZero OFT for the given route and blocks its canonical deposit.

## How it works

- Adds a cached `/api/layerzero-metadata` route that fetches LayerZero's metadata, trims it server-side to just what the client needs (~3.8MB → a small payload), and caches it (data cache + CDN).
- `isBlockedOftDeposit` decides whether a canonical deposit should be blocked:
  - Resolves the deterministic canonical destination address via `getL2ERC20Address` (handles standard, WETH, and custom gateways).
  - Looks up the token's OFT deployment(s) on the destination chain in the metadata and compares:
    - no canonical route (e.g. USDT), or canonical address ≠ the OFT deployment → **block** (route via OFT / LiFi)
    - canonical address == the OFT deployment (adapter over the canonical token, e.g. WETH, USDC.e) → **allow**
  - Falls back to an on-chain `oftVersion()` probe for tokens not yet listed in the metadata (catches native OFTs).

## Tests

- **Unit** — parsing / root-linking logic, malformed-metadata tolerance, and fetch caching + retry (synthetic fixtures).
- **Integration (live)** — validates detection against the real LayerZero metadata endpoint, asserting a known OFT resolves to its real destination deployment.

Closes FS-2352
