### PR TITLE
wip(bridge): keep lifi token registry under 2MB

### DIFF
--- a/packages/app/src/app/api/crosschain-transfers/lifi/tokens/registry.ts
+++ b/packages/app/src/app/api/crosschain-transfers/lifi/tokens/registry.ts
@@ -1,7 +1,10 @@
 import { CoinKey, ChainId as LiFiChainId, type Token as LiFiToken, getTokens } from '@lifi/sdk';
 import { unstable_cache } from 'next/cache';
 
-import { allowedLifiSourceChainIds } from '@/bridge/app/api/crosschain-transfers/constants';
+import {
+  allowedLifiSourceChainIds,
+  lifiDestinationChainIds,
+} from '@/bridge/app/api/crosschain-transfers/constants';
 import { ChainId } from '@/bridge/types/ChainId';
 import { CommonAddress } from '@/bridge/util/CommonAddressUtils';
 
@@ -182,25 +185,89 @@ export interface LifiTokenRegistry {
   tokensByChainAndCoinKey: Record<number, Record<string, LifiTokenWithCoinKey>>;
 }
 
-const fetchRegistry = async (): Promise<LifiTokenRegistry> => {
+// LiFi returns extra metadata (e.g. verification status breakdowns) that nothing downstream reads
+function toSlimToken(token: LifiTokenWithCoinKey): LifiTokenWithCoinKey {
+  return {
+    chainId: token.chainId,
+    address: token.address,
+    symbol: token.symbol,
+    decimals: token.decimals,
+    name: token.name,
+    coinKey: token.coinKey,
+    logoURI: token.logoURI,
+    priceUSD: token.priceUSD,
+  };
+}
+
+// Chains reachable from each chain, in either direction
+const PARTNER_CHAIN_IDS: Record<number, Set<number>> = {};
+for (const [sourceChainId, destinationChainIds] of Object.entries(lifiDestinationChainIds)) {
+  const sourceChainIdNum = Number(sourceChainId);
+  for (const destinationChainId of destinationChainIds) {
+    (PARTNER_CHAIN_IDS[sourceChainIdNum] ??= new Set()).add(destinationChainId);
+    (PARTNER_CHAIN_IDS[destinationChainId] ??= new Set()).add(sourceChainIdNum);
+  }
+}
+
+/**
+ * Tokens are matched across chains by coinKey (see groupChildTokensAndParentTokens),
+ * so a token whose coinKey doesn't exist on any partner chain can never appear
+ * in a route and only bloats the cache. LiFi returns thousands of such tokens
+ * (e.g. Ethereum-only meme tokens).
+ */
+function keepRoutableTokens(
+  tokensByChain: LifiTokenRegistry['tokensByChain'],
+): LifiTokenRegistry['tokensByChain'] {
+  const coinKeysByChain: Record<number, Set<CoinKey>> = {};
+  for (const chainId of allowedLifiSourceChainIds) {
+    coinKeysByChain[chainId] = new Set(
+      (tokensByChain[chainId] ?? []).map((token) => token.coinKey),
+    );
+  }
+
+  const routableTokensByChain: LifiTokenRegistry['tokensByChain'] = {};
+
+  for (const chainId of allowedLifiSourceChainIds) {
+    const partnerCoinKeys = new Set<CoinKey>();
+    for (const partnerChainId of PARTNER_CHAIN_IDS[chainId] ?? []) {
+      for (const coinKey of coinKeysByChain[partnerChainId] ?? []) {
+        partnerCoinKeys.add(coinKey);
+      }
+
+      // ETH on a parent chain routes to WETH on ApeChain (see groupChildTokensAndParentTokens)
+      if (
+        partnerChainId === ChainId.ApeChain &&
+        coinKeysByChain[partnerChainId]?.has(CoinKey.WETH)
+      ) {
+        partnerCoinKeys.add(CoinKey.ETH);
+      }
+    }
+
+    if (chainId === ChainId.ApeChain && partnerCoinKeys.has(CoinKey.ETH)) {
+      partnerCoinKeys.add(CoinKey.WETH);
+    }
+
+    routableTokensByChain[chainId] = (tokensByChain[chainId] ?? []).filter((token) =>
+      partnerCoinKeys.has(token.coinKey),
+    );
+  }
+
+  return routableTokensByChain;
+}
+
+const fetchTokensByChain = async (): Promise<LifiTokenRegistry['tokensByChain']> => {
   const response = await getTokens({
     chains: allowedLifiSourceChainIds as unknown as LiFiChainId[],
   });
 
   if (!response.tokens) {
-    return {
-      tokensByChain: {},
-      tokensByChainAndCoinKey: {},
-    };
+    return {};
   }
 
   const tokensByChain: LifiTokenRegistry['tokensByChain'] = {};
-  const tokensByChainAndCoinKey: LifiTokenRegistry['tokensByChainAndCoinKey'] = {};
 
   for (const chainId of allowedLifiSourceChainIds) {
-    const tokensGroupedByCoinKey: Partial<Record<CoinKey, LifiTokenWithCoinKey>> = {};
-
-    const filteredTokens = (response.tokens[chainId] ?? []).reduce<LifiTokenWithCoinKey[]>(
+    tokensByChain[chainId] = (response.tokens[chainId] ?? []).reduce<LifiTokenWithCoinKey[]>(
       (acc, token) => {
         // Exclude tokens on the exclude list
         if (isExcludedToken(token, chainId)) return acc;
@@ -211,20 +278,40 @@ const fetchRegistry = async (): Promise<LifiTokenRegistry> => {
         const tokenWithLogoURI = assignLogoURI(tokenWithCoinKey);
         const normalizedToken = normalizeTokenMetadata(tokenWithLogoURI);
 
-        tokensGroupedByCoinKey[normalizedToken.coinKey] ??= normalizedToken;
-        acc.push(normalizedToken);
+        acc.push(toSlimToken(normalizedToken));
         return acc;
       },
       [],
     );
+  }
 
-    tokensByChain[chainId] = filteredTokens;
+  return keepRoutableTokens(tokensByChain);
+};
+
+/**
+ * The serialized value must stay under Next.js' 2MB unstable_cache item limit,
+ * otherwise every cache write fails and every request refetches from LiFi.
+ * So we cache only the slimmed per-chain token arrays and rebuild the
+ * coinKey lookup (which duplicates almost every token) on read.
+ */
+const getCachedTokensByChain = unstable_cache(fetchTokensByChain, ['lifi-tokens-by-chain'], {
+  revalidate: 30,
+});
+
+export async function getLifiTokenRegistry(): Promise<LifiTokenRegistry> {
+  const tokensByChain = await getCachedTokensByChain();
+
+  const tokensByChainAndCoinKey: LifiTokenRegistry['tokensByChainAndCoinKey'] = {};
+
+  for (const chainId of allowedLifiSourceChainIds) {
+    const tokensGroupedByCoinKey: Partial<Record<CoinKey, LifiTokenWithCoinKey>> = {};
+
+    for (const token of tokensByChain[chainId] ?? []) {
+      tokensGroupedByCoinKey[token.coinKey] ??= token;
+    }
+
     tokensByChainAndCoinKey[chainId] = tokensGroupedByCoinKey;
   }
 
   return { tokensByChain, tokensByChainAndCoinKey };
-};
-
-export const getLifiTokenRegistry = unstable_cache(fetchRegistry, ['lifi-token-registry'], {
-  revalidate: 30,
-});
+}

--- a/packages/app/src/app/api/crosschain-transfers/lifi/tokens/route.ts
+++ b/packages/app/src/app/api/crosschain-transfers/lifi/tokens/route.ts
@@ -84,8 +84,13 @@ export async function GET(request: NextRequest): Promise<NextResponse<TokenList>
     );
   }
 
