### PR TITLE
feat(bridge): serve CCTP history from the indexer replica

### DIFF
--- a/packages/arb-token-bridge-ui/src/api-utils/ServerSubgraphUtils.ts
+++ b/packages/arb-token-bridge-ui/src/api-utils/ServerSubgraphUtils.ts
@@ -1,4 +1,13 @@
-import { ApolloClient, HttpLink, InMemoryCache, NormalizedCacheObject } from '@apollo/client';
+import {
+  ApolloClient,
+  ApolloQueryResult,
+  HttpLink,
+  InMemoryCache,
+  MaybeMasked,
+  NormalizedCacheObject,
+  OperationVariables,
+  QueryOptions,
+} from '@apollo/client';
 import ApolloLinkTimeout from 'apollo-link-timeout';
 
 import { ChainId } from '../types/ChainId';
@@ -11,72 +20,78 @@ const theGraphNetworkApiKey = process.env.THE_GRAPH_NETWORK_API_KEY;
 
 const selfHostedSubgraphApiKey = process.env.SELF_HOSTED_SUBGRAPH_API_KEY;
 
+// A label for `meta.source`, never a URL — our endpoints stay behind the API.
+const INDEXER_SOURCE = 'arbitrum-indexer';
+
 type SubgraphKey = keyof typeof subgraphs;
 
-type TheGraphNetworkSubgraphId = (typeof subgraphs)[SubgraphKey]['theGraphNetworkSubgraphId'];
+export type SubgraphSource = SubgraphKey | typeof INDEXER_SOURCE;
 
-type Subgraph = {
-  selfHostedSubgraph: string;
-  theGraphNetworkSubgraphId: string;
-  // pin queries to a single known-good indexer, e.g. while others serve incomplete data
-  // due to https://github.com/graphprotocol/graph-node/issues/6683
-  deploymentId?: string;
-  pinnedIndexer?: string;
+/** An Apollo client paired with the label to report it as. */
+type SourcedClient = {
+  client: ApolloClient<NormalizedCacheObject>;
+  source: SubgraphSource;
 };
+
+type Subgraph =
+  | { kind: 'self-hosted'; name: string }
+  | { kind: 'graph-network'; subgraphId: string }
+  // pin to one known-good indexer when others serve incomplete data:
+  // https://github.com/graphprotocol/graph-node/issues/6683
+  | { kind: 'pinned'; deploymentId: string; indexer: string };
+
+// Lunanova (https://thegraph.lunanova.tech), verified complete
+const lunanovaIndexer = '0xe13840a2e92e0cb17a246609b432d0fa2e418774';
 
 const subgraphs = {
   // CCTP Mainnet Subgraphs
   'cctp-ethereum': {
-    selfHostedSubgraph: '',
-    theGraphNetworkSubgraphId: 'E6iPLnDGEgrcc4gu9uiHJxENSRAAzTvUJqQqJcHZqJT1',
+    kind: 'pinned',
     deploymentId: 'QmWgi6hNfwCGiTAhH7gTSMSfvvYUPRbBQSjRmvuviRGGwy',
-    // Lunanova (https://thegraph.lunanova.tech), verified serving complete data
-    pinnedIndexer: '0xe13840a2e92e0cb17a246609b432d0fa2e418774',
+    indexer: lunanovaIndexer,
   },
   'cctp-arbitrum-one': {
-    selfHostedSubgraph: '',
-    theGraphNetworkSubgraphId: '9DgSggKVrvfi4vdyYTdmSBuPgDfm3D7zfLZ1qaQFjYYW',
+    kind: 'pinned',
     deploymentId: 'QmQtNd36amtQ8h8GF5rwkLLWyyBGwqad3j3WgZAMuLvDMd',
-    // Lunanova (https://thegraph.lunanova.tech), verified serving complete data
-    pinnedIndexer: '0xe13840a2e92e0cb17a246609b432d0fa2e418774',
+    indexer: lunanovaIndexer,
   },
   // CCTP Testnet Subgraphs
   'cctp-sepolia': {
-    selfHostedSubgraph: '',
-    theGraphNetworkSubgraphId: '4gSU1PTxjYPWk2TXPX2fusjuXrBFHC7kCZrbhrhaF9V5',
+    kind: 'graph-network',
+    subgraphId: '4gSU1PTxjYPWk2TXPX2fusjuXrBFHC7kCZrbhrhaF9V5',
   },
   'cctp-arbitrum-sepolia': {
-    selfHostedSubgraph: '',
-    theGraphNetworkSubgraphId: '4Dp9ENSFDKfeBsmZeSyATKKrhxC2EKzbC3bZvTHpU1DB',
+    kind: 'graph-network',
+    subgraphId: '4Dp9ENSFDKfeBsmZeSyATKKrhxC2EKzbC3bZvTHpU1DB',
   },
   // L1 Mainnet Subgraphs
   'l1-arbitrum-one': {
-    selfHostedSubgraph: '',
-    theGraphNetworkSubgraphId: 'F2N4nGH86Y5Bk2vPo15EVRSTz2wbtz7BGRe8DDJqMPG4',
+    kind: 'graph-network',
+    subgraphId: 'F2N4nGH86Y5Bk2vPo15EVRSTz2wbtz7BGRe8DDJqMPG4',
   },
   'l1-arbitrum-nova': {
-    selfHostedSubgraph: '',
-    theGraphNetworkSubgraphId: '6Xvyjk9r91N3DSRQP6UZ1Lkbou567hFxLSWt2Tsv5AWp',
+    kind: 'graph-network',
+    subgraphId: '6Xvyjk9r91N3DSRQP6UZ1Lkbou567hFxLSWt2Tsv5AWp',
   },
   // L1 Testnet Subgraphs
   'l1-arbitrum-sepolia': {
-    selfHostedSubgraph: '',
-    theGraphNetworkSubgraphId: 'GF6Ez7sY2gef8EoXrR76X6iFa41wf38zh4TXZkDkL5Z9',
+    kind: 'graph-network',
+    subgraphId: 'GF6Ez7sY2gef8EoXrR76X6iFa41wf38zh4TXZkDkL5Z9',
   },
   // L2 Mainnet Subgraphs
   'l2-arbitrum-one': {
-    selfHostedSubgraph: '',
-    theGraphNetworkSubgraphId: '9eFk14Tms68qBN7YwL6kFuk9e2BVRqkX6gXyjzLR3tuj',
+    kind: 'graph-network',
+    subgraphId: '9eFk14Tms68qBN7YwL6kFuk9e2BVRqkX6gXyjzLR3tuj',
   },
   // L2 Nova Subgraphs
   'l2-arbitrum-nova': {
-    selfHostedSubgraph: 'arbitrum-nova/layer2-token-gateway',
-    theGraphNetworkSubgraphId: '',
+    kind: 'self-hosted',
+    name: 'arbitrum-nova/layer2-token-gateway',
   },
   // L2 Testnet Subgraphs
   'l2-arbitrum-sepolia': {
-    selfHostedSubgraph: '',
-    theGraphNetworkSubgraphId: 'AaUuKWWuQbCXbvRkXpVDEpw9B7oVicYrovNyMLPZtLPw',
+    kind: 'graph-network',
+    subgraphId: 'AaUuKWWuQbCXbvRkXpVDEpw9B7oVicYrovNyMLPZtLPw',
   },
 } satisfies Record<string, Subgraph>;
 
@@ -107,7 +122,7 @@ function createSelfHostedSubgraphClient(subgraphName: string) {
   );
 }
 
