### PR TITLE
fix(bridge): tighten source chain checks before transfers

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -416,7 +416,7 @@ export function TransferPanel() {
     if (!signer) {
       throw new Error(signerUndefinedError);
     }
-    if (!isTransferAllowed) {
+    if (!isTransferAllowed.current) {
       throw new Error(transferNotAllowedError);
     }
 
@@ -535,7 +535,7 @@ export function TransferPanel() {
       if (!signer) {
         throw new Error(signerUndefinedError);
       }
-      if (!isTransferAllowed) {
+      if (!isTransferAllowed.current) {
         throw new Error(transferNotAllowedError);
       }
       if (!context) {
@@ -752,7 +752,7 @@ export function TransferPanel() {
     if (!signer) {
       throw new Error(signerUndefinedError);
     }
-    if (!isTransferAllowed) {
+    if (!isTransferAllowed.current) {
       throw new Error(transferNotAllowedError);
     }
 
@@ -883,7 +883,7 @@ export function TransferPanel() {
   const transfer = async () => {
     const sourceChainId = latestNetworks.current.sourceChain.id;
 
-    if (!isTransferAllowed) {
+    if (!isTransferAllowed.current) {
       throw new Error(transferNotAllowedError);
     }
 
@@ -1279,7 +1279,7 @@ export function TransferPanel() {
       setTransferring(false);
     }
 
-    if (!isTransferAllowed) {
+    if (!isTransferAllowed.current) {
       return networkConnectionWarningToast();
     }
 

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/LifiTransferStarter.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/LifiTransferStarter.ts
@@ -121,11 +121,13 @@ export class LifiTransferStarter extends BridgeTransferStarter {
       throw new Error('LifiTransferStarter is missing transaction request.');
     }
 
-    const { to, data, value } = this.lifiData.transactionRequest;
+    const { to, data, value, chainId } = this.lifiData.transactionRequest;
+    // pinning chainId propagates viem's active-chain assertion to the send
     const txHash = await sendTransaction(wagmiConfig, {
       to: to as Address,
       data: data as Address,
       value: BigInt(value),
+      chainId,
     });
     const fullTx = await this.sourceChainProvider.getTransaction(txHash);
 


### PR DESCRIPTION
## Summary

- Pass `chainId` to `sendTransaction` for LiFi transfers so viem verifies the wallet's reported chain right before dispatch. Some wallets (mostly mobile in-app browsers) don't complete `wallet_switchEthereumChain` cleanly; pinning the chainId lets the existing viem assertion catch that before the transaction is sent.
- Update the `isTransferAllowed` guards in `TransferPanel` to read the `useLatest` ref value, restoring the pre-transfer readiness re-check.

## Test plan

- Wallet on the source chain: LiFi transfer proceeds unchanged.
- Wallet on a different chain than the app's source chain at dispatch time: transfer is blocked with a chain-mismatch error instead of being handed to the wallet.