### PR TITLE
feat(bridge): block canonical USDT deposits to RH chain

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
@@ -85,6 +85,15 @@ describe('isWithdrawOnlyToken', () => {
     ).toBe(true);
   });
 
+  it('disables USDT deposits to Robinhood Chain', () => {
+    expect(
+      isWithdrawOnlyToken({
+        parentChainErc20Address: CommonAddress.Ethereum.USDT,
+        childChainId: ChainId.RobinhoodChain,
+      }),
+    ).toBe(true);
+  });
+
   it('keeps USDC deposits enabled for Arbitrum One', () => {
     expect(
       isWithdrawOnlyToken({

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -274,6 +274,13 @@ export const withdrawOnlyTokens: { [chainId: number]: WithdrawOnlyToken[] } = {
       l1Address: CommonAddress.Ethereum.USDC,
       l2Address: '0x80e0e24718dbFcad49ECAA6F1e6C89A190586cA8',
     },
+    {
+      // USDT reaches Robinhood Chain via LayerZero (USDT0); block the canonical route.
+      symbol: 'USDT',
+      l2CustomAddr: '',
+      l1Address: CommonAddress.Ethereum.USDT,
+      l2Address: '0xE246BC49b0598d7Cd9f0eAD48B885034f1254380',
+    },
   ],
   // Plume
   98866: [


### PR DESCRIPTION
USDT is a LayerZero (USDT0) implementation, so a canonical deposit lands on a bridged token rather than the USDT0 users expect. 

LayerZero's metadata lists no USDT on Robinhood Chain, so the automatic OFT detection doesn't catch it. Hence this needs to be blocked manually.

## Test
- Added a unit test asserting `isWithdrawOnlyToken` blocks USDT → Robinhood Chain.

Closes FS-2399