### PR TITLE
ci(monitoring): add enterprise chain slack alerts

### DIFF
--- a/.github/workflows/assertion-monitor.yml
+++ b/.github/workflows/assertion-monitor.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run-monitoring:
-    name: Assertion Monitor (${{ matrix.chain == 'orbit' && 'Orbit' || matrix.chain == 'core' && 'Core' || matrix.chain }})
+    name: Assertion Monitor (${{ matrix.chain == 'orbit' && 'Orbit' || matrix.chain == 'core' && 'Core' || matrix.chain == 'enterprise' && 'Enterprise' || matrix.chain }})
     strategy:
       matrix:
         chain: [core, orbit, enterprise]

--- a/.github/workflows/assertion-monitor.yml
+++ b/.github/workflows/assertion-monitor.yml
@@ -10,7 +10,7 @@ jobs:
     name: Assertion Monitor (${{ matrix.chain == 'orbit' && 'Orbit' || matrix.chain == 'core' && 'Core' || matrix.chain }})
     strategy:
       matrix:
-        chain: [core, orbit]
+        chain: [core, orbit, enterprise]
     uses: ./.github/workflows/monitoring.yml
     with:
       chain: ${{ matrix.chain }}

--- a/.github/workflows/batch-poster-monitor.yml
+++ b/.github/workflows/batch-poster-monitor.yml
@@ -10,7 +10,7 @@ jobs:
     name: Batch Poster Monitor (${{ matrix.chain == 'orbit' && 'Orbit' || matrix.chain == 'core' && 'Core' || matrix.chain }})
     strategy:
       matrix:
-        chain: [core, orbit]
+        chain: [core, orbit, enterprise]
     uses: ./.github/workflows/monitoring.yml
     with:
       chain: ${{ matrix.chain }}

--- a/.github/workflows/batch-poster-monitor.yml
+++ b/.github/workflows/batch-poster-monitor.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run-monitoring:
-    name: Batch Poster Monitor (${{ matrix.chain == 'orbit' && 'Orbit' || matrix.chain == 'core' && 'Core' || matrix.chain }})
+    name: Batch Poster Monitor (${{ matrix.chain == 'orbit' && 'Orbit' || matrix.chain == 'core' && 'Core' || matrix.chain == 'enterprise' && 'Enterprise' || matrix.chain }})
     strategy:
       matrix:
         chain: [core, orbit, enterprise]

--- a/.github/workflows/monitor-config.json
+++ b/.github/workflows/monitor-config.json
@@ -16,6 +16,7 @@
   "orbit": {
     "generateCommand": "generateOrbitChainsToMonitor",
     "configFile": "__auto-generated-orbit-chains.json",
+    "excludeChainIds": [4663],
     "slackTokens": {
       "assertion": "ORBIT_CHAIN_ASSERTION_MONITORING_SLACK_TOKEN",
       "batch-poster": "ORBIT_CHAIN_BATCH_POSTER_MONITORING_SLACK_TOKEN",
@@ -25,6 +26,21 @@
       "assertion": "ORBIT_CHAIN_ASSERTION_MONITORING_SLACK_CHANNEL",
       "batch-poster": "ORBIT_CHAIN_BATCH_POSTER_MONITORING_SLACK_CHANNEL",
       "retryable": "ORBIT_RETRYABLE_MONITORING_SLACK_CHANNEL"
+    }
+  },
+  "enterprise": {
+    "generateCommand": "generateOrbitChainsToMonitor",
+    "configFile": "__auto-generated-enterprise-chains.json",
+    "includeChainIds": [4663],
+    "slackTokens": {
+      "assertion": "ENTERPRISE_CHAIN_MONITORING_SLACK_TOKEN",
+      "batch-poster": "ENTERPRISE_CHAIN_MONITORING_SLACK_TOKEN",
+      "retryable": "ENTERPRISE_CHAIN_MONITORING_SLACK_TOKEN"
+    },
+    "slackChannels": {
+      "assertion": "ENTERPRISE_CHAIN_MONITORING_SLACK_CHANNEL",
+      "batch-poster": "ENTERPRISE_CHAIN_MONITORING_SLACK_CHANNEL",
+      "retryable": "ENTERPRISE_CHAIN_MONITORING_SLACK_CHANNEL"
     }
   }
 }

