### PR TITLE
fix(bridge): hide zero native gas costs

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/Routes/getGasCostAndToken.test.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/Routes/getGasCostAndToken.test.ts
@@ -162,6 +162,22 @@ describe('getGasCostAndToken', () => {
         });
       },
     );
+
+    test('does not return a gas row when the combined fee is zero', () => {
+      expect(
+        getGasCostAndToken({
+          childChainNativeCurrency: mockNativeCurrency,
+          parentChainNativeCurrency: mockNativeCurrency,
+          gasSummaryStatus: 'success',
+          estimatedChildChainGasFees: 0,
+          estimatedParentChainGasFees: 0,
+          isDepositMode: true,
+        }),
+      ).toEqual({
+        isLoading: false,
+        gasCost: [],
+      });
+    });
   });
 
   describe('should return gas cost for different native currencies in deposit mode', () => {
@@ -181,44 +197,6 @@ describe('getGasCostAndToken', () => {
             {
               gasCost: 305,
               gasToken: mockCustomNativeCurrency,
-            },
-          ],
-        },
-      },
-      {
-        parentCurrency: mockNativeCurrency,
-        childCurrency: mockCustomNativeCurrency,
-        estimatedParentChainGasFees: 201,
-        estimatedChildChainGasFees: 305,
-        expected: {
-          isLoading: false,
-          gasCost: [
-            {
-              gasCost: 201,
-              gasToken: mockNativeCurrency,
-            },
-            {
-              gasCost: 305,
-              gasToken: mockCustomNativeCurrency,
-            },
-          ],
-        },
-      },
-      {
-        parentCurrency: mockCustomNativeCurrency,
-        childCurrency: mockNativeCurrency,
-        estimatedParentChainGasFees: 634,
-        estimatedChildChainGasFees: 234,
-        expected: {
-          isLoading: false,
-          gasCost: [
-            {
-              gasCost: 634,
-              gasToken: mockCustomNativeCurrency,
-            },
-            {
-              gasCost: 234,
-              gasToken: mockNativeCurrency,
             },
           ],
         },
@@ -246,8 +224,7 @@ describe('getGasCostAndToken', () => {
       `getGasCostAndToken({
         ...,
         parentCurrency: $parentCurrency.name,
-        childCurrency: $childCurrency.name,
-        selectedToken: $selectedToken
+        childCurrency: $childCurrency.name
       })`,
       ({
         parentCurrency,
@@ -268,6 +245,27 @@ describe('getGasCostAndToken', () => {
         ).toEqual(expected);
       },
     );
+
+    test('omits a zero child-chain gas row while preserving the parent-chain gas row', () => {
+      expect(
+        getGasCostAndToken({
+          childChainNativeCurrency: mockCustomNativeCurrency,
+          parentChainNativeCurrency: mockNativeCurrency,
+          gasSummaryStatus: 'success',
+          estimatedChildChainGasFees: 0,
+          estimatedParentChainGasFees: 201,
+          isDepositMode: true,
+        }),
+      ).toEqual({
+        isLoading: false,
+        gasCost: [
+          {
+            gasCost: 201,
+            gasToken: mockNativeCurrency,
+          },
+        ],
+      });
+    });
   });
 
   describe('should return gas cost for different native currencies in withdrawal mode', () => {
@@ -327,5 +325,21 @@ describe('getGasCostAndToken', () => {
         ).toEqual(expected);
       },
     );
+
+    test('does not return a gas row when the child-chain fee is zero', () => {
+      expect(
+        getGasCostAndToken({
+          childChainNativeCurrency: mockCustomNativeCurrency,
+          parentChainNativeCurrency: mockNativeCurrency,
+          gasSummaryStatus: 'success',
+          estimatedChildChainGasFees: 0,
+          estimatedParentChainGasFees: 201,
+          isDepositMode: false,
+        }),
+      ).toEqual({
+        isLoading: false,
+        gasCost: [],
+      });
+    });
   });
 });

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/Routes/getGasCostAndToken.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/Routes/getGasCostAndToken.ts
@@ -61,12 +61,15 @@ export function getGasCostAndToken({
   if (sameNativeCurrency) {
     return {
       isLoading: false,
-      gasCost: [
-        {
-          gasCost: estimatedTotalGasFees,
-          gasToken: childChainNativeCurrencyWithAddress,
-        },
-      ],
+      gasCost:
+        estimatedTotalGasFees > 0
+          ? [
+              {
+                gasCost: estimatedTotalGasFees,
+                gasToken: childChainNativeCurrencyWithAddress,
+              },
+            ]
+          : [],
     };
   }
 
@@ -94,7 +97,7 @@ export function getGasCostAndToken({
         gasCost: estimatedChildChainGasFees!,
         gasToken: childChainNativeCurrencyWithAddress,
       },
-    ];
+    ].filter(({ gasCost }) => gasCost > 0);
 
     return {
       gasCost,
@@ -104,11 +107,14 @@ export function getGasCostAndToken({
 
   return {
     isLoading: false,
-    gasCost: [
-      {
-        gasCost: estimatedChildChainGasFees!,
-        gasToken: childChainNativeCurrencyWithAddress,
-      },
-    ],
+    gasCost:
+      estimatedChildChainGasFees! > 0
+        ? [
+            {
+              gasCost: estimatedChildChainGasFees!,
+              gasToken: childChainNativeCurrencyWithAddress,
+            },
+          ]
+        : [],
   };
 }


### PR DESCRIPTION
## Summary
- omit exact-zero gas rows from native bridge route estimates
- keep non-zero parent and child gas currencies displayed independently
- avoid rendering a combined gas row when its total is zero

## Testing
ArbitrumOne to ApeChain: Native route shows "X ETH and 0 APE" on production, it should shows "X ETH" only in this branch