### PR TITLE
fix(bridge): only run OFT check on parent-child routes

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { ChainId } from '../types/ChainId';
 import { CommonAddress } from './CommonAddressUtils';
-import { isCanonicalDepositBlocked, isWithdrawOnlyToken } from './WithdrawOnlyUtils';
+import {
+  isBlockedOftDeposit,
+  isCanonicalDepositBlocked,
+  isWithdrawOnlyToken,
+} from './WithdrawOnlyUtils';
 
 const CANONICAL_ENA_ARB = '0xdf8f0c63d9335a0abd89f9f752d293a98ea977d8'; // standard-gateway address
 const USDC_E_ARB = '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8';
@@ -72,6 +76,18 @@ describe('isCanonicalDepositBlocked', () => {
         hasOftChildDeployment: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe('isBlockedOftDeposit', () => {
+  it('does not block when the destination is not a canonical child of the source', async () => {
+    await expect(
+      isBlockedOftDeposit({
+        parentChainErc20Address: CommonAddress.ArbitrumOne.WETH,
+        parentChainId: ChainId.ArbitrumOne,
+        childChainId: ChainId.RobinhoodChain,
+      }),
+    ).resolves.toBe(false);
   });
 });
 

--- a/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/WithdrawOnlyUtils.ts
@@ -1,5 +1,6 @@
 // tokens that can't be bridged to Arbitrum (maybe coz they have their native protocol bridges and custom implementation or they are being discontinued)
 // the UI doesn't let users deposit such tokens. If bridged already, these can only be withdrawn.
+import { getArbitrumNetwork } from '@arbitrum/sdk';
 import { ethers } from 'ethers';
 
 import { getProviderForChainId } from '@/token-bridge-sdk/utils';
@@ -375,6 +376,14 @@ export function isCanonicalDepositBlocked({
   return hasOftChildDeployment;
 }
 
+function getParentChainId(chainId: number): number | undefined {
+  try {
+    return getArbitrumNetwork(chainId).parentChainId;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function isBlockedOftDeposit({
   parentChainErc20Address,
   parentChainId,
@@ -384,6 +393,12 @@ export async function isBlockedOftDeposit({
   parentChainId: number;
   childChainId: number;
 }) {
+  // Only a real parent/child deposit has a canonical route to evaluate; skip pairs
+  // like Arbitrum One to Robinhood Chain, whose canonical parent is Ethereum.
+  if (getParentChainId(childChainId) !== parentChainId) {
+    return false;
+  }
+
   const { isOft, hasOftChildDeployment } = await getLayerZeroOftInfo({
     parentChainId,
     parentTokenAddress: parentChainErc20Address,


### PR DESCRIPTION
`isBlockedOftDeposit` ran the canonical-address lookup for every deposit, including sibling pairs whose destination is not a canonical child of the source. The lookup cannot resolve there and returns null, which was treated as a block.

Example: bridging WETH from Arbitrum One to Robinhood Chain showed the "Token cannot be bridged here" dialog. Robinhood Chain's canonical parent is Ethereum, not Arbitrum One, so the canonical lookup failed and WETH was wrongly flagged as non-bridgeable.

This scopes the check to run only when the destination chain's canonical parent is the source chain.

## Test
Added a unit test asserting `isBlockedOftDeposit` returns false for WETH from Arbitrum One to Robinhood Chain.