### PR TITLE
fix(bridge): disable transfers for Trust Wallet connections

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadiness.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadiness.ts
@@ -1,3 +1,4 @@
+import { useWalletInfo } from '@reown/appkit/react';
 import { useLocalStorage } from '@uidotdev/usehooks';
 import { BigNumber, constants, utils } from 'ethers';
 import { useMemo } from 'react';
@@ -34,6 +35,7 @@ import {
   TransferReadinessRichErrorMessage,
   getInsufficientFundsErrorMessage,
   getInsufficientFundsForGasFeesErrorMessage,
+  getTrustWalletDisabledErrorMessage,
   getWithdrawOnlyChainErrorMessage,
 } from './useTransferReadinessUtils';
 
@@ -227,6 +229,8 @@ export function useTransferReadiness(): UseTransferReadinessResult {
   const { destinationAddressError } = useDestinationAddressError();
   const [tosAccepted] = useLocalStorage<boolean>(TOS_LOCALSTORAGE_KEY);
   const tokensFromLists = useTokensFromLists();
+  const { walletInfo } = useWalletInfo('eip155');
+  const isTrustWalletConnection = (walletInfo?.name ?? '').toLowerCase().includes('trust wallet');
 
   const ethL1BalanceFloat = ethParentBalance
     ? parseFloat(utils.formatEther(ethParentBalance))
@@ -307,6 +311,14 @@ export function useTransferReadiness(): UseTransferReadinessResult {
       isSmartContractWallet,
       isDepositMode,
     });
+
+    if (isTrustWalletConnection) {
+      return notReady({
+        errorMessages: {
+          inputAmount1: getTrustWalletDisabledErrorMessage(),
+        },
+      });
+    }
 
     if (!selectedRoute) {
       return notReady();
@@ -721,5 +733,6 @@ export function useTransferReadiness(): UseTransferReadinessResult {
     isSelectedTokenWithdrawOnly,
     isSelectedTokenWithdrawOnlyLoading,
     selectedRouteContext,
+    isTrustWalletConnection,
   ]);
 }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadinessUtils.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadinessUtils.ts
@@ -43,3 +43,7 @@ export function getInsufficientFundsForGasFeesErrorMessage({
 export function getWithdrawOnlyChainErrorMessage(chainName: string) {
   return `${chainName} has currently suspended deposits. You can only withdraw assets from this chain.`;
 }
+
+export function getTrustWalletDisabledErrorMessage() {
+  return 'Bridging with Trust Wallet is temporarily disabled due to a high rate of failed transactions. Please connect with a different wallet to continue.';
+}

--- a/packages/arb-token-bridge-ui/vitest.integration.setup.tsx
+++ b/packages/arb-token-bridge-ui/vitest.integration.setup.tsx
@@ -58,6 +58,13 @@ vi.mock('./src/wallet/hooks/useWalletModal', () => ({
   }),
 }));
 
+// Avoid error from appkit hooks requiring createAppKit to be called first
+vi.mock('@reown/appkit/react', () => ({
+  createAppKit: vi.fn(),
+  useAppKit: () => ({ open: vi.fn() }),
+  useWalletInfo: () => ({ walletInfo: undefined }),
+}));
+
 class MockLoadedImage {
   onload: ((event: Event) => void) | null = null;
   onerror: ((event: Event) => void) | null = null;


### PR DESCRIPTION
## Summary

Temporarily disables bridge transfers when the connected wallet is Trust Wallet, due to a high rate of failed transactions observed for Trust Wallet connections.

When Trust Wallet is connected, the Move Funds button is disabled and the transfer panel shows:

> Bridging with Trust Wallet is temporarily disabled due to a high rate of failed transactions. Please connect with a different wallet to continue.

Wallet detection uses the connector's `walletInfo.name` (same source as our analytics tagging). All other wallets are unaffected.

## Test plan

- Connect with Trust Wallet → Move Funds disabled, message shown under the amount input
- Connect with any other wallet → unchanged behavior
- `useTransferReadiness` and TransferPanel test suites pass (61 tests)