### PR TITLE
fix(bridge): pin CCTP subgraph to a known-good indexer

### DIFF
--- a/packages/arb-token-bridge-ui/src/api-utils/ServerSubgraphUtils.ts
+++ b/packages/arb-token-bridge-ui/src/api-utils/ServerSubgraphUtils.ts
@@ -15,15 +15,30 @@ type SubgraphKey = keyof typeof subgraphs;
 
 type TheGraphNetworkSubgraphId = (typeof subgraphs)[SubgraphKey]['theGraphNetworkSubgraphId'];
 
+type Subgraph = {
+  selfHostedSubgraph: string;
+  theGraphNetworkSubgraphId: string;
+  // pin queries to a single known-good indexer, e.g. while others serve incomplete data
+  // due to https://github.com/graphprotocol/graph-node/issues/6683
+  deploymentId?: string;
+  pinnedIndexer?: string;
+};
+
 const subgraphs = {
   // CCTP Mainnet Subgraphs
   'cctp-ethereum': {
     selfHostedSubgraph: '',
     theGraphNetworkSubgraphId: 'E6iPLnDGEgrcc4gu9uiHJxENSRAAzTvUJqQqJcHZqJT1',
+    deploymentId: 'QmWgi6hNfwCGiTAhH7gTSMSfvvYUPRbBQSjRmvuviRGGwy',
+    // Lunanova (https://thegraph.lunanova.tech), verified serving complete data
+    pinnedIndexer: '0xe13840a2e92e0cb17a246609b432d0fa2e418774',
   },
   'cctp-arbitrum-one': {
     selfHostedSubgraph: '',
     theGraphNetworkSubgraphId: '9DgSggKVrvfi4vdyYTdmSBuPgDfm3D7zfLZ1qaQFjYYW',
+    deploymentId: 'QmQtNd36amtQ8h8GF5rwkLLWyyBGwqad3j3WgZAMuLvDMd',
+    // Lunanova (https://thegraph.lunanova.tech), verified serving complete data
+    pinnedIndexer: '0xe13840a2e92e0cb17a246609b432d0fa2e418774',
   },
   // CCTP Testnet Subgraphs
   'cctp-sepolia': {
@@ -63,13 +78,14 @@ const subgraphs = {
     selfHostedSubgraph: '',
     theGraphNetworkSubgraphId: 'AaUuKWWuQbCXbvRkXpVDEpw9B7oVicYrovNyMLPZtLPw',
   },
-} as const;
+} satisfies Record<string, Subgraph>;
 
