### PR TITLE
fix(bridge): search tx history without wallet connection

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/canFetchTransactionHistory.test.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/canFetchTransactionHistory.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { canFetchTransactionHistory } from '../canFetchTransactionHistory';
+
+const address = '0x1798440327d78ebb19db0c8999e2368eaed8f413';
+
+describe('canFetchTransactionHistory', () => {
+  it('allows fetching for a searched EOA without a connected chain', () => {
+    expect(
+      canFetchTransactionHistory({
+        address,
+        isLoadingAccountType: false,
+        isTxHistoryEnabled: true,
+        isSmartContractWallet: false,
+        connectedChainId: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it('blocks fetching for smart contract wallets without a connected chain', () => {
+    expect(
+      canFetchTransactionHistory({
+        address,
+        isLoadingAccountType: false,
+        isTxHistoryEnabled: true,
+        isSmartContractWallet: true,
+        connectedChainId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it('prefers the shared fetch guards before chain-specific logic', () => {
+    expect(
+      canFetchTransactionHistory({
+        address: undefined,
+        isLoadingAccountType: false,
+        isTxHistoryEnabled: true,
+        isSmartContractWallet: false,
+        connectedChainId: undefined,
+      }),
+    ).toBe(false);
+
+    expect(
+      canFetchTransactionHistory({
+        address,
+        isLoadingAccountType: true,
+        isTxHistoryEnabled: true,
+        isSmartContractWallet: false,
+        connectedChainId: 11155111,
+      }),
+    ).toBe(false);
+
+    expect(
+      canFetchTransactionHistory({
+        address,
+        isLoadingAccountType: false,
+        isTxHistoryEnabled: false,
+        isSmartContractWallet: false,
+        connectedChainId: 11155111,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/canFetchTransactionHistory.test.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/canFetchTransactionHistory.test.ts
@@ -29,6 +29,18 @@ describe('canFetchTransactionHistory', () => {
     ).toBe(false);
   });
 
+  it('allows fetching for smart contract wallets with a connected chain', () => {
+    expect(
+      canFetchTransactionHistory({
+        address,
+        isLoadingAccountType: false,
+        isTxHistoryEnabled: true,
+        isSmartContractWallet: true,
+        connectedChainId: 11155111,
+      }),
+    ).toBe(true);
+  });
+
   it('prefers the shared fetch guards before chain-specific logic', () => {
     expect(
       canFetchTransactionHistory({

--- a/packages/arb-token-bridge-ui/src/hooks/canFetchTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/canFetchTransactionHistory.ts
@@ -1,0 +1,21 @@
+import type { Address } from '../util/AddressUtils';
+
+export function canFetchTransactionHistory({
+  address,
+  isLoadingAccountType,
+  isTxHistoryEnabled,
+  isSmartContractWallet,
+  connectedChainId,
+}: {
+  address: Address | undefined;
+  isLoadingAccountType: boolean;
+  isTxHistoryEnabled: boolean;
+  isSmartContractWallet: boolean;
+  connectedChainId: number | undefined;
+}) {
+  if (!address || isLoadingAccountType || !isTxHistoryEnabled) {
+    return false;
+  }
+
+  return !isSmartContractWallet || typeof connectedChainId !== 'undefined';
+}

--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -47,6 +47,7 @@ import {
   mapWithdrawalFromSubgraphToL2ToL1EventResult,
 } from '../util/withdrawals/helpers';
 import { AssetType, L2ToL1EventResultPlus, WithdrawalInitiated } from './arbTokenBridge.types';
+import { canFetchTransactionHistory } from './canFetchTransactionHistory';
 import { useAccountType } from './useAccountType';
 import { DisabledFeatures } from './useArbQueryParams';
 import { useDisabledFeatures } from './useDisabledFeatures';
@@ -618,10 +619,21 @@ const useTransactionHistoryWithoutStatuses = (address: Address | undefined) => {
   const { data: failedChainPairs, mutate: addFailedChainPair } = useSWRImmutable<ChainPair[]>(
     address ? ['failed_chain_pairs', address] : null,
   );
+  const connectedChainId = chain?.id;
+  const canFetch = canFetchTransactionHistory({
+    address,
+    isLoadingAccountType,
+    isTxHistoryEnabled,
+    isSmartContractWallet,
+    connectedChainId,
+  });
+  // SCW history is network-specific, so scope the cache by the connected chain
+  // to revalidate on network switch. EOA history is network-agnostic.
+  const smartContractWalletChainScope = isSmartContractWallet ? connectedChainId : undefined;
 
   const fetcher = useCallback(
     (type: 'deposits' | 'withdrawals') => {
-      if (!chain) {
+      if (!canFetch) {
         return [];
       }
 
@@ -629,8 +641,11 @@ const useTransactionHistoryWithoutStatuses = (address: Address | undefined) => {
         getMultiChainFetchList()
           .filter((chainPair) => {
             if (isSmartContractWallet) {
+              if (typeof connectedChainId === 'undefined') {
+                return false;
+              }
               // only fetch txs from the connected network
-              return [chainPair.parentChainId, chainPair.childChainId].includes(chain.id);
+              return [chainPair.parentChainId, chainPair.childChainId].includes(connectedChainId);
             }
 
             return isNetwork(chainPair.parentChainId).isTestnet === isTestnetMode;
@@ -639,7 +654,7 @@ const useTransactionHistoryWithoutStatuses = (address: Address | undefined) => {
             // SCW address is tied to a specific network
             // that's why we need to limit shown txs either to sent or received funds
             // otherwise we'd display funds for a different network, which could be someone else's account
-            const isConnectedToParentChain = chainPair.parentChainId === chain.id;
+            const isConnectedToParentChain = chainPair.parentChainId === connectedChainId;
 
             const includeSentTxs = shouldIncludeSentTxs({
               type,
@@ -696,17 +711,26 @@ const useTransactionHistoryWithoutStatuses = (address: Address | undefined) => {
           }),
       );
     },
-    [address, isTestnetMode, addFailedChainPair, isSmartContractWallet, chain, forceFetchReceived],
+    [
+      addFailedChainPair,
+      address,
+      canFetch,
+      connectedChainId,
+      forceFetchReceived,
+      isSmartContractWallet,
+      isTestnetMode,
+    ],
   );
-
-  const shouldFetch = address && !isLoadingAccountType && isTxHistoryEnabled;
 
   const {
     data: depositsData,
     error: depositsError,
     isLoading: depositsLoading,
-  } = useSWRImmutable(shouldFetch ? ['tx_list', 'deposits', address, isTestnetMode] : null, () =>
-    fetcher('deposits'),
+  } = useSWRImmutable(
+    canFetch
+      ? ['tx_list', 'deposits', address, isTestnetMode, smartContractWalletChainScope]
+      : null,
+    () => fetcher('deposits'),
   );
 
   const {
@@ -714,7 +738,16 @@ const useTransactionHistoryWithoutStatuses = (address: Address | undefined) => {
     error: withdrawalsError,
     isLoading: withdrawalsLoading,
   } = useSWRImmutable(
-    shouldFetch ? ['tx_list', 'withdrawals', address, isTestnetMode, forceFetchReceived] : null,
+    canFetch
+      ? [
+          'tx_list',
+          'withdrawals',
+          address,
+          isTestnetMode,
+          forceFetchReceived,
+          smartContractWalletChainScope,
+        ]
+      : null,
     () => fetcher('withdrawals'),
   );
 


### PR DESCRIPTION
## What

Transaction history now works for a **searched address** even when no wallet is connected.

## Why

The fetcher short-circuited whenever wagmi's `chain` was undefined, so searching a valid address without a connected wallet returned nothing.

## How

- Extract a `canFetchTransactionHistory` helper that gates fetching on the target address and feature availability — and only requires a connected chain for smart-contract wallets (their history is network-specific).
- Replace `chain.id` reads with a derived `connectedChainId`.
- Add unit tests for the helper.

Closes SUP-1467