-function createTheGraphNetworkClient(subgraphId: TheGraphNetworkSubgraphId) {
+function createTheGraphNetworkClient(subgraphId: string) {
   if (typeof theGraphNetworkApiKey === 'undefined' || theGraphNetworkApiKey === '') {
     throw new Error(
       `[createTheGraphNetworkClient] missing "THE_GRAPH_NETWORK_API_KEY" env variable`,
@@ -130,55 +145,137 @@ function createPinnedIndexerClient(deploymentId: string, indexerAddress: string)
   );
 }
 
-function createSubgraphClient(key: SubgraphKey) {
-  logger.debug(`[createSubgraphClient] key=${key}`);
+function createSubgraphClient(key: SubgraphKey): SourcedClient {
+  const subgraph = subgraphs[key];
+  logger.debug(`[createSubgraphClient] key=${key} kind=${subgraph.kind}`);
 
-  const { theGraphNetworkSubgraphId, selfHostedSubgraph, deploymentId, pinnedIndexer }: Subgraph =
-    subgraphs[key];
+  return { client: createClientFor(subgraph), source: key };
+}
 
-  if (selfHostedSubgraph !== '') {
-    return createSelfHostedSubgraphClient(selfHostedSubgraph);
+function createClientFor(subgraph: Subgraph): ApolloClient<NormalizedCacheObject> {
+  switch (subgraph.kind) {
+    case 'self-hosted':
+      return createSelfHostedSubgraphClient(subgraph.name);
+
+    case 'graph-network':
+      return createTheGraphNetworkClient(subgraph.subgraphId);
+
+    case 'pinned':
+      return createPinnedIndexerClient(subgraph.deploymentId, subgraph.indexer);
+  }
+}
+
+type CctpQueryResult<T> = ApolloQueryResult<MaybeMasked<T>> & {
+  source: SubgraphSource;
+};
+
+/**
+ * The subset of the Apollo client surface the CCTP route consumes. Deliberately
+ * query-only: a query may be served by either backend, so there is no single
+ * `link` that describes the client — whichever answered comes back as `source`.
+ */
+export type CctpSubgraphClient = {
+  query<T = unknown, TVariables extends OperationVariables = OperationVariables>(
+    options: QueryOptions<TVariables, T>,
+  ): Promise<CctpQueryResult<T>>;
+};
+
+/**
+ * Queries `primary`, falling back to `createFallback()` on failure. The fallback
+ * is built lazily, so a missing Graph API key is fine while the indexer holds,
+ * and reused, so repeated failures don't rebuild it.
+ */
+function createCctpSubgraphClient(
+  primary: SourcedClient,
+  createFallback?: () => SourcedClient,
+): CctpSubgraphClient {
+  let fallback: SourcedClient | undefined;
+
+  return {
+    query: async <T = unknown, TVariables extends OperationVariables = OperationVariables>(
+      options: QueryOptions<TVariables, T>,
+    ): Promise<CctpQueryResult<T>> => {
+      try {
+        return { ...(await primary.client.query<T, TVariables>(options)), source: primary.source };
+      } catch (error) {
+        if (typeof createFallback === 'undefined') {
+          throw error;
+        }
+
+        logger.warn(
+          `[getCctpSubgraphClient] "${primary.source}" query failed, falling back`,
+          error,
+        );
+        fallback ??= createFallback();
+        return {
+          ...(await fallback.client.query<T, TVariables>(options)),
+          source: fallback.source,
+        };
+      }
+    },
+  };
+}
+
+/**
+ * Indexer base URL for `chainId` from `INDEXER_API_URL_BY_CHAIN`
+ * (`{"42161":"https://indexer.example"}`) — chains sit on separate deployments.
+ * `undefined` for anything unusable, so a bad map degrades to the subgraph.
+ */
+function getIndexerApiUrl(chainId: number): string | undefined {
+  let urlByChainId: Record<string, unknown>;
+
+  try {
+    const parsed: unknown = JSON.parse(process.env.INDEXER_API_URL_BY_CHAIN || '{}');
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('expected a JSON object keyed by chain ID');
+    }
+    urlByChainId = parsed as Record<string, unknown>;
+  } catch (error) {
+    logger.error('[getIndexerApiUrl] cannot parse "INDEXER_API_URL_BY_CHAIN"', error);
+    return undefined;
   }
 
-  if ((typeof deploymentId === 'undefined') !== (typeof pinnedIndexer === 'undefined')) {
-    throw new Error(
-      `[createSubgraphClient] both "deploymentId" and "pinnedIndexer" must be set for "${key}"`,
-    );
+  const url = urlByChainId[String(chainId)];
+  if (typeof url !== 'string' || url === '') {
+    return undefined;
   }
 
-  if (typeof deploymentId !== 'undefined' && typeof pinnedIndexer !== 'undefined') {
-    logger.debug(
-      `[createSubgraphClient] using deployment "${deploymentId}" pinned to indexer "${pinnedIndexer}"`,
-    );
-    return createPinnedIndexerClient(deploymentId, pinnedIndexer);
+  // Some proxies read the resulting `//api/v1/...` as a different, missing path.
+  const baseUrl = url.replace(/\/+$/, '');
+  return URL.canParse(baseUrl) ? baseUrl : undefined;
+}
+
+const cctpSubgraphKeyByChainId: { [chainId: number]: SubgraphKey } = {
+  [ChainId.Ethereum]: 'cctp-ethereum',
+  [ChainId.ArbitrumOne]: 'cctp-arbitrum-one',
+  [ChainId.Sepolia]: 'cctp-sepolia',
+  [ChainId.ArbitrumSepolia]: 'cctp-arbitrum-sepolia',
+};
+
+export function getCctpSubgraphClient(chainId: number): CctpSubgraphClient {
+  const subgraphKey = cctpSubgraphKeyByChainId[chainId];
+
+  if (typeof subgraphKey === 'undefined') {
+    throw new Error(`[getCctpSubgraphClient] unsupported chain: ${chainId}`);
   }
 
-  logger.debug(
-    `[createSubgraphClient] using subgraph "${theGraphNetworkSubgraphId}" on the graph network`,
+  const indexerApiBaseUrl = getIndexerApiUrl(chainId);
+
+  if (typeof indexerApiBaseUrl === 'undefined') {
+    return createCctpSubgraphClient(createSubgraphClient(subgraphKey));
+  }
+
+  // /api/v1 only: the replica postdates the indexer's API versioning, no alias.
+  return createCctpSubgraphClient(
+    {
+      client: createApolloClient(`${indexerApiBaseUrl}/api/v1/cctp/graphql/${chainId}`),
+      source: INDEXER_SOURCE,
+    },
+    () => createSubgraphClient(subgraphKey),
   );
-  return createTheGraphNetworkClient(theGraphNetworkSubgraphId);
 }
 
-export function getCctpSubgraphClient(chainId: number) {
-  switch (chainId) {
-    case ChainId.Ethereum:
-      return createSubgraphClient('cctp-ethereum');
-
-    case ChainId.ArbitrumOne:
-      return createSubgraphClient('cctp-arbitrum-one');
-
-    case ChainId.Sepolia:
-      return createSubgraphClient('cctp-sepolia');
-
-    case ChainId.ArbitrumSepolia:
-      return createSubgraphClient('cctp-arbitrum-sepolia');
-
-    default:
-      throw new Error(`[getCctpSubgraphClient] unsupported chain: ${chainId}`);
-  }
-}
-
-export function getL1SubgraphClient(l2ChainId: number) {
+export function getL1SubgraphClient(l2ChainId: number): SourcedClient {
   switch (l2ChainId) {
     case ChainId.ArbitrumOne:
       return createSubgraphClient('l1-arbitrum-one');
@@ -194,7 +291,7 @@ export function getL1SubgraphClient(l2ChainId: number) {
   }
 }
 
-export function getL2SubgraphClient(l2ChainId: number) {
+export function getL2SubgraphClient(l2ChainId: number): SourcedClient {
   switch (l2ChainId) {
     case ChainId.ArbitrumOne:
       return createSubgraphClient('l2-arbitrum-one');
@@ -208,16 +305,4 @@ export function getL2SubgraphClient(l2ChainId: number) {
     default:
       throw new Error(`[getL2SubgraphClient] unsupported chain: ${l2ChainId}`);
   }
-}
-
-export function getSourceFromSubgraphClient(
-  subgraphClient: ApolloClient<NormalizedCacheObject>,
-): string | null {
-  const uri = (subgraphClient.link as any).options?.uri;
-
-  if (typeof uri === 'undefined') {
-    return null;
-  }
-
-  return new URL(uri).origin;
 }

--- a/packages/arb-token-bridge-ui/src/api-utils/__tests__/ServerSubgraphUtils.integration.test.ts
+++ b/packages/arb-token-bridge-ui/src/api-utils/__tests__/ServerSubgraphUtils.integration.test.ts
@@ -4,12 +4,14 @@ import { describe, expect, it } from 'vitest';
 import { ChainId } from '../../types/ChainId';
 import { getCctpSubgraphClient } from '../ServerSubgraphUtils';
 
-// missing from unpinned indexers due to https://github.com/graphprotocol/graph-node/issues/6683
+// missing from unpinned indexers: https://github.com/graphprotocol/graph-node/issues/6683
 const transactionHash = '0x77894001ee62c0b245e6e9c3b35fcdc79e917ce352b20a0b2ec49e8d916734c2';
 
 describe('getCctpSubgraphClient', () => {
   it('returns the transfer missing from unpinned indexers', async () => {
-    const { data } = await getCctpSubgraphClient(ChainId.Ethereum).query({
+    const { data } = await getCctpSubgraphClient(ChainId.Ethereum).query<{
+      messageSents: { transactionHash: string }[];
+    }>({
       query: gql`
         {
           messageSents(where: { transactionHash: "${transactionHash}" }) {
@@ -21,6 +23,6 @@ describe('getCctpSubgraphClient', () => {
     });
 
     expect(data.messageSents).toHaveLength(1);
-    expect(data.messageSents[0].transactionHash).toEqual(transactionHash);
+    expect(data.messageSents[0]?.transactionHash).toEqual(transactionHash);
   });
 });

--- a/packages/arb-token-bridge-ui/src/api-utils/__tests__/ServerSubgraphUtils.test.ts
+++ b/packages/arb-token-bridge-ui/src/api-utils/__tests__/ServerSubgraphUtils.test.ts
@@ -1,0 +1,212 @@
+import { gql } from '@apollo/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ChainId } from '../../types/ChainId';
+
+const query = gql`
+  {
+    messageSents {
+      id
+    }
+  }
+`;
+
+const indexerOrigin = 'https://indexer.example';
+const otherIndexerOrigin = 'https://indexer-2.example';
+const subgraphOrigin = 'https://gateway.thegraph.com';
+
+// Origins key the fetch stub; sources are the labels reported to clients.
+const indexerSource = 'arbitrum-indexer';
+const ethereumSubgraphSource = 'cctp-ethereum';
+
+const emptyResult = () =>
+  new Response(JSON.stringify({ data: { messageSents: [] } }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+// Records request URLs; failures keyed by origin, since a substring match
+// would also accept `https://indexer.example.evil`.
+function stubFetch(failRequest: (origin: string, callCount: number) => boolean) {
+  const urls: string[] = [];
+  const callsByOrigin: Record<string, number> = {};
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      urls.push(url);
+
+      const { origin } = new URL(url);
+      callsByOrigin[origin] = (callsByOrigin[origin] ?? 0) + 1;
+
+      if (failRequest(origin, callsByOrigin[origin])) {
+        throw new Error(`${origin} unavailable`);
+      }
+
+      return emptyResult();
+    }),
+  );
+
+  return {
+    urls,
+    countFor: (origin: string) => callsByOrigin[origin] ?? 0,
+  };
+}
+
+function stubIndexerApiUrlByChain(urlByChainId: Record<number, string> | string) {
+  vi.stubEnv(
+    'INDEXER_API_URL_BY_CHAIN',
+    typeof urlByChainId === 'string' ? urlByChainId : JSON.stringify(urlByChainId),
+  );
+}
+
+async function loadGetCctpSubgraphClient() {
+  vi.resetModules();
+  const { getCctpSubgraphClient } = await import('../ServerSubgraphUtils');
+  return getCctpSubgraphClient;
+}
+
+// Sequential: these share stubbed globals and re-import the module under test.
+describe.sequential('getCctpSubgraphClient', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('reports the source used by each query after fallback and recovery', async () => {
+    stubIndexerApiUrlByChain({ [ChainId.Ethereum]: indexerOrigin });
+    vi.stubEnv('THE_GRAPH_NETWORK_API_KEY', 'test-api-key');
+    const fetchStub = stubFetch((origin, callCount) => origin === indexerOrigin && callCount === 1);
+
+    const getCctpSubgraphClient = await loadGetCctpSubgraphClient();
+    const client = getCctpSubgraphClient(ChainId.Ethereum);
+
+    const fallbackResult = await client.query<{ messageSents: { id: string }[] }>({ query });
+    const recoveredResult = await client.query<{ messageSents: { id: string }[] }>({ query });
+
+    expect(fallbackResult.source).toBe(ethereumSubgraphSource);
+    expect(recoveredResult.source).toBe(indexerSource);
+    expect(fetchStub.countFor(subgraphOrigin)).toBe(1);
+  });
+
+  // Pins the invariant, not the vocabulary: key renames shouldn't break this.
+  it('never puts an endpoint in the source it reports', async () => {
+    stubIndexerApiUrlByChain({ [ChainId.Ethereum]: indexerOrigin });
+    vi.stubEnv('THE_GRAPH_NETWORK_API_KEY', 'test-api-key');
+    stubFetch((origin, callCount) => origin === indexerOrigin && callCount === 1);
+
+    const getCctpSubgraphClient = await loadGetCctpSubgraphClient();
+    const client = getCctpSubgraphClient(ChainId.Ethereum);
+
+    // first query falls back to the subgraph, second recovers to the indexer
+    const sources = [
+      (await client.query<{ messageSents: { id: string }[] }>({ query })).source,
+      (await client.query<{ messageSents: { id: string }[] }>({ query })).source,
+    ];
+
+    for (const source of sources) {
+      expect(URL.canParse(source)).toBe(false);
+      expect(source).not.toContain('indexer.example');
+      // API keys sit in the URI path, so a regression would leak more than a host
+      expect(source).not.toContain('test-api-key');
+    }
+  });
+
+  it('queries the indexer and never touches the subgraph while it succeeds', async () => {
+    stubIndexerApiUrlByChain({ [ChainId.ArbitrumOne]: indexerOrigin });
+    vi.stubEnv('THE_GRAPH_NETWORK_API_KEY', 'test-api-key');
+    const fetchStub = stubFetch(() => false);
+
+    const getCctpSubgraphClient = await loadGetCctpSubgraphClient();
+    const result = await getCctpSubgraphClient(ChainId.ArbitrumOne).query<{
+      messageSents: { id: string }[];
+    }>({ query });
+
+    expect(result.source).toBe(indexerSource);
+    expect(fetchStub.urls).toEqual([`${indexerOrigin}/api/v1/cctp/graphql/${ChainId.ArbitrumOne}`]);
+    expect(fetchStub.countFor(subgraphOrigin)).toBe(0);
+  });
+
+  it('sends each chain to the indexer configured for it', async () => {
+    stubIndexerApiUrlByChain({
+      [ChainId.Ethereum]: indexerOrigin,
+      [ChainId.ArbitrumOne]: otherIndexerOrigin,
+    });
+    vi.stubEnv('THE_GRAPH_NETWORK_API_KEY', 'test-api-key');
+    const fetchStub = stubFetch(() => false);
+
+    const getCctpSubgraphClient = await loadGetCctpSubgraphClient();
+    await getCctpSubgraphClient(ChainId.Ethereum).query<{ messageSents: { id: string }[] }>({
+      query,
+    });
+    await getCctpSubgraphClient(ChainId.ArbitrumOne).query<{ messageSents: { id: string }[] }>({
+      query,
+    });
+
+    expect(fetchStub.urls).toEqual([
+      `${indexerOrigin}/api/v1/cctp/graphql/${ChainId.Ethereum}`,
+      `${otherIndexerOrigin}/api/v1/cctp/graphql/${ChainId.ArbitrumOne}`,
+    ]);
+  });
+
+  it('reuses one fallback client across consecutive indexer failures', async () => {
+    stubIndexerApiUrlByChain({ [ChainId.Ethereum]: indexerOrigin });
+    vi.stubEnv('THE_GRAPH_NETWORK_API_KEY', 'test-api-key');
+    const fetchStub = stubFetch((origin) => origin === indexerOrigin);
+
+    const getCctpSubgraphClient = await loadGetCctpSubgraphClient();
+    const client = getCctpSubgraphClient(ChainId.Ethereum);
+
+    const first = await client.query<{ messageSents: { id: string }[] }>({ query });
+    const second = await client.query<{ messageSents: { id: string }[] }>({ query });
+
+    expect(first.source).toBe(ethereumSubgraphSource);
+    expect(second.source).toBe(ethereumSubgraphSource);
+    // A client rebuilt per failure would arrive cold and refetch.
+    expect(fetchStub.countFor(subgraphOrigin)).toBe(1);
+  });
+
+  it('tolerates a trailing slash on a configured indexer URL', async () => {
+    stubIndexerApiUrlByChain({ [ChainId.Ethereum]: `${indexerOrigin}/` });
+    vi.stubEnv('THE_GRAPH_NETWORK_API_KEY', 'test-api-key');
+    const fetchStub = stubFetch(() => false);
+
+    const getCctpSubgraphClient = await loadGetCctpSubgraphClient();
+    await getCctpSubgraphClient(ChainId.Ethereum).query<{ messageSents: { id: string }[] }>({
+      query,
+    });
+
+    expect(fetchStub.urls).toEqual([`${indexerOrigin}/api/v1/cctp/graphql/${ChainId.Ethereum}`]);
+  });
+
+  // Every unusable map must degrade to the subgraph, never fail the request.
+  it.each([
+    ['an unset variable', ''],
+    ['a chain missing from the map', JSON.stringify({ [ChainId.ArbitrumOne]: indexerOrigin })],
+    ['malformed JSON', '{"1": '],
+    ['a JSON array', `["${indexerOrigin}"]`],
+    ['a non-URL value', JSON.stringify({ [ChainId.Ethereum]: 'not a url' })],
+  ])('queries the subgraph for Ethereum given %s', async (_label, rawEnvValue) => {
+    stubIndexerApiUrlByChain(rawEnvValue);
+    vi.stubEnv('THE_GRAPH_NETWORK_API_KEY', 'test-api-key');
+    const fetchStub = stubFetch(() => false);
+
+    const getCctpSubgraphClient = await loadGetCctpSubgraphClient();
+    const result = await getCctpSubgraphClient(ChainId.Ethereum).query<{
+      messageSents: { id: string }[];
+    }>({ query });
+
+    expect(result.source).toBe(ethereumSubgraphSource);
+    expect(fetchStub.countFor(indexerOrigin)).toBe(0);
+  });
+
+  it('throws for a chain without a CCTP subgraph', async () => {
+    const getCctpSubgraphClient = await loadGetCctpSubgraphClient();
+
+    expect(() => getCctpSubgraphClient(ChainId.ArbitrumNova)).toThrow(
+      `[getCctpSubgraphClient] unsupported chain: ${ChainId.ArbitrumNova}`,
+    );
+  });
+});

--- a/packages/arb-token-bridge-ui/src/app/api/cctp/[type].ts
+++ b/packages/arb-token-bridge-ui/src/app/api/cctp/[type].ts
@@ -1,10 +1,7 @@
 import { gql } from '@apollo/client';
 import { NextResponse } from 'next/server';
 
-import {
-  getCctpSubgraphClient,
-  getSourceFromSubgraphClient,
-} from '../../../api-utils/ServerSubgraphUtils';
+import { type SubgraphSource, getCctpSubgraphClient } from '../../../api-utils/ServerSubgraphUtils';
 import { ChainId } from '../../../types/ChainId';
 import { Address } from '../../../util/AddressUtils';
 
@@ -50,7 +47,7 @@ export type CompletedCCTPTransfer = PendingCCTPTransfer & {
 export type Response =
   | {
       meta?: {
-        source: string | null;
+        source: SubgraphSource;
       };
       data: {
         pending: PendingCCTPTransfer[];
@@ -241,7 +238,7 @@ export async function GET(
     return NextResponse.json(
       {
         meta: {
-          source: getSourceFromSubgraphClient(l1Subgraph),
+          source: messagesSentResult.source,
         },
         data: {
           pending,

--- a/packages/arb-token-bridge-ui/src/app/api/chains/[chainId]/block-number.test.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/chains/[chainId]/block-number.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  getL2SubgraphClient,
-  getSourceFromSubgraphClient,
-} from '../../../../api-utils/ServerSubgraphUtils';
+import { getL2SubgraphClient } from '../../../../api-utils/ServerSubgraphUtils';
 import { ChainId } from '../../../../types/ChainId';
 import { isChildChainIndexed } from '../../../../util/txHistory/sources';
 import { GET } from './block-number';
@@ -15,12 +12,10 @@ vi.mock('../../../../util/txHistory/sources', () => ({
 vi.mock('../../../../api-utils/ServerSubgraphUtils', () => ({
   getL1SubgraphClient: vi.fn(),
   getL2SubgraphClient: vi.fn(),
-  getSourceFromSubgraphClient: vi.fn(),
 }));
 
 const isChildChainIndexedMock = vi.mocked(isChildChainIndexed);
 const getL2SubgraphClientMock = vi.mocked(getL2SubgraphClient);
-const getSourceFromSubgraphClientMock = vi.mocked(getSourceFromSubgraphClient);
 
 function getBlockNumber(chainId: number) {
   return GET({} as never, { params: Promise.resolve({ chainId: String(chainId) }) });
@@ -75,13 +70,15 @@ describe.sequential('GET /api/chains/[chainId]/block-number', () => {
   it('uses the subgraph for a non-indexed chain', async () => {
     isChildChainIndexedMock.mockReturnValue(false);
     const query = vi.fn().mockResolvedValue({ data: { _meta: { block: { number: 999 } } } });
-    getL2SubgraphClientMock.mockReturnValue({ query } as never);
-    getSourceFromSubgraphClientMock.mockReturnValue('arbitrum-one-subgraph');
+    getL2SubgraphClientMock.mockReturnValue({
+      client: { query },
+      source: 'l2-arbitrum-one',
+    } as never);
 
     const response = await getBlockNumber(ChainId.ArbitrumOne);
     const body = await response.json();
 
-    expect(body).toEqual({ meta: { source: 'arbitrum-one-subgraph' }, data: 999 });
+    expect(body).toEqual({ meta: { source: 'l2-arbitrum-one' }, data: 999 });
     expect(query).toHaveBeenCalled();
     // the indexer is never consulted for a non-indexed chain
     expect(fetchMock).not.toHaveBeenCalled();

--- a/packages/arb-token-bridge-ui/src/app/api/chains/[chainId]/block-number.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/chains/[chainId]/block-number.ts
@@ -2,9 +2,9 @@ import { gql } from '@apollo/client';
 import { NextResponse } from 'next/server';
 
 import {
+  type SubgraphSource,
   getL1SubgraphClient,
   getL2SubgraphClient,
-  getSourceFromSubgraphClient,
 } from '../../../../api-utils/ServerSubgraphUtils';
 import { ChainId } from '../../../../types/ChainId';
 import { isChildChainIndexed } from '../../../../util/txHistory/sources';
@@ -59,7 +59,9 @@ function getSubgraphClient(chainId: number) {
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ chainId: string }> },
-): Promise<NextResponse<{ data: number; meta?: { source: string | null } } | { message: string }>> {
+): Promise<
+  NextResponse<{ data: number; meta?: { source: SubgraphSource } } | { message: string }>
+> {
   const { chainId } = await params;
   const numericChainId = Number(chainId);
 
@@ -83,7 +85,7 @@ export async function GET(
       );
     }
 
-    const subgraphClient = getSubgraphClient(numericChainId);
+    const subgraph = getSubgraphClient(numericChainId);
 
     const result: {
       data: {
@@ -93,7 +95,7 @@ export async function GET(
           };
         };
       };
-    } = await subgraphClient.query({
+    } = await subgraph.client.query({
       query: gql`
         {
           _meta {
@@ -107,7 +109,7 @@ export async function GET(
 
     return NextResponse.json(
       {
-        meta: { source: getSourceFromSubgraphClient(subgraphClient) },
+        meta: { source: subgraph.source },
         data: result.data._meta.block.number,
       },
       { status: 200 },

--- a/packages/arb-token-bridge-ui/src/app/api/deposits.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/deposits.ts
@@ -1,15 +1,12 @@
 import { gql } from '@apollo/client';
 import { NextRequest, NextResponse } from 'next/server';
 
-import {
-  getL1SubgraphClient,
-  getSourceFromSubgraphClient,
-} from '../../api-utils/ServerSubgraphUtils';
+import { type SubgraphSource, getL1SubgraphClient } from '../../api-utils/ServerSubgraphUtils';
 import { FetchDepositsFromSubgraphResult } from '../../util/deposits/fetchDepositsFromSubgraph';
 import { isIndexerEnabledForRequest, proxyToIndexer } from './indexer';
 
 type DepositsResponse = {
-  meta?: { source: string | null };
+  meta?: { source: SubgraphSource };
   data: FetchDepositsFromSubgraphResult[];
   message?: string; // in case of any error
 };
@@ -56,9 +53,9 @@ export async function GET(request: NextRequest): Promise<NextResponse<DepositsRe
     ${search ? `transactionHash_contains: "${search}"` : ''}
     `;
 
-    let subgraphClient;
+    let subgraph;
     try {
-      subgraphClient = getL1SubgraphClient(Number(l2ChainId));
+      subgraph = getL1SubgraphClient(Number(l2ChainId));
     } catch (error: any) {
       // catch attempt to query unsupported networks and throw a 400
       return NextResponse.json(
@@ -70,7 +67,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<DepositsRe
       );
     }
 
-    const subgraphResult = await subgraphClient.query({
+    const subgraphResult = await subgraph.client.query({
       query: gql(`{
         deposits(
           where: {            
@@ -111,7 +108,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<DepositsRe
 
     return NextResponse.json(
       {
-        meta: { source: getSourceFromSubgraphClient(subgraphClient) },
+        meta: { source: subgraph.source },
         data: transactions,
       },
       { status: 200 },

--- a/packages/arb-token-bridge-ui/src/app/api/eth-deposits-custom-destination.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/eth-deposits-custom-destination.ts
@@ -1,10 +1,7 @@
 import { gql } from '@apollo/client';
 import { NextRequest, NextResponse } from 'next/server';
 
-import {
-  getL1SubgraphClient,
-  getSourceFromSubgraphClient,
-} from '../../api-utils/ServerSubgraphUtils';
+import { type SubgraphSource, getL1SubgraphClient } from '../../api-utils/ServerSubgraphUtils';
 import { FetchEthDepositsToCustomDestinationFromSubgraphResult } from '../../util/deposits/fetchEthDepositsToCustomDestinationFromSubgraph';
 import { isIndexerEnabledForRequest, proxyToIndexer } from './indexer';
 
@@ -19,7 +16,7 @@ type RetryableFromSubgraph = {
 };
 
 type EthDepositsToCustomDestinationResponse = {
-  meta?: { source: string | null };
+  meta?: { source: SubgraphSource };
   data: FetchEthDepositsToCustomDestinationFromSubgraphResult[];
   message?: string;
 };
@@ -69,9 +66,9 @@ export async function GET(
     l2Calldata: "0x"
     `;
 
-    const subgraphClient = getL1SubgraphClient(Number(l2ChainId));
+    const subgraph = getL1SubgraphClient(Number(l2ChainId));
 
-    const subgraphResult = await subgraphClient.query({
+    const subgraphResult = await subgraph.client.query({
       query: gql(`{
         retryables(
           where: {            
@@ -115,7 +112,7 @@ export async function GET(
 
     return NextResponse.json(
       {
-        meta: { source: getSourceFromSubgraphClient(subgraphClient) },
+        meta: { source: subgraph.source },
         data: transactions,
       },
       { status: 200 },

--- a/packages/arb-token-bridge-ui/src/app/api/withdrawals.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/withdrawals.ts
@@ -1,15 +1,12 @@
 import { gql } from '@apollo/client';
 import { NextRequest, NextResponse } from 'next/server';
 
-import {
-  getL2SubgraphClient,
-  getSourceFromSubgraphClient,
-} from '../../api-utils/ServerSubgraphUtils';
+import { type SubgraphSource, getL2SubgraphClient } from '../../api-utils/ServerSubgraphUtils';
 import { WithdrawalFromSubgraph } from '../../util/withdrawals/fetchWithdrawalsFromSubgraph';
 import { isIndexerEnabledForRequest, proxyToIndexer } from './indexer';
 
 type WithdrawalResponse = {
-  meta?: { source: string | null };
+  meta?: { source: SubgraphSource };
   data: WithdrawalFromSubgraph[];
   message?: string; // in case of any error
 };
@@ -56,9 +53,9 @@ export async function GET(request: NextRequest): Promise<NextResponse<Withdrawal
     ${search ? `l2TxHash_contains: "${search}"` : ''}
     `;
 
-    let subgraphClient;
+    let subgraph;
     try {
-      subgraphClient = getL2SubgraphClient(Number(l2ChainId));
+      subgraph = getL2SubgraphClient(Number(l2ChainId));
     } catch (error: any) {
       // catch attempt to query unsupported networks and throw a 400
       return NextResponse.json(
@@ -70,7 +67,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<Withdrawal
       );
     }
 
-    const subgraphResult = await subgraphClient.query({
+    const subgraphResult = await subgraph.client.query({
       query: gql`{
         withdrawals(
           where: {            
@@ -135,7 +132,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<Withdrawal
 
     return NextResponse.json(
       {
-        meta: { source: getSourceFromSubgraphClient(subgraphClient) },
+        meta: { source: subgraph.source },
         data: transactions,
       },
       { status: 200 },


### PR DESCRIPTION
CCTP history queries now go to the arbitrum-indexer's drop-in replica of Circle's CCTP v1 subgraphs, falling back to the Circle subgraph on any query error.

The indexer base URL is resolved per chain from `INDEXER_API_URL_BY_CHAIN` — a JSON object keyed by chain ID, e.g. `{"42161":"https://indexer.example"}` — because chains are split across separate indexer deployments rather than served by one host. Each chain's queries go to `<its URL>/api/v1/cctp/graphql/:chainId`.

A chain missing from the map — or an unparseable map, or a non-URL value — resolves to "no indexer", and that chain's queries go straight to the subgraph. Behavior is unchanged wherever the variable isn't configured.

**Deploy note:** `INDEXER_API_URL_BY_CHAIN` is set on this project for production, preview and development, so no action is needed at merge. Until a chain is present in the map, its CCTP history comes from the Circle subgraphs.

The other `INDEXER_API_URL` consumers (bridge history proxy, block-number route) still read the single-host variable and migrate separately. When they do, they must resolve by child chain ID — the parent-chain entries point at the deployment that serves the CCTP replica, which is not necessarily the one indexing a given child chain.

Verified on the preview deployment: `meta.source` reports the indexer for mainnet and testnet, deposits and withdrawals; transfer sets and every non-`id` field match what the Circle subgraphs return for the same wallets.