-function createApolloClient(uri: string) {
+function createApolloClient(uri: string, headers?: Record<string, string>) {
   const timeoutLink = new ApolloLinkTimeout();
   const httpLink = timeoutLink.concat(
     new HttpLink({
       uri,
+      headers,
       fetch: (url, options) => fetch(url, { ...options, cache: 'no-store' }),
     }),
   );
@@ -93,7 +109,9 @@ function createSelfHostedSubgraphClient(subgraphName: string) {
 
 function createTheGraphNetworkClient(subgraphId: TheGraphNetworkSubgraphId) {
   if (typeof theGraphNetworkApiKey === 'undefined' || theGraphNetworkApiKey === '') {
-    throw new Error(`[createTheGraphNetworkClient] missing "GRAPH_NETWORK_API_KEY" env variable"`);
+    throw new Error(
+      `[createTheGraphNetworkClient] missing "THE_GRAPH_NETWORK_API_KEY" env variable`,
+    );
   }
 
   return createApolloClient(
@@ -101,13 +119,38 @@ function createTheGraphNetworkClient(subgraphId: TheGraphNetworkSubgraphId) {
   );
 }
 
+function createPinnedIndexerClient(deploymentId: string, indexerAddress: string) {
+  if (typeof theGraphNetworkApiKey === 'undefined' || theGraphNetworkApiKey === '') {
+    throw new Error(`[createPinnedIndexerClient] missing "THE_GRAPH_NETWORK_API_KEY" env variable`);
+  }
+
+  return createApolloClient(
+    `https://gateway.thegraph.com/api/deployments/id/${deploymentId}/indexers/id/${indexerAddress}`,
+    { Authorization: `Bearer ${theGraphNetworkApiKey}` },
+  );
+}
+
 function createSubgraphClient(key: SubgraphKey) {
   logger.debug(`[createSubgraphClient] key=${key}`);
 
-  const { theGraphNetworkSubgraphId, selfHostedSubgraph } = subgraphs[key];
+  const { theGraphNetworkSubgraphId, selfHostedSubgraph, deploymentId, pinnedIndexer }: Subgraph =
+    subgraphs[key];
 
   if (selfHostedSubgraph !== '') {
     return createSelfHostedSubgraphClient(selfHostedSubgraph);
+  }
+
+  if ((typeof deploymentId === 'undefined') !== (typeof pinnedIndexer === 'undefined')) {
+    throw new Error(
+      `[createSubgraphClient] both "deploymentId" and "pinnedIndexer" must be set for "${key}"`,
+    );
+  }
+
+  if (typeof deploymentId !== 'undefined' && typeof pinnedIndexer !== 'undefined') {
+    logger.debug(
+      `[createSubgraphClient] using deployment "${deploymentId}" pinned to indexer "${pinnedIndexer}"`,
+    );
+    return createPinnedIndexerClient(deploymentId, pinnedIndexer);
   }
 
   logger.debug(

--- a/packages/arb-token-bridge-ui/src/api-utils/__tests__/ServerSubgraphUtils.integration.test.ts
+++ b/packages/arb-token-bridge-ui/src/api-utils/__tests__/ServerSubgraphUtils.integration.test.ts
@@ -1,0 +1,26 @@
+import { gql } from '@apollo/client';
+import { describe, expect, it } from 'vitest';
+
+import { ChainId } from '../../types/ChainId';
+import { getCctpSubgraphClient } from '../ServerSubgraphUtils';
+
+// missing from unpinned indexers due to https://github.com/graphprotocol/graph-node/issues/6683
+const transactionHash = '0x77894001ee62c0b245e6e9c3b35fcdc79e917ce352b20a0b2ec49e8d916734c2';
+
+describe('getCctpSubgraphClient', () => {
+  it('returns the transfer missing from unpinned indexers', async () => {
+    const { data } = await getCctpSubgraphClient(ChainId.Ethereum).query({
+      query: gql`
+        {
+          messageSents(where: { transactionHash: "${transactionHash}" }) {
+            id
+            transactionHash
+          }
+        }
+      `,
+    });
+
+    expect(data.messageSents).toHaveLength(1);
+    expect(data.messageSents[0].transactionHash).toEqual(transactionHash);
+  });
+});


### PR DESCRIPTION
Some indexers serve incomplete CCTP subgraph data (`MessageSent` entities missing on graph-node >= 0.42, graphprotocol/graph-node#6683), so CCTP transfers were intermittently missing from transaction history. This pins CCTP queries to a known-good indexer via the gateway's deployment endpoint until the fixed subgraphs (OffchainLabs/arbitrum-subgraphs#43) are republished.

The pin is configured per subgraph via the optional `deploymentId` / `pinnedIndexer` fields; removing them restores normal gateway routing.

### Steps to test

1. Open transaction history and search for the address `0x2a306013ECEf96C2fD06995f7F140a17A095dA71`
2. Look for the CCTP deposit [`0x778940...34c2`](https://etherscan.io/tx/0x77894001ee62c0b245e6e9c3b35fcdc79e917ce352b20a0b2ec49e8d916734c2) (Jul 12)

On prod the deposit may or may not appear - the gateway routes each query to an arbitrary indexer, some of which serve a dataset missing all CCTP transfers after Jun 24. On this branch it appears every time.

Closes FS-2400