### PR TITLE
feat(bridge): use isBlockedOftDeposit in canonical tx detection

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferDisabledDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferDisabledDialog.tsx
@@ -42,11 +42,12 @@ export async function isDisabledCanonicalTransfer({
   }
 
   if (
-    await isBlockedOftDeposit({
+    isDepositMode &&
+    (await isBlockedOftDeposit({
       parentChainErc20Address: selectedToken.address,
       parentChainId,
       childChainId,
-    })
+    }))
   ) {
     return true;
   }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferDisabledDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferDisabledDialog.tsx
@@ -54,7 +54,7 @@ export function TransferDisabledDialog() {
     }
 
     return [
-      selectedToken.address,
+      selectedToken.address.toLowerCase(),
       isDepositMode,
       parentChain.id,
       childChain.id,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferDisabledDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferDisabledDialog.tsx
@@ -1,5 +1,6 @@
 import { constants } from 'ethers';
 import { useEffect, useMemo, useState } from 'react';
+import useSWRImmutable from 'swr/immutable';
 
 import { isValidLifiTransfer } from '../../app/api/crosschain-transfers/utils';
 import { ERC20BridgeToken } from '../../hooks/arbTokenBridge.types';
@@ -10,14 +11,14 @@ import { ChainId } from '../../types/ChainId';
 import { addressesEqual } from '../../util/AddressUtils';
 import { isTransferDisabledToken } from '../../util/TokenTransferDisabledUtils';
 import { sanitizeTokenSymbol } from '../../util/TokenUtils';
-import { withdrawOnlyTokens } from '../../util/WithdrawOnlyUtils';
+import { isBlockedOftDeposit, withdrawOnlyTokens } from '../../util/WithdrawOnlyUtils';
 import { isLifiEnabled } from '../../util/featureFlag';
 import { Dialog } from '../common/Dialog';
 import { ExternalLink } from '../common/ExternalLink';
 import { useTokensFromLists } from './TokenSearchUtils';
 import { useSelectedTokenIsWithdrawOnly } from './hooks/useSelectedTokenIsWithdrawOnly';
 
-export function isDisabledCanonicalTransfer({
+export async function isDisabledCanonicalTransfer({
   selectedToken,
   isDepositMode,
   parentChainId,
@@ -37,6 +38,16 @@ export function isDisabledCanonicalTransfer({
   }
 
   if (isTransferDisabledToken(selectedToken.address, childChainId)) {
+    return true;
+  }
+
+  if (
+    await isBlockedOftDeposit({
+      parentChainErc20Address: selectedToken.address,
+      parentChainId,
+      childChainId,
+    })
+  ) {
     return true;
   }
 
@@ -67,12 +78,12 @@ export function TransferDisabledDialog() {
     chainId: networks.sourceChain.id,
   });
 
-  const shouldShowDialog = useMemo(() => {
+  const queryKey = useMemo(() => {
     if (
       !selectedToken ||
       addressesEqual(selectedToken?.address, selectedTokenAddressLocalValue ?? undefined)
     ) {
-      return false;
+      return null;
     }
 
     // If a lifi route exists, don't show any dialog
@@ -85,17 +96,18 @@ export function TransferDisabledDialog() {
         tokensFromLists,
       })
     ) {
-      return false;
+      return null;
     }
 
-    return isDisabledCanonicalTransfer({
-      selectedToken,
+    return [
+      selectedToken.address,
       isDepositMode,
-      parentChainId: parentChain.id,
-      childChainId: childChain.id,
+      parentChain.id,
+      childChain.id,
       isSelectedTokenWithdrawOnly,
       isSelectedTokenWithdrawOnlyLoading,
-    });
+      'isDisabledCanonicalTransfer',
+    ] as const;
   }, [
     childChain.id,
     isDepositMode,
@@ -108,6 +120,26 @@ export function TransferDisabledDialog() {
     networks.sourceChain.id,
     networks.destinationChain.id,
   ]);
+
+  const { data: shouldShowDialog = false } = useSWRImmutable(
+    queryKey,
+    ([
+      ,
+      _isDepositMode,
+      parentChainId,
+      childChainId,
+      _isSelectedTokenWithdrawOnly,
+      _isSelectedTokenWithdrawOnlyLoading,
+    ]) =>
+      isDisabledCanonicalTransfer({
+        selectedToken,
+        isDepositMode: _isDepositMode,
+        parentChainId,
+        childChainId,
+        isSelectedTokenWithdrawOnly: _isSelectedTokenWithdrawOnly,
+        isSelectedTokenWithdrawOnlyLoading: _isSelectedTokenWithdrawOnlyLoading,
+      }),
+  );
 
   const isGHO =
     selectedToken &&

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferDisabledDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferDisabledDialog.tsx
@@ -1,67 +1,20 @@
-import { constants } from 'ethers';
 import { useEffect, useMemo, useState } from 'react';
 import useSWRImmutable from 'swr/immutable';
 
 import { isValidLifiTransfer } from '../../app/api/crosschain-transfers/utils';
-import { ERC20BridgeToken } from '../../hooks/arbTokenBridge.types';
 import { useNetworks } from '../../hooks/useNetworks';
 import { useNetworksRelationship } from '../../hooks/useNetworksRelationship';
 import { useSelectedToken } from '../../hooks/useSelectedToken';
 import { ChainId } from '../../types/ChainId';
 import { addressesEqual } from '../../util/AddressUtils';
-import { isTransferDisabledToken } from '../../util/TokenTransferDisabledUtils';
 import { sanitizeTokenSymbol } from '../../util/TokenUtils';
-import { isBlockedOftDeposit, withdrawOnlyTokens } from '../../util/WithdrawOnlyUtils';
+import { withdrawOnlyTokens } from '../../util/WithdrawOnlyUtils';
 import { isLifiEnabled } from '../../util/featureFlag';
 import { Dialog } from '../common/Dialog';
 import { ExternalLink } from '../common/ExternalLink';
 import { useTokensFromLists } from './TokenSearchUtils';
 import { useSelectedTokenIsWithdrawOnly } from './hooks/useSelectedTokenIsWithdrawOnly';
-
-export async function isDisabledCanonicalTransfer({
-  selectedToken,
-  isDepositMode,
-  parentChainId,
-  childChainId,
-  isSelectedTokenWithdrawOnly,
-  isSelectedTokenWithdrawOnlyLoading,
-}: {
-  selectedToken: ERC20BridgeToken | null;
-  isDepositMode: boolean;
-  parentChainId: ChainId;
-  childChainId: ChainId;
-  isSelectedTokenWithdrawOnly: boolean | undefined;
-  isSelectedTokenWithdrawOnlyLoading: boolean;
-}) {
-  if (!selectedToken) {
-    return false;
-  }
-
-  if (isTransferDisabledToken(selectedToken.address, childChainId)) {
-    return true;
-  }
-
-  if (
-    isDepositMode &&
-    (await isBlockedOftDeposit({
-      parentChainErc20Address: selectedToken.address,
-      parentChainId,
-      childChainId,
-    }))
-  ) {
-    return true;
-  }
-
-  if (
-    parentChainId === ChainId.ArbitrumOne &&
-    childChainId === ChainId.ApeChain &&
-    addressesEqual(selectedToken.address, constants.AddressZero)
-  ) {
-    return true;
-  }
-
-  return !!(isDepositMode && isSelectedTokenWithdrawOnly && !isSelectedTokenWithdrawOnlyLoading);
-}
+import { isDisabledCanonicalTransfer } from './isDisabledCanonicalTransfer';
 
 export function TransferDisabledDialog() {
   const [networks] = useNetworks();

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useIsCanonicalTransfer.test.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useIsCanonicalTransfer.test.ts
@@ -222,8 +222,8 @@ describe('isArbitrumCanonicalTransfer', () => {
         address: CommonAddress.Ethereum.USDG,
         l2Address: CommonAddress.RobinhoodChain.USDG,
       },
-    ])('should return false for Robinhood LiFi-only $symbol deposits', (token) => {
-      const deposit = isArbitrumCanonicalTransfer({
+    ])('should return false for Robinhood LiFi-only $symbol deposits', async (token) => {
+      const deposit = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.RobinhoodChain,
         parentChainId: ChainId.Ethereum,
         sourceChainId: ChainId.Ethereum,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useIsCanonicalTransfer.test.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useIsCanonicalTransfer.test.ts
@@ -395,8 +395,8 @@ describe('isArbitrumCanonicalTransfer', () => {
         address: CommonAddress.Ethereum.USDG,
         l2Address: CommonAddress.RobinhoodChain.USDG,
       },
-    ])('should return false for Robinhood LiFi-only $symbol withdrawals', (token) => {
-      const withdrawal = isArbitrumCanonicalTransfer({
+    ])('should return false for Robinhood LiFi-only $symbol withdrawals', async (token) => {
+      const withdrawal = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.RobinhoodChain,
         parentChainId: ChainId.Ethereum,
         sourceChainId: ChainId.RobinhoodChain,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useIsCanonicalTransfer.test.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useIsCanonicalTransfer.test.ts
@@ -1,13 +1,22 @@
 import { registerCustomArbitrumNetwork } from '@arbitrum/sdk';
 import { constants } from 'ethers';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { ether } from '../../../constants';
 import { ERC20BridgeToken, TokenType } from '../../../hooks/arbTokenBridge.types';
 import { ChainId } from '../../../types/ChainId';
 import { CommonAddress } from '../../../util/CommonAddressUtils';
+import { isBlockedOftDeposit } from '../../../util/WithdrawOnlyUtils';
 import orbitChainsData from '../../../util/orbitChainsData.json';
 import { isArbitrumCanonicalTransfer } from './useIsCanonicalTransfer';
+
+vi.mock('../../../util/WithdrawOnlyUtils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../util/WithdrawOnlyUtils')>();
+  return {
+    ...actual,
+    isBlockedOftDeposit: vi.fn().mockResolvedValue(false),
+  };
+});
 
 const usdcToken: ERC20BridgeToken = {
   address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
@@ -32,8 +41,8 @@ describe('isArbitrumCanonicalTransfer', () => {
   });
 
   describe('for deposits', () => {
-    it('should return true from Ethereum to Arbitrum One', () => {
-      const ethDeposit = isArbitrumCanonicalTransfer({
+    it('should return true from Ethereum to Arbitrum One', async () => {
+      const ethDeposit = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.ArbitrumOne,
         parentChainId: ChainId.Ethereum,
         sourceChainId: ChainId.Ethereum,
@@ -45,7 +54,7 @@ describe('isArbitrumCanonicalTransfer', () => {
       });
       expect(ethDeposit).toBe(true);
 
-      const erc20Deposit = isArbitrumCanonicalTransfer({
+      const erc20Deposit = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.ArbitrumOne,
         parentChainId: ChainId.Ethereum,
         sourceChainId: ChainId.Ethereum,
@@ -58,8 +67,8 @@ describe('isArbitrumCanonicalTransfer', () => {
       expect(erc20Deposit).toBe(true);
     });
 
-    it('should return false for withdraw only token', () => {
-      const erc20Deposit = isArbitrumCanonicalTransfer({
+    it('should return false for withdraw only token', async () => {
+      const erc20Deposit = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.ArbitrumOne,
         parentChainId: ChainId.Ethereum,
         sourceChainId: ChainId.Ethereum,
@@ -72,8 +81,24 @@ describe('isArbitrumCanonicalTransfer', () => {
       expect(erc20Deposit).toBe(false);
     });
 
-    it('should return false from Base to Arbitrum One', () => {
-      const baseDeposit = isArbitrumCanonicalTransfer({
+    it('should return false for LayerZero token', async () => {
+      vi.mocked(isBlockedOftDeposit).mockResolvedValueOnce(true);
+
+      const erc20Deposit = await isArbitrumCanonicalTransfer({
+        childChainId: ChainId.ArbitrumOne,
+        parentChainId: ChainId.Ethereum,
+        sourceChainId: ChainId.Ethereum,
+        destinationChainId: ChainId.ArbitrumOne,
+        isSelectedTokenWithdrawOnly: false,
+        isSelectedTokenWithdrawOnlyLoading: false,
+        selectedToken: usdcToken,
+        isSwap: false,
+      });
+      expect(erc20Deposit).toBe(false);
+    });
+
+    it('should return false from Base to Arbitrum One', async () => {
+      const baseDeposit = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.ArbitrumOne,
         parentChainId: ChainId.Base,
         sourceChainId: ChainId.Base,
@@ -86,8 +111,8 @@ describe('isArbitrumCanonicalTransfer', () => {
       expect(baseDeposit).toBe(false);
     });
 
-    it('should return false for disabled token', () => {
-      const deposit = isArbitrumCanonicalTransfer({
+    it('should return false for disabled token', async () => {
+      const deposit = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.ArbitrumOne,
         parentChainId: ChainId.Ethereum,
         sourceChainId: ChainId.Ethereum,
@@ -107,8 +132,8 @@ describe('isArbitrumCanonicalTransfer', () => {
       expect(deposit).toBe(false);
     });
 
-    it('should return from ArbitrumOne to ApeChain', () => {
-      const apeDeposit = isArbitrumCanonicalTransfer({
+    it('should return from ArbitrumOne to ApeChain', async () => {
+      const apeDeposit = await isArbitrumCanonicalTransfer({
         sourceChainId: ChainId.ArbitrumOne,
         destinationChainId: ChainId.ApeChain,
         childChainId: ChainId.ApeChain,
@@ -120,7 +145,7 @@ describe('isArbitrumCanonicalTransfer', () => {
       });
       expect(apeDeposit).toBe(true);
 
-      const ethDeposit = isArbitrumCanonicalTransfer({
+      const ethDeposit = await isArbitrumCanonicalTransfer({
         sourceChainId: ChainId.ArbitrumOne,
         destinationChainId: ChainId.ApeChain,
         childChainId: ChainId.ApeChain,
@@ -139,8 +164,8 @@ describe('isArbitrumCanonicalTransfer', () => {
       expect(ethDeposit).toBe(false);
     });
 
-    it('should return from ArbitrumOne to Superposition', () => {
-      const ethDeposit = isArbitrumCanonicalTransfer({
+    it('should return from ArbitrumOne to Superposition', async () => {
+      const ethDeposit = await isArbitrumCanonicalTransfer({
         sourceChainId: ChainId.ArbitrumOne,
         destinationChainId: ChainId.Superposition,
         childChainId: ChainId.Superposition,
@@ -152,7 +177,7 @@ describe('isArbitrumCanonicalTransfer', () => {
       });
       expect(ethDeposit).toBe(true);
 
-      const usdcDeposit = isArbitrumCanonicalTransfer({
+      const usdcDeposit = await isArbitrumCanonicalTransfer({
         sourceChainId: ChainId.ArbitrumOne,
         destinationChainId: ChainId.Superposition,
         childChainId: ChainId.Superposition,
@@ -168,8 +193,8 @@ describe('isArbitrumCanonicalTransfer', () => {
       expect(usdcDeposit).toBe(true);
     });
 
-    it('Should return true for USDC transfers', () => {
-      const usdcDeposit = isArbitrumCanonicalTransfer({
+    it('Should return true for USDC transfers', async () => {
+      const usdcDeposit = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.ArbitrumOne,
         parentChainId: ChainId.Ethereum,
         sourceChainId: ChainId.Ethereum,
@@ -220,8 +245,8 @@ describe('isArbitrumCanonicalTransfer', () => {
   });
 
   describe('for withdrawals', () => {
-    it('should return true from Arbitrum One to Ethereum', () => {
-      const ethWithdrawal = isArbitrumCanonicalTransfer({
+    it('should return true from Arbitrum One to Ethereum', async () => {
+      const ethWithdrawal = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.ArbitrumOne,
         parentChainId: ChainId.Ethereum,
         sourceChainId: ChainId.ArbitrumOne,
@@ -233,7 +258,7 @@ describe('isArbitrumCanonicalTransfer', () => {
       });
       expect(ethWithdrawal).toBe(true);
 
-      const erc20Withdrawal = isArbitrumCanonicalTransfer({
+      const erc20Withdrawal = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.ArbitrumOne,
         parentChainId: ChainId.Ethereum,
         sourceChainId: ChainId.ArbitrumOne,
@@ -246,8 +271,8 @@ describe('isArbitrumCanonicalTransfer', () => {
       expect(erc20Withdrawal).toBe(true);
     });
 
-    it('should return true for withdraw only token', () => {
-      const erc20Withdrawal = isArbitrumCanonicalTransfer({
+    it('should return true for withdraw only token', async () => {
+      const erc20Withdrawal = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.ArbitrumOne,
         parentChainId: ChainId.Ethereum,
         sourceChainId: ChainId.ArbitrumOne,
@@ -260,8 +285,8 @@ describe('isArbitrumCanonicalTransfer', () => {
       expect(erc20Withdrawal).toBe(true);
     });
 
-    it('should return false from Arbitrum One to Base', () => {
-      const baseWithdrawal = isArbitrumCanonicalTransfer({
+    it('should return false from Arbitrum One to Base', async () => {
+      const baseWithdrawal = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.ArbitrumOne,
         parentChainId: ChainId.Base,
         sourceChainId: ChainId.ArbitrumOne,
@@ -274,8 +299,8 @@ describe('isArbitrumCanonicalTransfer', () => {
       expect(baseWithdrawal).toBe(false);
     });
 
-    it('should return false for disabled token', () => {
-      const withdrawal = isArbitrumCanonicalTransfer({
+    it('should return false for disabled token', async () => {
+      const withdrawal = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.ArbitrumOne,
         parentChainId: ChainId.Ethereum,
         sourceChainId: ChainId.ArbitrumOne,
@@ -295,8 +320,8 @@ describe('isArbitrumCanonicalTransfer', () => {
       expect(withdrawal).toBe(false);
     });
 
-    it('should return from ApeChain to ArbitrumOne', () => {
-      const apeWithdraw = isArbitrumCanonicalTransfer({
+    it('should return from ApeChain to ArbitrumOne', async () => {
+      const apeWithdraw = await isArbitrumCanonicalTransfer({
         sourceChainId: ChainId.ApeChain,
         destinationChainId: ChainId.ArbitrumOne,
         childChainId: ChainId.ApeChain,
@@ -308,7 +333,7 @@ describe('isArbitrumCanonicalTransfer', () => {
       });
       expect(apeWithdraw).toBe(true);
 
-      const wethWithdraw = isArbitrumCanonicalTransfer({
+      const wethWithdraw = await isArbitrumCanonicalTransfer({
         sourceChainId: ChainId.ApeChain,
         destinationChainId: ChainId.ArbitrumOne,
         childChainId: ChainId.ApeChain,
@@ -330,8 +355,8 @@ describe('isArbitrumCanonicalTransfer', () => {
       expect(wethWithdraw).toBe(false);
     });
 
-    it('should return from Superposition to ArbitrumOne', () => {
-      const ethWithdraw = isArbitrumCanonicalTransfer({
+    it('should return from Superposition to ArbitrumOne', async () => {
+      const ethWithdraw = await isArbitrumCanonicalTransfer({
         sourceChainId: ChainId.Superposition,
         destinationChainId: ChainId.ArbitrumOne,
         childChainId: ChainId.Superposition,
@@ -343,7 +368,7 @@ describe('isArbitrumCanonicalTransfer', () => {
       });
       expect(ethWithdraw).toBe(true);
 
-      const usdcWithdraw = isArbitrumCanonicalTransfer({
+      const usdcWithdraw = await isArbitrumCanonicalTransfer({
         sourceChainId: ChainId.Superposition,
         destinationChainId: ChainId.ArbitrumOne,
         childChainId: ChainId.Superposition,
@@ -393,8 +418,8 @@ describe('isArbitrumCanonicalTransfer', () => {
   });
 
   describe('for swaps', () => {
-    it('should return false for any swap', () => {
-      const ethDeposit = isArbitrumCanonicalTransfer({
+    it('should return false for any swap', async () => {
+      const ethDeposit = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.ArbitrumOne,
         parentChainId: ChainId.Ethereum,
         sourceChainId: ChainId.Ethereum,
@@ -406,7 +431,7 @@ describe('isArbitrumCanonicalTransfer', () => {
       });
       expect(ethDeposit).toBe(false);
 
-      const erc20Deposit = isArbitrumCanonicalTransfer({
+      const erc20Deposit = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.ArbitrumOne,
         parentChainId: ChainId.Ethereum,
         sourceChainId: ChainId.Ethereum,
@@ -418,7 +443,7 @@ describe('isArbitrumCanonicalTransfer', () => {
       });
       expect(erc20Deposit).toBe(false);
 
-      const ethDeposit2 = isArbitrumCanonicalTransfer({
+      const ethDeposit2 = await isArbitrumCanonicalTransfer({
         childChainId: ChainId.Superposition,
         parentChainId: ChainId.ArbitrumOne,
         sourceChainId: ChainId.ArbitrumOne,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useIsCanonicalTransfer.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useIsCanonicalTransfer.ts
@@ -6,7 +6,7 @@ import { useNetworksRelationship } from '../../../hooks/useNetworksRelationship'
 import { useSelectedToken } from '../../../hooks/useSelectedToken';
 import { isDepositMode } from '../../../util/isDepositMode';
 import { getDestinationChainIds } from '../../../util/networks';
-import { isDisabledCanonicalTransfer } from '../TransferDisabledDialog';
+import { isDisabledCanonicalTransfer } from '../isDisabledCanonicalTransfer';
 import { useIsSwapTransfer } from './useIsSwapTransfer';
 import { useSelectedTokenIsWithdrawOnly } from './useSelectedTokenIsWithdrawOnly';
 
@@ -40,11 +40,11 @@ export async function isArbitrumCanonicalTransfer({
   }
 
   return !(await isDisabledCanonicalTransfer({
-    childChainId: childChainId,
+    childChainId,
     isDepositMode: isDeposit,
     isSelectedTokenWithdrawOnly,
     isSelectedTokenWithdrawOnlyLoading,
-    parentChainId: parentChainId,
+    parentChainId,
     selectedToken,
   }));
 }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useIsCanonicalTransfer.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useIsCanonicalTransfer.ts
@@ -1,3 +1,5 @@
+import useSWRImmutable from 'swr/immutable';
+
 import { ERC20BridgeToken } from '../../../hooks/arbTokenBridge.types';
 import { useNetworks } from '../../../hooks/useNetworks';
 import { useNetworksRelationship } from '../../../hooks/useNetworksRelationship';
@@ -8,7 +10,7 @@ import { isDisabledCanonicalTransfer } from '../TransferDisabledDialog';
 import { useIsSwapTransfer } from './useIsSwapTransfer';
 import { useSelectedTokenIsWithdrawOnly } from './useSelectedTokenIsWithdrawOnly';
 
-export function isArbitrumCanonicalTransfer({
+export async function isArbitrumCanonicalTransfer({
   sourceChainId,
   destinationChainId,
   childChainId,
@@ -26,7 +28,7 @@ export function isArbitrumCanonicalTransfer({
   isSelectedTokenWithdrawOnlyLoading: boolean;
   selectedToken: ERC20BridgeToken | null;
   isSwap: boolean;
-}): boolean {
+}): Promise<boolean> {
   const isDeposit = isDepositMode({ sourceChainId, destinationChainId });
   const isValidPair = getDestinationChainIds(sourceChainId).includes(destinationChainId);
 
@@ -37,14 +39,14 @@ export function isArbitrumCanonicalTransfer({
     return false;
   }
 
-  return !isDisabledCanonicalTransfer({
+  return !(await isDisabledCanonicalTransfer({
     childChainId: childChainId,
     isDepositMode: isDeposit,
     isSelectedTokenWithdrawOnly,
     isSelectedTokenWithdrawOnlyLoading,
     parentChainId: parentChainId,
     selectedToken,
-  });
+  }));
 }
 
 export const useIsArbitrumCanonicalTransfer = function () {
@@ -55,14 +57,39 @@ export const useIsArbitrumCanonicalTransfer = function () {
     useSelectedTokenIsWithdrawOnly();
   const isSwap = useIsSwapTransfer();
 
-  return isArbitrumCanonicalTransfer({
-    sourceChainId: networks.sourceChain.id,
-    destinationChainId: networks.destinationChain.id,
-    childChainId: childChain.id,
-    parentChainId: parentChain.id,
-    isSelectedTokenWithdrawOnly,
-    isSelectedTokenWithdrawOnlyLoading,
-    selectedToken,
-    isSwap,
-  });
+  const { data: isCanonicalTransfer = false } = useSWRImmutable(
+    [
+      networks.sourceChain.id,
+      networks.destinationChain.id,
+      childChain.id,
+      parentChain.id,
+      isSelectedTokenWithdrawOnly,
+      isSelectedTokenWithdrawOnlyLoading,
+      selectedToken?.address ?? null,
+      isSwap,
+      'useIsArbitrumCanonicalTransfer',
+    ] as const,
+    ([
+      sourceChainId,
+      destinationChainId,
+      childChainId,
+      parentChainId,
+      _isSelectedTokenWithdrawOnly,
+      _isSelectedTokenWithdrawOnlyLoading,
+      ,
+      _isSwap,
+    ]) =>
+      isArbitrumCanonicalTransfer({
+        sourceChainId,
+        destinationChainId,
+        childChainId,
+        parentChainId,
+        isSelectedTokenWithdrawOnly: _isSelectedTokenWithdrawOnly,
+        isSelectedTokenWithdrawOnlyLoading: _isSelectedTokenWithdrawOnlyLoading,
+        selectedToken,
+        isSwap: _isSwap,
+      }),
+  );
+
+  return isCanonicalTransfer;
 };

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useSelectedTokenIsWithdrawOnly.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useSelectedTokenIsWithdrawOnly.ts
@@ -1,6 +1,3 @@
-import { useMemo } from 'react';
-import useSWRImmutable from 'swr/immutable';
-
 import { useNetworks } from '../../../hooks/useNetworks';
 import { useNetworksRelationship } from '../../../hooks/useNetworksRelationship';
 import { useSelectedToken } from '../../../hooks/useSelectedToken';
@@ -9,35 +6,18 @@ import { isWithdrawOnlyToken } from '../../../util/WithdrawOnlyUtils';
 export function useSelectedTokenIsWithdrawOnly() {
   const [selectedToken] = useSelectedToken();
   const [networks] = useNetworks();
-  const { isDepositMode, parentChain, childChain } = useNetworksRelationship(networks);
+  const { isDepositMode, childChain } = useNetworksRelationship(networks);
 
-  const queryKey = useMemo(() => {
-    if (!selectedToken) {
-      return null;
-    }
-    if (!isDepositMode) {
-      return null;
-    }
-    return [
-      selectedToken.address.toLowerCase(),
-      parentChain.id,
-      childChain.id,
-      'useSelectedTokenIsWithdrawOnly',
-    ] as const;
-  }, [selectedToken, isDepositMode, parentChain.id, childChain.id]);
-
-  const { data: isSelectedTokenWithdrawOnly, isLoading } = useSWRImmutable(
-    queryKey,
-    ([parentChainErc20Address, parentChainId, childChainId]) =>
-      isWithdrawOnlyToken({
-        parentChainErc20Address,
-        parentChainId,
-        childChainId,
-      }),
-  );
+  const isSelectedTokenWithdrawOnly =
+    !!selectedToken &&
+    isDepositMode &&
+    isWithdrawOnlyToken({
+      parentChainErc20Address: selectedToken.address,
+      childChainId: childChain.id,
+    });
 
   return {
-    isSelectedTokenWithdrawOnly: !!isSelectedTokenWithdrawOnly,
-    isSelectedTokenWithdrawOnlyLoading: isLoading,
+    isSelectedTokenWithdrawOnly,
+    isSelectedTokenWithdrawOnlyLoading: false,
   };
 }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/isDisabledCanonicalTransfer.test.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/isDisabledCanonicalTransfer.test.ts
@@ -1,0 +1,163 @@
+import { constants } from 'ethers';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ERC20BridgeToken, TokenType } from '../../hooks/arbTokenBridge.types';
+import { ChainId } from '../../types/ChainId';
+import { isDisabledCanonicalTransfer } from './isDisabledCanonicalTransfer';
+
+// OFT tokens whose canonical deposit is blocked in favor of their OFT route
+const { BLOCKED_OFT_PARENT_ADDRESSES } = vi.hoisted(() => ({
+  BLOCKED_OFT_PARENT_ADDRESSES: [
+    '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDT on Ethereum
+    '0x64d3cae387405d91f7b0d91fb1d824a281719500', // GS on Ethereum
+  ],
+}));
+
+vi.mock('../../util/WithdrawOnlyUtils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../util/WithdrawOnlyUtils')>();
+  return {
+    ...actual,
+    // tests run concurrently, so key the mock on its arguments instead of mutating it per test
+    isBlockedOftDeposit: vi.fn(
+      async ({ parentChainErc20Address }: { parentChainErc20Address: string }) =>
+        BLOCKED_OFT_PARENT_ADDRESSES.some(
+          (address) => address.toLowerCase() === parentChainErc20Address.toLowerCase(),
+        ),
+    ),
+  };
+});
+
+function buildToken(address: string): ERC20BridgeToken {
+  return {
+    address,
+    decimals: 18,
+    name: 'Test Token',
+    symbol: 'TEST',
+    type: TokenType.ERC20,
+    listIds: new Set<string>(),
+  };
+}
+
+const usdcToken = buildToken('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48');
+const rdpxToken = buildToken('0x0ff5A8451A839f5F0BB3562689D9A44089738D11');
+
+const baseParams = {
+  selectedToken: usdcToken,
+  isDepositMode: true,
+  parentChainId: ChainId.Ethereum,
+  childChainId: ChainId.ArbitrumOne,
+  isSelectedTokenWithdrawOnly: false,
+  isSelectedTokenWithdrawOnlyLoading: false,
+};
+
+describe('isDisabledCanonicalTransfer', () => {
+  it('returns false when no token is selected', async () => {
+    expect(
+      await isDisabledCanonicalTransfer({
+        ...baseParams,
+        selectedToken: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for a regular token with no restrictions', async () => {
+    expect(await isDisabledCanonicalTransfer(baseParams)).toBe(false);
+  });
+
+  it('returns true for a token in the transfer-disabled list, regardless of direction (rDPX)', async () => {
+    expect(
+      await isDisabledCanonicalTransfer({
+        ...baseParams,
+        selectedToken: rdpxToken,
+      }),
+    ).toBe(true);
+
+    expect(
+      await isDisabledCanonicalTransfer({
+        ...baseParams,
+        selectedToken: rdpxToken,
+        isDepositMode: false,
+      }),
+    ).toBe(true);
+  });
+
+  it.each(BLOCKED_OFT_PARENT_ADDRESSES)(
+    'returns true when the canonical deposit is blocked in favor of the OFT route (%s)',
+    async (address) => {
+      expect(
+        await isDisabledCanonicalTransfer({
+          ...baseParams,
+          selectedToken: buildToken(address),
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it('returns true for ETH from Arbitrum One to ApeChain', async () => {
+    expect(
+      await isDisabledCanonicalTransfer({
+        ...baseParams,
+        selectedToken: buildToken(constants.AddressZero),
+        parentChainId: ChainId.ArbitrumOne,
+        childChainId: ChainId.ApeChain,
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for an ERC20 from Arbitrum One to ApeChain', async () => {
+    expect(
+      await isDisabledCanonicalTransfer({
+        ...baseParams,
+        parentChainId: ChainId.ArbitrumOne,
+        childChainId: ChainId.ApeChain,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for ETH token address on other chain pairs', async () => {
+    expect(
+      await isDisabledCanonicalTransfer({
+        ...baseParams,
+        selectedToken: buildToken(constants.AddressZero),
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when depositing a withdraw-only token', async () => {
+    expect(
+      await isDisabledCanonicalTransfer({
+        ...baseParams,
+        isSelectedTokenWithdrawOnly: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false while the withdraw-only status is still loading', async () => {
+    expect(
+      await isDisabledCanonicalTransfer({
+        ...baseParams,
+        isSelectedTokenWithdrawOnly: true,
+        isSelectedTokenWithdrawOnlyLoading: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when withdrawing a withdraw-only token', async () => {
+    expect(
+      await isDisabledCanonicalTransfer({
+        ...baseParams,
+        isSelectedTokenWithdrawOnly: true,
+        isDepositMode: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when the withdraw-only status is undefined', async () => {
+    expect(
+      await isDisabledCanonicalTransfer({
+        ...baseParams,
+        isSelectedTokenWithdrawOnly: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/isDisabledCanonicalTransfer.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/isDisabledCanonicalTransfer.ts
@@ -1,0 +1,51 @@
+import { constants } from 'ethers';
+
+import { ERC20BridgeToken } from '../../hooks/arbTokenBridge.types';
+import { ChainId } from '../../types/ChainId';
+import { addressesEqual } from '../../util/AddressUtils';
+import { isTransferDisabledToken } from '../../util/TokenTransferDisabledUtils';
+import { isBlockedOftDeposit } from '../../util/WithdrawOnlyUtils';
+
+export async function isDisabledCanonicalTransfer({
+  selectedToken,
+  isDepositMode,
+  parentChainId,
+  childChainId,
+  isSelectedTokenWithdrawOnly,
+  isSelectedTokenWithdrawOnlyLoading,
+}: {
+  selectedToken: ERC20BridgeToken | null;
+  isDepositMode: boolean;
+  parentChainId: ChainId;
+  childChainId: ChainId;
+  isSelectedTokenWithdrawOnly: boolean | undefined;
+  isSelectedTokenWithdrawOnlyLoading: boolean;
+}) {
+  if (!selectedToken) {
+    return false;
+  }
+
+  if (isTransferDisabledToken(selectedToken.address, childChainId)) {
+    return true;
+  }
+
+  if (
+    await isBlockedOftDeposit({
+      parentChainErc20Address: selectedToken.address,
+      parentChainId,
+      childChainId,
+    })
+  ) {
+    return true;
+  }
+
+  if (
+    parentChainId === ChainId.ArbitrumOne &&
+    childChainId === ChainId.ApeChain &&
+    addressesEqual(selectedToken.address, constants.AddressZero)
+  ) {
+    return true;
+  }
+
+  return !!(isDepositMode && isSelectedTokenWithdrawOnly && !isSelectedTokenWithdrawOnlyLoading);
+}

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -360,7 +360,7 @@ export function isCanonicalDepositBlocked({
   return hasOftChildDeployment;
 }
 
-async function isBlockedOftDeposit({
+export async function isBlockedOftDeposit({
   parentChainErc20Address,
   parentChainId,
   childChainId,
@@ -405,13 +405,11 @@ async function isBlockedOftDeposit({
  * @param erc20L1Address
  * @param childChainId
  */
-export async function isWithdrawOnlyToken({
+export function isWithdrawOnlyToken({
   parentChainErc20Address,
-  parentChainId,
   childChainId,
 }: {
   parentChainErc20Address: string;
-  parentChainId: number;
   childChainId: number;
 }) {
   // disable USDC.e deposits for Orbit chains
@@ -428,10 +426,6 @@ export async function isWithdrawOnlyToken({
     .includes(parentChainErc20Address.toLowerCase());
 
   if (inWithdrawOnlyList) {
-    return true;
-  }
-
-  if (await isBlockedOftDeposit({ parentChainErc20Address, parentChainId, childChainId })) {
     return true;
   }
 

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -402,7 +402,7 @@ export async function isBlockedOftDeposit({
 
 /**
  *
- * @param erc20L1Address
+ * @param parentChainErc20Address
  * @param childChainId
  */
 export function isWithdrawOnlyToken({


### PR DESCRIPTION
This branch removed the OFT token detection from `isWithdrawOnlyToken` because we want to allow deposits via Li.Fi, so OFT tokens are not withdraw-only.

Only OFT tokens wrongly bridged via the canonical bridge are withdraw-only. For that, we could not support them out of the box, but if we set up the deposits correctly from the beginning based on our OFT token detection, wrongly-canonical-bridged OFTs should be impossible to happen via the UI.

## UI improvement vs Prod
picked GammaSwap (0xb08d8becab1bf76a9ce3d2d5fa946f65ec1d3e83) for testing
This is from the OFT list on https://docs.layerzero.network/v2/deployments/chains/arbitrum

### Deposits
On this branch, allow OFT deposits via Li.Fi
<img width="692" height="884" alt="image" src="https://github.com/user-attachments/assets/7c816d18-117a-4b13-9423-01fc24be73d3" />

#### Base branch and Prod
did not allow OFT deposits via Li.Fi
<img width="678" height="867" alt="image" src="https://github.com/user-attachments/assets/0365db93-80e3-4915-a938-91fc606c7bb3" />

### Withdrawals
<img width="674" height="833" alt="image" src="https://github.com/user-attachments/assets/94a05c4b-3c30-4e1b-80c0-866c51b382ec" />

#### Base branch and Prod
mistakenly showing canonical withdrawal route for child chain OFT address (should only be a possible route for the canonically bridged address)
<img width="677" height="927" alt="image" src="https://github.com/user-attachments/assets/596abc40-7791-407a-9da1-573c397482d1" />