### PR TITLE
fix(bridge): limit tx history block range for AltLayer chains

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -65,6 +65,9 @@ const BATCH_FETCH_BLOCKS: { [key: number]: number } = {
   1628: 10_000, // T-REX
   228: 10_000, // Mind Network
   869: 10_000, // World Mobile Chain
+  680: 10_000, // JASMY Chain
+  20010: 10_000, // Mandala Chain
+  704851: 10_000, // Mars Chain
 };
 
 export type UseTransactionHistoryResult = {


### PR DESCRIPTION
Limit the tx history RPC block range to 10k for the AltLayer chains JASMY (680), Mandala (20010), and Mars (704851). Follows the existing per-chain `BATCH_FETCH_BLOCKS` pattern. T-Rex (1628) was already limited.