### PR TITLE
feat(bridge): block USDC deposits to Robinhood Chain

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { isCanonicalDepositBlocked } from './WithdrawOnlyUtils';
+import { ChainId } from '../types/ChainId';
+import { CommonAddress } from './CommonAddressUtils';
+import { isCanonicalDepositBlocked, isWithdrawOnlyToken } from './WithdrawOnlyUtils';
 
 const CANONICAL_ENA_ARB = '0xdf8f0c63d9335a0abd89f9f752d293a98ea977d8'; // standard-gateway address
 const USDC_E_ARB = '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8';
@@ -68,6 +70,26 @@ describe('isCanonicalDepositBlocked', () => {
         canonicalChildTokenAddress: CANONICAL_FRAX_ARB,
         canonicalIsKnownLayerZeroToken: false,
         hasOftChildDeployment: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isWithdrawOnlyToken', () => {
+  it('disables USDC deposits to Robinhood Chain', () => {
+    expect(
+      isWithdrawOnlyToken({
+        parentChainErc20Address: CommonAddress.Ethereum.USDC,
+        childChainId: ChainId.RobinhoodChain,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps USDC deposits enabled for Arbitrum One', () => {
+    expect(
+      isWithdrawOnlyToken({
+        parentChainErc20Address: CommonAddress.Ethereum.USDC,
+        childChainId: ChainId.ArbitrumOne,
       }),
     ).toBe(false);
   });

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -267,6 +267,14 @@ export const withdrawOnlyTokens: { [chainId: number]: WithdrawOnlyToken[] } = {
     },
   ],
   [ChainId.ArbitrumNova]: [],
+  [ChainId.RobinhoodChain]: [
+    {
+      symbol: 'USDC',
+      l2CustomAddr: '',
+      l1Address: CommonAddress.Ethereum.USDC,
+      l2Address: '0x80e0e24718dbFcad49ECAA6F1e6C89A190586cA8',
+    },
+  ],
   // Plume
   98866: [
     {


### PR DESCRIPTION
USDC doesn't have a native CCTP deployment on RobinHood chain, leading the canonical route to bridge to the wrong L2 token. This makes USDC(e) withdraw-only on Robinhood Chain.

Closes FS-2397