### PR TITLE
ci: save retryable monitor run report as artifact

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -83,6 +83,14 @@ jobs:
           RETRYABLE_MONITORING_NOTION_TOKEN: ${{ secrets.RETRYABLE_MONITORING_NOTION_TOKEN }}
           RETRYABLE_MONITORING_NOTION_DB_ID: ${{ secrets.RETRYABLE_MONITORING_NOTION_DB_ID }}
 
+      - name: Upload retryable run report
+        if: inputs.monitor == 'retryable' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: retryable-run-report-${{ inputs.chain }}
+          path: arbitrum-monitoring/packages/retryable-monitor/retryable-run-report.json
+          if-no-files-found: ignore
+
       - name: Send Slack notification on failure
         if: failure()
         uses: slackapi/slack-github-action@v1.27.0

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -89,7 +89,8 @@ jobs:
         with:
           name: retryable-run-report-${{ inputs.chain }}
           path: arbitrum-monitoring/packages/retryable-monitor/retryable-run-report.json
-          if-no-files-found: ignore
+          if-no-files-found: 'ignore'
+        continue-on-error: true
 
       - name: Send Slack notification on failure
         if: failure()


### PR DESCRIPTION
Uploads the `retryable-run-report.json` produced by the retryable monitor as a run artifact, so all failed retryables found in a run (including zero-value ones that only appear in the Slack digest) can be referenced or redeemed later.

Companion to OffchainLabs/arbitrum-monitoring#123 — the file only exists once that PR lands, so `if-no-files-found: ignore` keeps runs green until then.