+  // TODO: remove diagnostics
+  const startedAt = Date.now();
   try {
     const { tokensByChain, tokensByChainAndCoinKey } = await getLifiTokenRegistry();
+    console.log(
+      `[lifi-tokens-diag] registry ready in ${Date.now() - startedAt}ms parent=${parentChainId} child=${childChainId}`,
+    );
 
     const parentTokens = getParentTokensForRoute({
       parentChainId,
@@ -132,6 +137,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<TokenList>
       },
     );
   } catch (error: unknown) {
+    console.log(`[lifi-tokens-diag] registry FAILED in ${Date.now() - startedAt}ms`, error);
     return NextResponse.json(
       {
         ...BASE_TOKEN_LIST,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -2,7 +2,7 @@ import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
 import { constants } from 'ethers';
 import { isAddress } from 'ethers/lib/utils';
 import Image from 'next/image';
-import React, { FormEventHandler, useCallback, useMemo, useState } from 'react';
+import React, { FormEventHandler, useCallback, useEffect, useMemo, useState } from 'react';
 import { AutoSizer, List, ListRowProps } from 'react-virtualized';
 import useSWRImmutable from 'swr/immutable';
 import { twMerge } from 'tailwind-merge';
@@ -435,6 +435,15 @@ function TokensPanel({
     childChain.id,
     getBalance,
   ]);
+
+  // TODO: remove diagnostics
+  useEffect(() => {
+    console.error(
+      `[token-search-diag] parent=${parentChain.id} child=${childChain.id} fromLists=${
+        Object.keys(tokensFromLists).length
+      } fromUser=${Object.keys(tokensFromUser).length} show=${tokensToShow.length} search="${newToken}"`,
+    );
+  }, [parentChain.id, childChain.id, tokensFromLists, tokensFromUser, tokensToShow, newToken]);
 
   const storeNewToken = async () => {
     let error = 'Token not found on this network.';

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
@@ -23,18 +23,26 @@ export function useTokensFromLists() {
     error,
   } = useSWRImmutable(
     [tokenLists ?? [], parentChain.id, childChain.id, 'useTokensFromLists'],
-    ([_tokenLists, _parentChainId, _childChainId]) =>
-      tokenListsToSearchableTokenStorage(
+    ([_tokenLists, _parentChainId, _childChainId]) => {
+      // TODO: remove diagnostics
+      const storage = tokenListsToSearchableTokenStorage(
         _tokenLists,
         String(_parentChainId),
         String(_childChainId),
-      ),
+      );
+      console.error(
+        `[token-search-diag] storage computed lists=${_tokenLists.length} entries=${
+          Object.keys(storage).length
+        }`,
+      );
+      return storage;
+    },
   );
 
   // TODO: remove diagnostics
-  if (error) {
-    console.error(`[token-search-diag] fromLists ERROR`, error);
-  }
+  console.error(
+    `[token-search-diag] fromLists render tokenLists=${tokenLists?.length ?? 'undef'} isLoadingLists=${isLoadingTokenLists} data=${Object.keys(data).length} err=${String(error ?? '')}`,
+  );
 
   return { data, isLoading: isLoadingTokenLists || isLoading };
 }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
@@ -17,7 +17,11 @@ export function useTokensFromLists() {
   const { childChain, parentChain } = useNetworksRelationship(networks);
   const { data: tokenLists, isLoading: isLoadingTokenLists } = useTokenLists(childChain.id);
 
-  const { data = emptyData, isLoading } = useSWRImmutable(
+  const {
+    data = emptyData,
+    isLoading,
+    error,
+  } = useSWRImmutable(
     [tokenLists ?? [], parentChain.id, childChain.id, 'useTokensFromLists'],
     ([_tokenLists, _parentChainId, _childChainId]) =>
       tokenListsToSearchableTokenStorage(
@@ -26,6 +30,11 @@ export function useTokensFromLists() {
         String(_childChainId),
       ),
   );
+
+  // TODO: remove diagnostics
+  if (error) {
+    console.error(`[token-search-diag] fromLists ERROR`, error);
+  }
 
   return { data, isLoading: isLoadingTokenLists || isLoading };
 }

--- a/packages/arb-token-bridge-ui/src/hooks/useTokenLists.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTokenLists.ts
@@ -55,6 +55,10 @@ function fetchTokenLists(forL2ChainId: number, parentChainId: number): Promise<T
         [],
       );
 
+      // TODO: remove diagnostics
+      console.error(
+        `[token-list-diag] settled child=${forL2ChainId} parent=${parentChainId} lists=${tokenListsWithBridgeTokenListId.length} ids=${tokenListsWithBridgeTokenListId.map((l) => l.bridgeTokenListId).join(',')}`,
+      );
       resolve(tokenListsWithBridgeTokenListId);
     });
   });

