### PR TITLE
fix(bridge): update EDU Chain rpc and explorer urls

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/orbitChainsData.json
+++ b/packages/arb-token-bridge-ui/src/util/orbitChainsData.json
@@ -294,8 +294,8 @@
         "sequencerInbox": "0xA3464bf0ed52cFe6676D3e34ab1F4DF53f193631"
       },
       "nativeToken": "0xf8173a39c56a554837C4C7f104153A005D284D11",
-      "explorerUrl": "https://educhain.blockscout.com",
-      "rpcUrl": "https://rpc.edu-chain.raas.gelato.cloud",
+      "explorerUrl": "https://explorer.educhain.xyz",
+      "rpcUrl": "https://rpc.educhain.xyz",
       "isArbitrum": true,
       "isCustom": true,
       "isTestnet": false,


### PR DESCRIPTION
Updates the EDU Chain mainnet entry in `orbitChainsData.json` per the EduChain team's request:

- RPC: `https://rpc.edu-chain.raas.gelato.cloud` → `https://rpc.educhain.xyz`
- Explorer: `https://educhain.blockscout.com` → `https://explorer.educhain.xyz`

Verified the new RPC returns the correct chain ID (41923) and the explorer resolves.

Closes FS-2431