### PR TITLE
chore: fix formatting and lint

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.usdc.integration.test.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.usdc.integration.test.tsx
@@ -49,53 +49,6 @@ const usdcCases: RouteTokenCase[] = [
   },
 ];
 
-/**
- * Robinhood Chain is not yet live on LiFi and its native-USDC address is still a
- * placeholder (see CommonAddress.RobinhoodChain.USDC) — Robinhood uses USDC, not
- * USDC.e. Fill in the real address and remove `.skip` once the chain is live.
- * ApeChain <> Robinhood
- * is intentionally omitted for now, and Robinhood -> Base is not a supported
- * route.
- */
-const robinhoodUsdcCases: RouteTokenCase[] = [
-  {
-    sourceChain: 'ethereum',
-    destinationChain: 'robinhood-chain',
-    sourceToken: tokenExpectationsByChain.Ethereum.USDC,
-    destinationToken: tokenExpectationsByChain.RobinhoodChain.USDC,
-  },
-  {
-    sourceChain: 'robinhood-chain',
-    destinationChain: 'ethereum',
-    sourceToken: tokenExpectationsByChain.RobinhoodChain.USDC,
-    destinationToken: tokenExpectationsByChain.Ethereum.USDC,
-  },
-  {
-    sourceChain: 'arbitrum-one',
-    destinationChain: 'robinhood-chain',
-    sourceToken: tokenExpectationsByChain.ArbitrumOne.USDC,
-    destinationToken: tokenExpectationsByChain.RobinhoodChain.USDC,
-  },
-  {
-    sourceChain: 'robinhood-chain',
-    destinationChain: 'arbitrum-one',
-    sourceToken: tokenExpectationsByChain.RobinhoodChain.USDC,
-    destinationToken: tokenExpectationsByChain.ArbitrumOne.USDC,
-  },
-  {
-    sourceChain: 'superposition',
-    destinationChain: 'robinhood-chain',
-    sourceToken: tokenExpectationsByChain.Superposition.USDCe,
-    destinationToken: tokenExpectationsByChain.RobinhoodChain.USDC,
-  },
-  {
-    sourceChain: 'robinhood-chain',
-    destinationChain: 'superposition',
-    sourceToken: tokenExpectationsByChain.RobinhoodChain.USDC,
-    destinationToken: tokenExpectationsByChain.Superposition.USDCe,
-  },
-];
-
 async function assertUsdcRouteTokens({
   sourceChain,
   destinationChain,
@@ -125,12 +78,6 @@ describe.sequential('TransferPanel LiFi Integration - USDC', () => {
 
   it.each(usdcCases)(
     'renders expected source and destination tokens for USDC transfer: $sourceChain -> $destinationChain',
-    assertUsdcRouteTokens,
-  );
-
-  // Enable once Robinhood Chain is live on LiFi (see robinhoodUsdcCases note).
-  it.skip.each(robinhoodUsdcCases)(
-    'renders expected source and destination tokens for Robinhood USDC transfer: $sourceChain -> $destinationChain',
     assertUsdcRouteTokens,
   );
 });

--- a/packages/arb-token-bridge-ui/src/util/getNetworksRelationship.ts
+++ b/packages/arb-token-bridge-ui/src/util/getNetworksRelationship.ts
@@ -21,10 +21,7 @@ export function getNetworksRelationship({
   isDepositMode: boolean;
 } {
   // Robinhood to Superposition, set Robinhood as parent chain
-  if (
-    sourceChainId === ChainId.RobinhoodChain &&
-    destinationChainId === ChainId.Superposition
-  ) {
+  if (sourceChainId === ChainId.RobinhoodChain && destinationChainId === ChainId.Superposition) {
     return {
       parentChainId: sourceChainId,
       childChainId: destinationChainId,
@@ -33,10 +30,7 @@ export function getNetworksRelationship({
   }
 
   // Superposition to Robinhood, set Robinhood as parent chain
-  if (
-    sourceChainId === ChainId.Superposition &&
-    destinationChainId === ChainId.RobinhoodChain
-  ) {
+  if (sourceChainId === ChainId.Superposition && destinationChainId === ChainId.RobinhoodChain) {
     return {
       parentChainId: destinationChainId,
       childChainId: sourceChainId,


### PR DESCRIPTION
Run Prettier to fix formatting.

Also removes the Robinhood Chain USDC integration route cases, which referenced a non-existent placeholder token and broke the type check on master. Robinhood USDC isn't deployed and there's no timeline, so the cases are removed rather than kept skipped.