### PR TITLE
fix(bridge): limit tx history block range for AltLayer testnets

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -71,6 +71,10 @@ const BATCH_FETCH_BLOCKS: { [key: number]: number } = {
   680: 10_000, // JASMY Chain
   20010: 10_000, // Mandala Chain
   704851: 10_000, // Mars Chain
+  1962: 10_000, // T-Rex Testnet
+  681: 10_000, // JASMY Chain Testnet
+  20011: 10_000, // Mandala Chain Testnet
+  704852: 10_000, // Mars Chain Testnet
 };
 
 export type UseTransactionHistoryResult = {


### PR DESCRIPTION
Adds the AltLayer testnets to `BATCH_FETCH_BLOCKS` with the same 10k block range limit as their mainnets (follow-up to #382):

- T-Rex Testnet (1962)
- JASMY Chain Testnet (681)
- Mandala Chain Testnet (20011)
- Mars Chain Testnet (704852)

Requested by the AltLayer team.