--- a/.github/workflows/monitor-config.json
+++ b/.github/workflows/monitor-config.json
@@ -16,7 +16,6 @@
   "orbit": {
     "generateCommand": "generateOrbitChainsToMonitor",
     "configFile": "__auto-generated-orbit-chains.json",
-    "excludeChainIds": [4663],
     "slackTokens": {
       "assertion": "ORBIT_CHAIN_ASSERTION_MONITORING_SLACK_TOKEN",
       "batch-poster": "ORBIT_CHAIN_BATCH_POSTER_MONITORING_SLACK_TOKEN",
@@ -31,7 +30,6 @@
   "enterprise": {
     "generateCommand": "generateOrbitChainsToMonitor",
     "configFile": "__auto-generated-enterprise-chains.json",
-    "includeChainIds": [4663],
     "slackTokens": {
       "assertion": "ENTERPRISE_CHAIN_MONITORING_SLACK_TOKEN",
       "batch-poster": "ENTERPRISE_CHAIN_MONITORING_SLACK_TOKEN",

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -63,15 +63,11 @@ jobs:
           echo "config_file=$(echo $CONFIG | jq -r '.configFile')" >> $GITHUB_OUTPUT
           echo "slack_token=$(echo $CONFIG | jq -r '.slackTokens["${{ inputs.monitor }}"]')" >> $GITHUB_OUTPUT
           echo "slack_channel=$(echo $CONFIG | jq -r '.slackChannels["${{ inputs.monitor }}"]')" >> $GITHUB_OUTPUT
-          echo "include_chain_ids=$(echo $CONFIG | jq -r '.includeChainIds // [] | join(",")')" >> $GITHUB_OUTPUT
-          echo "exclude_chain_ids=$(echo $CONFIG | jq -r '.excludeChainIds // [] | join(",")')" >> $GITHUB_OUTPUT
 
       - name: Generate chains JSON
         run: pnpm --filter arb-token-bridge-ui ${{ steps.config.outputs.generate_command }}
         env:
-          MONITOR_INCLUDE_CHAIN_IDS: ${{ steps.config.outputs.include_chain_ids }}
-          MONITOR_EXCLUDE_CHAIN_IDS: ${{ steps.config.outputs.exclude_chain_ids }}
-          MONITOR_OUTPUT_FILE: ${{ steps.config.outputs.config_file }}
+          MONITOR_ENTERPRISE_CHAINS: ${{ inputs.chain == 'enterprise' }}
 
       - name: Copy chains JSON to Arbitrum Monitoring
         run: cp ./packages/arb-token-bridge-ui/public/${{ steps.config.outputs.config_file }} ./arbitrum-monitoring/config.json

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -63,9 +63,15 @@ jobs:
           echo "config_file=$(echo $CONFIG | jq -r '.configFile')" >> $GITHUB_OUTPUT
           echo "slack_token=$(echo $CONFIG | jq -r '.slackTokens["${{ inputs.monitor }}"]')" >> $GITHUB_OUTPUT
           echo "slack_channel=$(echo $CONFIG | jq -r '.slackChannels["${{ inputs.monitor }}"]')" >> $GITHUB_OUTPUT
+          echo "include_chain_ids=$(echo $CONFIG | jq -r '.includeChainIds // [] | join(",")')" >> $GITHUB_OUTPUT
+          echo "exclude_chain_ids=$(echo $CONFIG | jq -r '.excludeChainIds // [] | join(",")')" >> $GITHUB_OUTPUT
 
       - name: Generate chains JSON
         run: pnpm --filter arb-token-bridge-ui ${{ steps.config.outputs.generate_command }}
+        env:
+          MONITOR_INCLUDE_CHAIN_IDS: ${{ steps.config.outputs.include_chain_ids }}
+          MONITOR_EXCLUDE_CHAIN_IDS: ${{ steps.config.outputs.exclude_chain_ids }}
+          MONITOR_OUTPUT_FILE: ${{ steps.config.outputs.config_file }}
 
       - name: Copy chains JSON to Arbitrum Monitoring
         run: cp ./packages/arb-token-bridge-ui/public/${{ steps.config.outputs.config_file }} ./arbitrum-monitoring/config.json

--- a/.github/workflows/retryable-monitor.yml
+++ b/.github/workflows/retryable-monitor.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run-retryable-monitoring:
-    name: Retryable Monitor (${{ matrix.chain == 'orbit' && 'Orbit' || matrix.chain == 'core' && 'Core' || matrix.chain }})
+    name: Retryable Monitor (${{ matrix.chain == 'orbit' && 'Orbit' || matrix.chain == 'core' && 'Core' || matrix.chain == 'enterprise' && 'Enterprise' || matrix.chain }})
     strategy:
       matrix:
         chain: [core, orbit, enterprise]

--- a/.github/workflows/retryable-monitor.yml
+++ b/.github/workflows/retryable-monitor.yml
@@ -10,7 +10,7 @@ jobs:
     name: Retryable Monitor (${{ matrix.chain == 'orbit' && 'Orbit' || matrix.chain == 'core' && 'Core' || matrix.chain }})
     strategy:
       matrix:
-        chain: [core, orbit]
+        chain: [core, orbit, enterprise]
     uses: ./.github/workflows/monitoring.yml
     with:
       chain: ${{ matrix.chain }}

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -4,8 +4,6 @@ import { isEnterpriseChain } from '../src/util/enterpriseChains';
 import { getOrbitChains } from '../src/util/orbitChainsList';
 import { getChainToMonitor } from './utils';
 
-// enterprise chains alert to their own slack channels, so they are monitored
-// in a separate run from the other orbit chains
 const enterpriseMode = process.env.MONITOR_ENTERPRISE_CHAINS === 'true';
 
 function getOrbitChainsToMonitor() {

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -1,28 +1,6 @@
 import fs from 'fs';
 
-import { isEnterpriseChain } from '../src/util/enterpriseChains';
-import { getOrbitChains } from '../src/util/orbitChainsList';
-import { getChainToMonitor } from './utils';
-
-const enterpriseMode = process.env.MONITOR_ENTERPRISE_CHAINS === 'true';
-
-function getOrbitChainsToMonitor() {
-  const orbitChains = getOrbitChains({ mainnet: true, testnet: false });
-
-  if (enterpriseMode) {
-    return orbitChains.filter((orbitChain) => isEnterpriseChain(orbitChain.chainId));
-  }
-
-  return orbitChains.filter((orbitChain) => !isEnterpriseChain(orbitChain.chainId));
-}
-
-function getOutputFile() {
-  if (enterpriseMode) {
-    return '__auto-generated-enterprise-chains.json';
-  }
-
-  return '__auto-generated-orbit-chains.json';
-}
+import { getChainToMonitor, getOrbitChainsOutputFile, getOrbitChainsToMonitor } from './utils';
 
 async function generateOrbitChainsToMonitor() {
   // make the orbit chain data compatible with the orbit-data required by the retryable-monitoring script
@@ -47,7 +25,7 @@ async function generateOrbitChainsToMonitor() {
     null,
     2,
   );
-  fs.writeFileSync(`./public/${getOutputFile()}`, resultsJson);
+  fs.writeFileSync(`./public/${getOrbitChainsOutputFile()}`, resultsJson);
 }
 
 generateOrbitChainsToMonitor();

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -1,28 +1,34 @@
 import fs from 'fs';
 
+import { isEnterpriseChain } from '../src/util/enterpriseChains';
 import { getOrbitChains } from '../src/util/orbitChainsList';
 import { getChainToMonitor } from './utils';
 
-function parseChainIds(envValue: string | undefined) {
-  if (typeof envValue !== 'string' || envValue === '') {
-    return undefined;
+// enterprise chains alert to their own slack channels, so they are monitored
+// in a separate run from the other orbit chains
+const enterpriseMode = process.env.MONITOR_ENTERPRISE_CHAINS === 'true';
+
+function getOrbitChainsToMonitor() {
+  const orbitChains = getOrbitChains({ mainnet: true, testnet: false });
+
+  if (enterpriseMode) {
+    return orbitChains.filter((orbitChain) => isEnterpriseChain(orbitChain.chainId));
   }
-  return envValue.split(',').map((chainId) => Number(chainId.trim()));
+
+  return orbitChains.filter((orbitChain) => !isEnterpriseChain(orbitChain.chainId));
+}
+
+function getOutputFile() {
+  if (enterpriseMode) {
+    return '__auto-generated-enterprise-chains.json';
+  }
+
+  return '__auto-generated-orbit-chains.json';
 }
 
 async function generateOrbitChainsToMonitor() {
-  const includeChainIds = parseChainIds(process.env.MONITOR_INCLUDE_CHAIN_IDS);
-  const excludeChainIds = parseChainIds(process.env.MONITOR_EXCLUDE_CHAIN_IDS);
-  const outputFile = process.env.MONITOR_OUTPUT_FILE || '__auto-generated-orbit-chains.json';
-
-  const orbitChains = getOrbitChains({ mainnet: true, testnet: false }).filter(
-    (orbitChain) =>
-      (!includeChainIds || includeChainIds.includes(orbitChain.chainId)) &&
-      !excludeChainIds?.includes(orbitChain.chainId),
-  );
-
   // make the orbit chain data compatible with the orbit-data required by the retryable-monitoring script
-  const orbitChainsToMonitor = orbitChains.map((orbitChain) => {
+  const orbitChainsToMonitor = getOrbitChainsToMonitor().map((orbitChain) => {
     return getChainToMonitor({
       chain: orbitChain,
       rpcUrl: orbitChain.rpcUrl,
@@ -35,7 +41,7 @@ async function generateOrbitChainsToMonitor() {
     fs.mkdirSync(publicDir, { recursive: true });
   }
 
-  // write to orbit-chains.json, we will use this json as an input to the retryable-monitoring script
+  // write the chains json, we will use it as an input to the retryable-monitoring script
   const resultsJson = JSON.stringify(
     {
       childChains: orbitChainsToMonitor,
@@ -43,7 +49,7 @@ async function generateOrbitChainsToMonitor() {
     null,
     2,
   );
-  fs.writeFileSync(`./public/${outputFile}`, resultsJson);
+  fs.writeFileSync(`./public/${getOutputFile()}`, resultsJson);
 }
 
 generateOrbitChainsToMonitor();

--- a/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
+++ b/packages/arb-token-bridge-ui/scripts/generateOrbitChainsToMonitor.ts
@@ -3,8 +3,23 @@ import fs from 'fs';
 import { getOrbitChains } from '../src/util/orbitChainsList';
 import { getChainToMonitor } from './utils';
 
+function parseChainIds(envValue: string | undefined) {
+  if (typeof envValue !== 'string' || envValue === '') {
+    return undefined;
+  }
+  return envValue.split(',').map((chainId) => Number(chainId.trim()));
+}
+
 async function generateOrbitChainsToMonitor() {
-  const orbitChains = getOrbitChains({ mainnet: true, testnet: false });
+  const includeChainIds = parseChainIds(process.env.MONITOR_INCLUDE_CHAIN_IDS);
+  const excludeChainIds = parseChainIds(process.env.MONITOR_EXCLUDE_CHAIN_IDS);
+  const outputFile = process.env.MONITOR_OUTPUT_FILE || '__auto-generated-orbit-chains.json';
+
+  const orbitChains = getOrbitChains({ mainnet: true, testnet: false }).filter(
+    (orbitChain) =>
+      (!includeChainIds || includeChainIds.includes(orbitChain.chainId)) &&
+      !excludeChainIds?.includes(orbitChain.chainId),
+  );
 
   // make the orbit chain data compatible with the orbit-data required by the retryable-monitoring script
   const orbitChainsToMonitor = orbitChains.map((orbitChain) => {
@@ -28,7 +43,7 @@ async function generateOrbitChainsToMonitor() {
     null,
     2,
   );
-  fs.writeFileSync('./public/__auto-generated-orbit-chains.json', resultsJson);
+  fs.writeFileSync(`./public/${outputFile}`, resultsJson);
 }
 
 generateOrbitChainsToMonitor();

--- a/packages/arb-token-bridge-ui/scripts/utils.test.ts
+++ b/packages/arb-token-bridge-ui/scripts/utils.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ChainId } from '../src/types/ChainId';
+import { getOrbitChainsOutputFile, getOrbitChainsToMonitor } from './utils';
+
+describe('getOrbitChainsToMonitor', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('excludes enterprise chains by default', () => {
+    vi.stubEnv('MONITOR_ENTERPRISE_CHAINS', '');
+
+    const chainIds = getOrbitChainsToMonitor().map((orbitChain) => orbitChain.chainId);
+
+    expect(chainIds.length).toBeGreaterThan(0);
+    expect(chainIds).not.toContain(ChainId.RobinhoodChain);
+    expect(getOrbitChainsOutputFile()).toBe('__auto-generated-orbit-chains.json');
+  });
+
+  it('returns only enterprise chains in enterprise mode', () => {
+    vi.stubEnv('MONITOR_ENTERPRISE_CHAINS', 'true');
+
+    const chainIds = getOrbitChainsToMonitor().map((orbitChain) => orbitChain.chainId);
+
+    expect(chainIds).toEqual([ChainId.RobinhoodChain]);
+    expect(getOrbitChainsOutputFile()).toBe('__auto-generated-enterprise-chains.json');
+  });
+});

--- a/packages/arb-token-bridge-ui/scripts/utils.test.ts
+++ b/packages/arb-token-bridge-ui/scripts/utils.test.ts
@@ -32,7 +32,8 @@ describe('getOrbitChainsToMonitor', () => {
 
     const chainIds = getOrbitChainsToMonitor().map((orbitChain) => orbitChain.chainId);
 
-    expect(chainIds).toEqual([ChainId.RobinhoodChain]);
+    expect(chainIds).toContain(ChainId.RobinhoodChain);
+    expect(chainIds.every(isEnterpriseChain)).toBe(true);
     expect(getOrbitChainsOutputFile()).toBe('__auto-generated-enterprise-chains.json');
   });
 });

--- a/packages/arb-token-bridge-ui/scripts/utils.test.ts
+++ b/packages/arb-token-bridge-ui/scripts/utils.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ChainId } from '../src/types/ChainId';
+import { isEnterpriseChain } from '../src/util/networks';
 import { getOrbitChainsOutputFile, getOrbitChainsToMonitor } from './utils';
 
 describe('getOrbitChainsToMonitor', () => {
@@ -16,6 +17,14 @@ describe('getOrbitChainsToMonitor', () => {
     expect(chainIds.length).toBeGreaterThan(0);
     expect(chainIds).not.toContain(ChainId.RobinhoodChain);
     expect(getOrbitChainsOutputFile()).toBe('__auto-generated-orbit-chains.json');
+  });
+
+  it('does not include any enterprise chains in the orbit chains output', () => {
+    vi.stubEnv('MONITOR_ENTERPRISE_CHAINS', '');
+
+    const chainIds = getOrbitChainsToMonitor().map((orbitChain) => orbitChain.chainId);
+
+    expect(chainIds.filter(isEnterpriseChain)).toEqual([]);
   });
 
   it('returns only enterprise chains in enterprise mode', () => {

--- a/packages/arb-token-bridge-ui/scripts/utils.ts
+++ b/packages/arb-token-bridge-ui/scripts/utils.ts
@@ -1,7 +1,7 @@
 import { ArbitrumNetwork } from '@arbitrum/sdk';
 
-import { getExplorerUrl, rpcURLs } from '../src/util/networks';
-import { OrbitChainConfig } from '../src/util/orbitChainsList';
+import { getExplorerUrl, isEnterpriseChain, rpcURLs } from '../src/util/networks';
+import { OrbitChainConfig, getOrbitChains } from '../src/util/orbitChainsList';
 
 export interface ChainToMonitor extends ArbitrumNetwork {
   parentRpcUrl: string;
@@ -49,3 +49,23 @@ export const getChainToMonitor = ({
   parentRpcUrl: sanitizeRpcUrl(rpcURLs[chain.parentChainId] as string),
   parentExplorerUrl: sanitizeExplorerUrl(getExplorerUrl(chain.parentChainId)),
 });
+
+const isEnterpriseMode = () => process.env.MONITOR_ENTERPRISE_CHAINS === 'true';
+
+export function getOrbitChainsToMonitor() {
+  const orbitChains = getOrbitChains({ mainnet: true, testnet: false });
+
+  if (isEnterpriseMode()) {
+    return orbitChains.filter((orbitChain) => isEnterpriseChain(orbitChain.chainId));
+  }
+
+  return orbitChains.filter((orbitChain) => !isEnterpriseChain(orbitChain.chainId));
+}
+
+export function getOrbitChainsOutputFile() {
+  if (isEnterpriseMode()) {
+    return '__auto-generated-enterprise-chains.json';
+  }
+
+  return '__auto-generated-orbit-chains.json';
+}

--- a/packages/arb-token-bridge-ui/src/util/enterpriseChains.ts
+++ b/packages/arb-token-bridge-ui/src/util/enterpriseChains.ts
@@ -1,0 +1,9 @@
+import { ChainId } from '../types/ChainId';
+
+// Chains operated for enterprise partners; their monitoring alerts route to
+// dedicated Slack channels instead of the shared orbit channels.
+export const enterpriseChainIds: ChainId[] = [ChainId.RobinhoodChain];
+
+export function isEnterpriseChain(chainId: number): boolean {
+  return enterpriseChainIds.includes(chainId);
+}

--- a/packages/arb-token-bridge-ui/src/util/enterpriseChains.ts
+++ b/packages/arb-token-bridge-ui/src/util/enterpriseChains.ts
@@ -1,7 +1,0 @@
-import { ChainId } from '../types/ChainId';
-
-export const enterpriseChainIds: ChainId[] = [ChainId.RobinhoodChain];
-
-export function isEnterpriseChain(chainId: number): boolean {
-  return enterpriseChainIds.includes(chainId);
-}

--- a/packages/arb-token-bridge-ui/src/util/enterpriseChains.ts
+++ b/packages/arb-token-bridge-ui/src/util/enterpriseChains.ts
@@ -1,7 +1,5 @@
 import { ChainId } from '../types/ChainId';
 
-// Chains operated for enterprise partners; their monitoring alerts route to
-// dedicated Slack channels instead of the shared orbit channels.
 export const enterpriseChainIds: ChainId[] = [ChainId.RobinhoodChain];
 
 export function isEnterpriseChain(chainId: number): boolean {

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -559,6 +559,7 @@ export function isCoreChainForDisplay(chainId: number) {
   return isNetwork(chainId).isCoreChain || uiCoreChainIds.includes(chainId);
 }
 
+// monitoring alert routing only — independent of the uiCoreChainIds display grouping above
 const enterpriseChainIds: number[] = [ChainId.RobinhoodChain];
 
 export function isEnterpriseChain(chainId: number) {

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -559,6 +559,13 @@ export function isCoreChainForDisplay(chainId: number) {
   return isNetwork(chainId).isCoreChain || uiCoreChainIds.includes(chainId);
 }
 
+// Orbit chains operated for enterprise partners; monitored separately with dedicated alert channels.
+const enterpriseChainIds: number[] = [ChainId.RobinhoodChain];
+
+export function isEnterpriseChain(chainId: number) {
+  return enterpriseChainIds.includes(chainId);
+}
+
 // Core chains not listed here sort after these, by ascending chainId.
 const coreChainSortOrder: number[] = [
   ChainId.Ethereum,

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -559,7 +559,6 @@ export function isCoreChainForDisplay(chainId: number) {
   return isNetwork(chainId).isCoreChain || uiCoreChainIds.includes(chainId);
 }
 
-// Orbit chains operated for enterprise partners; monitored separately with dedicated alert channels.
 const enterpriseChainIds: number[] = [ChainId.RobinhoodChain];
 
 export function isEnterpriseChain(chainId: number) {

--- a/packages/arb-token-bridge-ui/vitest.config.ts
+++ b/packages/arb-token-bridge-ui/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       escapeString: true,
     },
     testTimeout: 15_000,
-    include: ['./src/**/*.test.ts', './src/**/*.test.tsx'],
+    include: ['./src/**/*.test.ts', './src/**/*.test.tsx', './scripts/**/*.test.ts'],
     exclude: ['./src/**/*.integration.test.ts', './src/**/*.integration.test.tsx'],
     env: loadEnv('', '../app/', ''),
     environment: 'happy-dom',


### PR DESCRIPTION
## Summary

Monitoring alerts for enterprise chains (currently Robinhood) now fire in their own Slack channel instead of the shared orbit channels.

- `networks.ts`: `enterpriseChainIds` + `isEnterpriseChain()` — product-wide classification
- `generateOrbitChainsToMonitor`: `MONITOR_ENTERPRISE_CHAINS` flag picks enterprise chains or all other orbit chains
- `monitor-config.json` + monitor workflows: new `enterprise` group using `ENTERPRISE_CHAIN_MONITORING_SLACK_TOKEN` / `_CHANNEL`
- Unit tests for the chain selection

No changes needed in arbitrum-monitoring.

## Before merge

- [x] Add the `ENTERPRISE_CHAIN_MONITORING_SLACK_TOKEN` / `_CHANNEL` repo secrets.