--- a/packages/arb-token-bridge-ui/src/util/TokenListUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/TokenListUtils.ts
@@ -253,6 +253,8 @@ export async function fetchBridgeTokenList(bridgeTokenList: BridgeTokenList): Pr
 export async function fetchTokenListFromURL(tokenListURL: string): Promise<{
   data: TokenList | undefined;
 }> {
+  // TODO: remove diagnostics (console.error is visible in CI E2E logs, logger is not)
+  const startedAt = Date.now();
   try {
     const { data } = await axios.get(tokenListURL, {
       headers: {
@@ -260,8 +262,12 @@ export async function fetchTokenListFromURL(tokenListURL: string): Promise<{
       },
     });
 
+    console.error(
+      `[token-list-diag] ok ${tokenListURL} ${Date.now() - startedAt}ms tokens=${data?.tokens?.length}`,
+    );
     return { data };
   } catch (error) {
+    console.error(`[token-list-diag] fail ${tokenListURL} ${Date.now() - startedAt}ms`, error);
     logger.warn('Token List URL Invalid', tokenListURL);
     return { data: undefined };
   }


### PR DESCRIPTION
The serialized lifi token registry is ~2.6MB, over Next.js' 2MB `unstable_cache` item limit. Every cache write fails (`Failed to set Next.js data cache ... items over 2MB can not be cached`), so every request to `/api/crosschain-transfers/lifi/tokens` refetches the full token universe from li.quest. On CI runners this takes longer than the import E2E test's 30s window, which is why the Import test jobs fail on every PR. It also slows down token search for real users.

This shrinks the cached value from ~2.6MB to ~170KB (6.6%):

- Cache only `tokensByChain` and rebuild the `tokensByChainAndCoinKey` lookup on read — the lookup duplicates almost every token.
- Strip fields nothing downstream reads (e.g. verification status breakdowns).
- Drop tokens whose coinKey doesn't exist on any partner chain — they can never match a route. Includes the ApeChain ETH<>WETH special case.

Verified against live li.quest data that the route output is identical for all 25 supported chain pairs before/after.