### PR TITLE
feat(bridge): execute LiFi routes with SDK

### DIFF
--- a/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/lifi.test.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/lifi.test.ts
@@ -31,6 +31,7 @@ function createMockRoute(
     protocolData: {
       orders: [],
       tool: { key: 'test', name: 'Test', logoURI: '' },
+      route: {} as LifiCrosschainTransfersRoute['protocolData']['route'],
       step: {} as LifiCrosschainTransfersRoute['protocolData']['step'],
     },
   };

--- a/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/lifi.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/lifi.ts
@@ -51,7 +51,9 @@ export interface LifiCrosschainTransfersRoute extends CrosschainTransfersRouteBa
   protocolData: {
     orders: Tags;
     tool: StepToolDetails;
-    /** This is needed to fetch transactionRequest later on */
+    /** Full route used by the LiFi SDK during execution. */
+    route: Route;
+    /** Single-step metadata used by the existing route UI. */
     step: LiFiStep;
   };
 }
@@ -229,6 +231,7 @@ function parseLifiRouteToCrosschainTransfersQuoteWithLifiData({
     toChainId: Number(toChainId),
     spenderAddress: step.estimate.approvalAddress,
     protocolData: {
+      route,
       step,
       tool: step.toolDetails,
       orders: tags,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/LifiTokenApprovalDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/LifiTokenApprovalDialog.tsx
@@ -1,0 +1,87 @@
+import type { TransactionParameters } from '@lifi/sdk';
+import { utils } from 'ethers';
+import { useMemo, useState } from 'react';
+
+import { shortenAddress } from '../../util/CommonUtils';
+import { Checkbox } from '../common/Checkbox';
+import { Dialog, UseDialogProps } from '../common/Dialog';
+import { NoteBox } from '../common/NoteBox';
+
+export type LifiApprovalDialogData = {
+  approvalRequest: TransactionParameters;
+};
+
+function getApprovalSpender(approvalRequest: TransactionParameters | undefined) {
+  if (!approvalRequest?.data) {
+    return undefined;
+  }
+
+  try {
+    const erc20Interface = new utils.Interface([
+      'function approve(address spender,uint256 amount)',
+    ]);
+    const [spender] = erc20Interface.decodeFunctionData('approve', approvalRequest.data);
+
+    return typeof spender === 'string' ? spender : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function LifiTokenApprovalDialog({
+  approvalRequest,
+  isOpen,
+  onClose,
+}: UseDialogProps & {
+  approvalRequest: TransactionParameters | undefined;
+}) {
+  const [checked, setChecked] = useState(false);
+  const spenderAddress = useMemo(() => getApprovalSpender(approvalRequest), [approvalRequest]);
+
+  const closeWithReset = (confirmed: boolean) => {
+    onClose(confirmed);
+    setChecked(false);
+  };
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={closeWithReset}
+      title="Acknowledge token approval"
+      actionButtonTitle="Continue to approval"
+      actionButtonProps={{ disabled: !checked }}
+    >
+      <div className="flex flex-col space-y-4 py-4 text-sm">
+        <Checkbox
+          label={
+            <span className="font-light">
+              I understand this LiFi route needs a token approval before the next transaction.
+            </span>
+          }
+          checked={checked}
+          onChange={setChecked}
+        />
+
+        <div className="space-y-2">
+          {approvalRequest?.to && (
+            <div className="flex justify-between gap-4">
+              <span className="text-white/60">Token contract</span>
+              <span>{shortenAddress(approvalRequest.to)}</span>
+            </div>
+          )}
+          {spenderAddress && (
+            <div className="flex justify-between gap-4">
+              <span className="text-white/60">Spender contract</span>
+              <span>{shortenAddress(spenderAddress)}</span>
+            </div>
+          )}
+        </div>
+
+        <NoteBox>
+          Your wallet will ask you to approve token spending. After approval, LiFi will continue
+          with the route.
+        </NoteBox>
+      </div>
+    </Dialog>
+  );
+}

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenApprovalDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenApprovalDialog.tsx
@@ -1,11 +1,9 @@
 import { BigNumber, constants, utils } from 'ethers';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAccount, useChainId } from 'wagmi';
-import { shallow } from 'zustand/shallow';
 
 import { BridgeTransferStarterFactory } from '@/token-bridge-sdk/BridgeTransferStarterFactory';
 import { CctpTransferStarter } from '@/token-bridge-sdk/CctpTransferStarter';
-import { LifiTransferStarter } from '@/token-bridge-sdk/LifiTransferStarter';
 import { getCctpContracts } from '@/token-bridge-sdk/cctp';
 
 import { TOKEN_APPROVAL_ARTICLE_LINK, ether } from '../../constants';
@@ -29,7 +27,7 @@ import { Dialog, UseDialogProps } from '../common/Dialog';
 import { ExternalLink } from '../common/ExternalLink';
 import { NoteBox } from '../common/NoteBox';
 import { TokenInfo } from './TokenInfo';
-import { isLifiRoute, useRouteStore } from './hooks/useRouteStore';
+import { useRouteStore } from './hooks/useRouteStore';
 
 export type TokenApprovalDialogProps = UseDialogProps & {
   token: ERC20BridgeToken | null;
@@ -50,15 +48,8 @@ export function TokenApprovalDialog(props: TokenApprovalDialogProps) {
   const gasPrice = useGasPrice({ provider });
   const chainId = useChainId();
   const signer = useEthersSigner({ chainId });
-  const { selectedRoute, context } = useRouteStore(
-    (state) => ({
-      selectedRoute: state.selectedRoute,
-      context: state.context,
-    }),
-    shallow,
-  );
+  const selectedRoute = useRouteStore((state) => state.selectedRoute);
   const isCctp = selectedRoute === 'cctp';
-  const isLifi = isLifiRoute(selectedRoute);
   const isOft = selectedRoute === 'oftV2';
 
   const [checked, setChecked] = useState(false);
@@ -97,20 +88,6 @@ export function TokenApprovalDialog(props: TokenApprovalDialogProps) {
 
       if (!signer) {
         gasEstimate = constants.Zero;
-      } else if (isLifi) {
-        if (!context) {
-          throw new Error('Missing context data for Lifi transfer.');
-        }
-        const lifiTransferStarter = new LifiTransferStarter({
-          sourceChainProvider,
-          destinationChainProvider,
-          lifiData: context,
-          sourceChainErc20Address: token.address,
-        });
-        gasEstimate = await lifiTransferStarter.approveTokenEstimateGas({
-          signer,
-          amount: constants.MaxUint256,
-        });
       } else if (isCctp) {
         const cctpTransferStarter = new CctpTransferStarter({
           sourceChainProvider,
@@ -164,21 +141,10 @@ export function TokenApprovalDialog(props: TokenApprovalDialogProps) {
     chainId,
     isCctp,
     isOft,
-    isLifi,
-    context,
   ]);
 
   useEffect(() => {
     const getContractAddress = async function () {
-      if (isLifi) {
-        if (!context) {
-          throw new Error('Missing context data for Lifi transfer.');
-        }
-
-        setContractAddress(context.spenderAddress);
-        return;
-      }
-
       if (isOft) {
         const oftTransferConfig = getOftV2TransferConfig({
           sourceChainId: sourceChain.id,
@@ -233,8 +199,6 @@ export function TokenApprovalDialog(props: TokenApprovalDialogProps) {
     sourceChain.id,
     destinationChain.id,
     isOft,
-    isLifi,
-    context,
   ]);
 
   const closeWithReset = useCallback(
@@ -244,12 +208,6 @@ export function TokenApprovalDialog(props: TokenApprovalDialogProps) {
     },
     [onClose],
   );
-
-  useEffect(() => {
-    if (isLifi && !context) {
-      closeWithReset(false);
-    }
-  }, [context, closeWithReset, isLifi]);
 
   return (
     <Dialog

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -1,6 +1,5 @@
 import { scaleFrom18DecimalsToNativeTokenDecimals } from '@arbitrum/sdk';
 import { TransactionResponse } from '@ethersproject/providers';
-import { getStepTransaction } from '@lifi/sdk';
 import dayjs from 'dayjs';
 import { constants, utils } from 'ethers';
 import { usePathname } from 'next/navigation';
@@ -55,7 +54,6 @@ import { getLifiAssetType, trackEvent } from '../../util/AnalyticsUtils';
 import { isGatewayRegistered, isTokenNativeUSDC } from '../../util/TokenUtils';
 import { isCctpEnabled } from '../../util/featureFlag';
 import { isUserRejectedError } from '../../util/isUserRejectedError';
-import { isValidTransactionRequest } from '../../util/isValidTransactionRequest';
 import { logger } from '../../util/logger';
 import { getNetworkName, isNetwork } from '../../util/networks';
 import { normalizeTimestamp } from '../../util/normalizeTimestamp';
@@ -67,7 +65,7 @@ import { addDepositToCache } from '../TransactionHistory/helpers';
 import { WidgetBuyPanel } from '../Widget/WidgetBuyPanel';
 import { WidgetTransferPanel } from '../Widget/WidgetTransferPanel';
 import { useDialog } from '../common/Dialog';
-import { DialogType, DialogWrapper, useDialog2 } from '../common/Dialog2';
+import { DialogData, DialogType, DialogWrapper, useDialog2 } from '../common/Dialog2';
 import { ExternalLink } from '../common/ExternalLink';
 import { errorToast, warningToast } from '../common/atoms/Toast';
 import { ConnectWalletButton } from './ConnectWalletButton';
@@ -311,8 +309,8 @@ export function TransferPanel() {
 
   const { current: amountBigNumber } = useLatest(useAmountBigNumber());
 
-  const confirmDialog = async (dialogType: DialogType) => {
-    const waitForInput = openDialog(dialogType);
+  const confirmDialog = async (dialogType: DialogType, dialogData?: DialogData) => {
+    const waitForInput = openDialog(dialogType, dialogData);
     const [confirmed] = await waitForInput();
     return confirmed;
   };
@@ -615,65 +613,19 @@ export function TransferPanel() {
         destinationChainId: networks.destinationChain.id,
       });
 
-      const { transactionRequest } = await getStepTransaction(context.step);
-      if (!isValidTransactionRequest(transactionRequest)) {
-        return;
-      }
-
       const destinationChainErc20Address =
-        tokenOverrides.destination?.address || isDepositMode
-          ? selectedToken?.l2Address
-          : selectedToken?.address;
+        tokenOverrides.destination?.address ||
+        (isDepositMode ? selectedToken?.l2Address : selectedToken?.address);
       const sourceChainErc20Address =
-        tokenOverrides.source?.address || isDepositMode
-          ? selectedToken?.address
-          : selectedToken?.l2Address;
+        tokenOverrides.source?.address ||
+        (isDepositMode ? selectedToken?.address : selectedToken?.l2Address);
       const lifiTransferStarter = new LifiTransferStarter({
         destinationChainProvider,
         sourceChainProvider,
         destinationChainErc20Address,
         sourceChainErc20Address,
-        lifiData: {
-          ...context,
-          transactionRequest,
-        },
+        lifiData: context,
       });
-
-      // Check for allowance
-      if (
-        await lifiTransferStarter.requiresTokenApproval({
-          amount: amountBigNumber,
-          owner: await signer.getAddress(),
-        })
-      ) {
-        const userConfirmation = await confirmDialog('approve_token');
-        if (!userConfirmation) return false;
-
-        if (isSmartContractWallet) {
-          showDelayedSmartContractTxRequest();
-        }
-
-        try {
-          const tx = await lifiTransferStarter.approveToken({
-            signer,
-            amount: amountBigNumber,
-          });
-          if (tx) await tx.wait();
-        } catch (error) {
-          if (isUserRejectedError(error)) {
-            return;
-          }
-          handleError({
-            error,
-            label: 'lifi_approve_token',
-            category: 'token_approval',
-          });
-          errorToast(
-            `Lifi approval transaction failed: ${error instanceof BaseError ? error.shortMessage : (error as Error).message}`,
-          );
-          return;
-        }
-      }
 
       if (isSmartContractWallet) {
         showDelayedSmartContractTxRequest();
@@ -684,6 +636,19 @@ export function TransferPanel() {
         signer,
         destinationAddress,
         wagmiConfig,
+        switchChainAsync,
+        onApprovalRequest: (approvalRequest) =>
+          confirmDialog('approve_lifi_token', { lifiApproval: { approvalRequest } }),
+        onRouteExecutionError: (error) => {
+          handleError({
+            error,
+            label: 'lifi_route_execution',
+            category: 'token_transfer',
+          });
+          errorToast(
+            'LiFi transaction execution was interrupted. Check transaction history for its latest status.',
+          );
+        },
       });
 
       const assetType = getLifiAssetType({
@@ -750,7 +715,6 @@ export function TransferPanel() {
           fromAmount: context.fromAmount,
           toAmount: context.toAmount,
           destinationTxId: null,
-          transactionRequest,
         };
         addPendingTransaction(newTransfer);
         addLifiTransactionToCache(newTransfer);
@@ -758,8 +722,9 @@ export function TransferPanel() {
 
       clearRoute();
 
-      if (transfer?.sourceChainTransaction?.wait) {
-        await transfer.sourceChainTransaction.wait();
+      const sourceChainTransaction = transfer.sourceChainTransaction;
+      if ('wait' in sourceChainTransaction) {
+        await sourceChainTransaction.wait();
 
         await Promise.all([updateEthParentBalance(), updateEthChildBalance()]);
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useRouteStore.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useRouteStore.ts
@@ -140,6 +140,7 @@ export function getContextFromRoute(route: LifiCrosschainTransfersRoute): RouteC
     toolDetails: route.protocolData.tool,
     durationMs: route.durationMs,
     destinationTxId: null,
+    route: route.protocolData.route,
     step: route.protocolData.step,
   };
 }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadiness.test.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadiness.test.ts
@@ -53,6 +53,7 @@ function getMock({
     },
     durationMs: 4000,
     destinationTxId: null,
+    route: {} as RouteContext['route'],
     step: {
       type: 'lifi',
       id: 'ef70a077-0322-4b80-b2c4-7117eaf544d4:0',

--- a/packages/arb-token-bridge-ui/src/components/common/Dialog2.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Dialog2.tsx
@@ -12,6 +12,10 @@ import { CustomDestinationAddressConfirmationDialog } from '../TransferPanel/Cus
 import { CustomFeeTokenApprovalDialog } from '../TransferPanel/CustomFeeTokenApprovalDialog';
 import { DestinationTokenSearch } from '../TransferPanel/DestinationTokenSearch';
 import { HighSlippageWarningDialog } from '../TransferPanel/HighSlippageWarningDialog';
+import {
+  LifiApprovalDialogData,
+  LifiTokenApprovalDialog,
+} from '../TransferPanel/LifiTokenApprovalDialog';
 import { NovaDepositWarningDialog } from '../TransferPanel/NovaDepositWarningDialog';
 import { SettingsDialog } from '../TransferPanel/SettingsDialog';
 import { TokenApprovalDialog } from '../TransferPanel/TokenApprovalDialog';
@@ -35,7 +39,14 @@ type WaitForInputFunction = () => Promise<[boolean, unknown]>;
 /**
  * Opens the dialog and returns a function which can be called to retrieve a {@link WaitForInputFunction}.
  */
-export type OpenDialogFunction = (dialogType: DialogType) => WaitForInputFunction;
+export type DialogData = {
+  lifiApproval?: LifiApprovalDialogData;
+};
+
+export type OpenDialogFunction = (
+  dialogType: DialogType,
+  dialogData?: DialogData,
+) => WaitForInputFunction;
 
 /**
  * Returns an array containing {@link DialogProps} and {@link OpenDialogFunction}.
@@ -44,6 +55,7 @@ type UseDialogResult = [DialogProps, OpenDialogFunction];
 
 export type DialogType =
   | 'approve_token'
+  | 'approve_lifi_token'
   | 'approve_cctp_usdc'
   | 'approve_custom_fee_token'
   | 'withdraw'
@@ -73,16 +85,21 @@ export function useDialog2(): UseDialogResult {
 
   // Whether the dialog is currently open
   const [openedDialogType, setOpenedDialogType] = useState<DialogType | null>(null);
+  const [dialogData, setDialogData] = useState<DialogData | undefined>();
 
-  const openDialog: OpenDialogFunction = useCallback((dialogType: DialogType) => {
-    setOpenedDialogType(dialogType);
+  const openDialog: OpenDialogFunction = useCallback(
+    (dialogType: DialogType, data?: DialogData) => {
+      setOpenedDialogType(dialogType);
+      setDialogData(data);
 
-    return () => {
-      return new Promise((resolve) => {
-        resolveRef.current = resolve;
-      });
-    };
-  }, []);
+      return () => {
+        return new Promise((resolve) => {
+          resolveRef.current = resolve;
+        });
+      };
+    },
+    [],
+  );
 
   const closeDialog = useCallback((confirmed: boolean, onCloseData?: unknown) => {
     if (typeof resolveRef.current !== 'undefined') {
@@ -90,13 +107,15 @@ export function useDialog2(): UseDialogResult {
     }
 
     setOpenedDialogType(null);
+    setDialogData(undefined);
   }, []);
 
-  return [{ openedDialogType, onClose: closeDialog }, openDialog];
+  return [{ openedDialogType, dialogData, onClose: closeDialog }, openDialog];
 }
 
 export type DialogProps = {
   openedDialogType: DialogType | null;
+  dialogData?: DialogData;
   onClose: (confirmed: boolean, onCloseData?: unknown) => void;
 };
 
@@ -121,6 +140,13 @@ export function DialogWrapper(props: DialogProps) {
     case 'approve_token':
     case 'approve_cctp_usdc':
       return <TokenApprovalDialog {...commonProps} token={selectedToken} />;
+    case 'approve_lifi_token':
+      return (
+        <LifiTokenApprovalDialog
+          {...commonProps}
+          approvalRequest={props.dialogData?.lifiApproval?.approvalRequest}
+        />
+      );
     case 'approve_custom_fee_token':
       if (nativeCurrency.isCustom) {
         return <CustomFeeTokenApprovalDialog {...commonProps} customFeeToken={nativeCurrency} />;

--- a/packages/arb-token-bridge-ui/src/hooks/useLifiMergedTransactionCacheStore.test.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useLifiMergedTransactionCacheStore.test.ts
@@ -1,12 +1,29 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import dayjs from 'dayjs';
 import { BigNumber, constants } from 'ethers';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { shallow } from 'zustand/shallow';
 
 import { DepositStatus, LifiMergedTransaction, WithdrawalStatus } from '../state/app/state';
 import { AssetType } from './arbTokenBridge.types';
-import { useLifiMergedTransactionCacheStore } from './useLifiMergedTransactionCacheStore';
+
+const LIFI_CACHE_KEY = 'lifi-merged-transaction-cache';
+const storage = new Map<string, string>();
+const localStorageMock: Storage = {
+  clear: () => storage.clear(),
+  getItem: (key) => storage.get(key) ?? null,
+  key: (index) => Array.from(storage.keys())[index] ?? null,
+  get length() {
+    return storage.size;
+  },
+  removeItem: (key) => {
+    storage.delete(key);
+  },
+  setItem: (key, value) => {
+    storage.set(key, value);
+  },
+};
+let useLifiMergedTransactionCacheStore: (typeof import('./useLifiMergedTransactionCacheStore'))['useLifiMergedTransactionCacheStore'];
 
 function createMockedLifiTransaction({
   hash,
@@ -69,9 +86,20 @@ function createMockedLifiTransaction({
 }
 
 describe.sequential('useLifiMergedTransactionCacheStore', () => {
+  beforeAll(async () => {
+    vi.stubGlobal('localStorage', localStorageMock);
+    ({ useLifiMergedTransactionCacheStore } = await import('./useLifiMergedTransactionCacheStore'));
+  });
+
   beforeEach(() => {
+    localStorageMock.clear();
     useLifiMergedTransactionCacheStore.setState({ transactions: {} });
   });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('should return undefined by default', async () => {
     const walletAddress = '0x9481eF9e2CA814fc94676dEa3E8c3097B06b3a33';
     const { result } = renderHook(() =>
@@ -177,6 +205,39 @@ describe.sequential('useLifiMergedTransactionCacheStore', () => {
     await waitFor(() => {
       expect(result.current.transactions[walletAddress]).toEqual([updatedTransaction]);
       expect(result.current.transactions[customDestinationAddress]).toEqual([updatedTransaction]);
+    });
+  });
+
+  it('rehydrates legacy version-1 transactions that include a transaction request', async () => {
+    const walletAddress = '0x9481eF9e2CA814fc94676dEa3E8c3097B06b3a33';
+    const legacyTransaction = createMockedLifiTransaction({
+      hash: '0x240c2c89b5f153b0cc1fce5ea709473b858359887d0aa1d4157fe130c95d2134',
+      sender: walletAddress,
+      destinationAddress: walletAddress,
+    });
+
+    localStorage.setItem(
+      LIFI_CACHE_KEY,
+      JSON.stringify({
+        state: {
+          transactions: {
+            [walletAddress]: [legacyTransaction],
+          },
+        },
+        version: 1,
+      }),
+    );
+
+    await useLifiMergedTransactionCacheStore.persist.rehydrate();
+
+    const hydratedTransaction =
+      useLifiMergedTransactionCacheStore.getState().transactions[walletAddress]?.[0];
+
+    expect(hydratedTransaction).toMatchObject({
+      txId: legacyTransaction.txId,
+      isLifi: true,
+      toolDetails: legacyTransaction.toolDetails,
+      transactionRequest: legacyTransaction.transactionRequest,
     });
   });
 });

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/BridgeTransferStarterFactory.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/BridgeTransferStarterFactory.ts
@@ -23,7 +23,7 @@ function getCacheKey(props: BridgeTransferStarterPropsWithChainIds): string {
   }
 
   if (props.lifiData) {
-    cacheKey += `-${props.lifiData.transactionRequest?.data}-${props.lifiData.spenderAddress}`;
+    cacheKey += `-${props.lifiData.route.id}`;
   }
 
   return cacheKey;

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/LifiRouteExecutor.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/LifiRouteExecutor.ts
@@ -1,0 +1,116 @@
+import type { ExecutionOptions, Route, RouteExtended, TransactionParameters } from '@lifi/sdk';
+import { EVM, executeRoute, config as lifiConfig } from '@lifi/sdk';
+import type { Config } from '@wagmi/core';
+import { getWalletClient } from '@wagmi/core';
+import { Client, UserRejectedRequestError } from 'viem';
+
+import { getExecutedLifiRouteTxHash } from '../util/LifiTransactionStatus';
+
+type SwitchChainAsync = (parameters: { chainId: number }) => Promise<{ id: number } | undefined>;
+
+type LifiRouteRunProps = {
+  wagmiConfig: Config;
+  switchChainAsync: SwitchChainAsync;
+  onApprovalRequest?: (approvalRequest: TransactionParameters) => Promise<boolean>;
+};
+
+export type LifiRouteExecutionProps = LifiRouteRunProps & {
+  onRouteExecutionError: (error: unknown) => void;
+};
+
+function configureLifiEvmProvider({
+  wagmiConfig,
+  switchChainAsync,
+}: Pick<LifiRouteRunProps, 'wagmiConfig' | 'switchChainAsync'>) {
+  lifiConfig.setProviders([
+    EVM({
+      getWalletClient: async () => {
+        const walletClient = await getWalletClient(wagmiConfig);
+        if (!walletClient) {
+          throw new Error('LiFi SDK wallet client is unavailable.');
+        }
+        return walletClient as Client;
+      },
+      switchChain: async (chainId) => {
+        await switchChainAsync({ chainId });
+
+        const walletClient = await getWalletClient(wagmiConfig, { chainId });
+        if (!walletClient) {
+          throw new Error('LiFi SDK wallet client is unavailable after switching chain.');
+        }
+        return walletClient as Client;
+      },
+    }),
+  ]);
+}
+
+function createExecutionOptions({
+  wagmiConfig,
+  switchChainAsync,
+  onApprovalRequest,
+}: LifiRouteRunProps): ExecutionOptions {
+  configureLifiEvmProvider({ wagmiConfig, switchChainAsync });
+
+  return {
+    updateTransactionRequestHook: async ({ requestType, ...transactionRequest }) => {
+      if (requestType === 'approve') {
+        const approvalConfirmed = await onApprovalRequest?.(transactionRequest);
+
+        if (approvalConfirmed === false) {
+          throw new UserRejectedRequestError(new Error('User declined token approval'));
+        }
+      }
+
+      return transactionRequest;
+    },
+  };
+}
+
+// LiFi's `executeRoute` resolves after route execution has finished, but the app needs the
+// source-chain transaction hash as soon as it exists so it can create its history entry.
+// EIP-5792 wallet batch ids are ignored until LiFi reports the real on-chain transaction hash.
+export function executeLifiRoute(
+  route: Route | RouteExtended,
+  {
+    wagmiConfig,
+    switchChainAsync,
+    onApprovalRequest,
+    onRouteExecutionError,
+  }: LifiRouteExecutionProps,
+): Promise<{ txHash: string }> {
+  const executionOptions = createExecutionOptions({
+    wagmiConfig,
+    switchChainAsync,
+    onApprovalRequest,
+  });
+
+  return new Promise((resolve, reject) => {
+    let resolvedRouteTx = false;
+
+    const handleRouteUpdate = (updatedRoute: RouteExtended) => {
+      const txHash = getExecutedLifiRouteTxHash(updatedRoute);
+      if (txHash && !resolvedRouteTx) {
+        resolvedRouteTx = true;
+        resolve({ txHash });
+      }
+    };
+
+    executeRoute(route, {
+      ...executionOptions,
+      updateRouteHook: handleRouteUpdate,
+    })
+      .then((updatedRoute) => {
+        handleRouteUpdate(updatedRoute);
+        if (!resolvedRouteTx) {
+          reject(new Error('LiFi route execution completed without a route transaction hash.'));
+        }
+      })
+      .catch((error) => {
+        if (resolvedRouteTx) {
+          onRouteExecutionError(error);
+        } else {
+          reject(error);
+        }
+      });
+  });
+}

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/LifiTransferStarter.test.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/LifiTransferStarter.test.ts
@@ -1,0 +1,351 @@
+import type { Provider } from '@ethersproject/providers';
+import { RouteExtended, executeRoute } from '@lifi/sdk';
+import { BigNumber, constants } from 'ethers';
+import { UserRejectedRequestError } from 'viem';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getExecutedLifiRouteTxHash,
+  getSubmittedLifiRouteTxHash,
+} from '../util/LifiTransactionStatus';
+import { LifiData, LifiTransferStarter } from './LifiTransferStarter';
+
+vi.mock('@lifi/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@lifi/sdk')>();
+
+  return {
+    ...actual,
+    config: {
+      setProviders: vi.fn(),
+    },
+    EVM: vi.fn((options) => options),
+    executeRoute: vi.fn(),
+  };
+});
+
+const eth = {
+  address: constants.AddressZero,
+  decimals: 18,
+  logoURI: '',
+  symbol: 'ETH',
+};
+
+function createLifiData({
+  gasAmount = BigNumber.from(0),
+  feeAmount = BigNumber.from(0),
+  route = { id: 'route-id', steps: [] } as unknown as RouteExtended,
+}: {
+  gasAmount?: BigNumber;
+  feeAmount?: BigNumber;
+  route?: RouteExtended;
+} = {}): LifiData {
+  return {
+    spenderAddress: constants.AddressZero,
+    gas: { amount: gasAmount, amountUSD: '0', token: eth },
+    fee: { amount: feeAmount, amountUSD: '0', token: eth },
+    route,
+  };
+}
+const routeTxHash = '0xa0231341aef0576cd9467d1506011d1dd041167762db0d2b1657678e3c0c5255';
+const batchId = '0x3ed2270c44494ccfa9c60daf655e7879';
+const batchId32Bytes = '0x5f4e4b452a390f349b7fc1f7b9b1666da36199b342de010996606ac8cea5ace1';
+
+function createStarter() {
+  return new LifiTransferStarter({
+    sourceChainProvider: {
+      getNetwork: async () => ({ chainId: 1 }),
+      getTransaction: async (hash: string) => ({ hash }),
+    } as unknown as Provider,
+    destinationChainProvider: {
+      getNetwork: async () => ({ chainId: 42161 }),
+    } as unknown as Provider,
+    lifiData: createLifiData(),
+  });
+}
+
+function createTransferProps(
+  onApprovalRequest: NonNullable<
+    Parameters<LifiTransferStarter['transfer']>[0]['onApprovalRequest']
+  >,
+): Parameters<LifiTransferStarter['transfer']>[0] {
+  return {
+    amount: BigNumber.from(1),
+    destinationAddress: constants.AddressZero,
+    signer: {} as Parameters<LifiTransferStarter['transfer']>[0]['signer'],
+    wagmiConfig: {} as Parameters<LifiTransferStarter['transfer']>[0]['wagmiConfig'],
+    switchChainAsync: vi.fn().mockResolvedValue(undefined),
+    onApprovalRequest,
+    onRouteExecutionError: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getExecutedLifiRouteTxHash', () => {
+  it('ignores approval-only transaction hashes', () => {
+    const route = {
+      steps: [
+        {
+          execution: {
+            process: [
+              {
+                type: 'TOKEN_ALLOWANCE',
+                status: 'DONE',
+                txHash: '0xapproval',
+              },
+            ],
+          },
+        },
+      ],
+    } as unknown as RouteExtended;
+
+    expect(getExecutedLifiRouteTxHash(route)).toBeUndefined();
+  });
+
+  it('returns the first route execution transaction hash', () => {
+    const route = {
+      steps: [
+        {
+          execution: {
+            process: [
+              {
+                type: 'TOKEN_ALLOWANCE',
+                status: 'DONE',
+                txHash: '0xapproval',
+              },
+              {
+                type: 'CROSS_CHAIN',
+                status: 'PENDING',
+                txHash: routeTxHash,
+              },
+            ],
+          },
+        },
+      ],
+    } as unknown as RouteExtended;
+
+    expect(getExecutedLifiRouteTxHash(route)).toBe(routeTxHash);
+  });
+
+  it('ignores EIP-5792 batch ids until LiFi updates the route with a transaction hash', () => {
+    const routeWithBatchId = {
+      steps: [
+        {
+          execution: {
+            process: [
+              {
+                type: 'CROSS_CHAIN',
+                status: 'PENDING',
+                txHash: batchId32Bytes,
+                txType: 'batched',
+              },
+            ],
+          },
+        },
+      ],
+    } as unknown as RouteExtended;
+    const routeWithTransactionHash = {
+      steps: [
+        {
+          execution: {
+            process: [
+              {
+                type: 'CROSS_CHAIN',
+                status: 'PENDING',
+                txHash: routeTxHash,
+                txType: 'batched',
+                txLink: `https://etherscan.io/tx/${routeTxHash}`,
+              },
+            ],
+          },
+        },
+      ],
+    } as unknown as RouteExtended;
+
+    expect(getExecutedLifiRouteTxHash(routeWithBatchId)).toBeUndefined();
+    expect(getSubmittedLifiRouteTxHash(routeWithBatchId)).toBe(batchId32Bytes);
+    expect(getExecutedLifiRouteTxHash(routeWithTransactionHash)).toBe(routeTxHash);
+    expect(getSubmittedLifiRouteTxHash(routeWithTransactionHash)).toBe(routeTxHash);
+  });
+});
+
+describe('LifiTransferStarter approvals', () => {
+  it('asks for approval through each LiFi approval transaction request hook', async () => {
+    const onApprovalRequest = vi.fn().mockResolvedValue(true);
+    const executedRoute = {
+      id: 'route-id',
+      steps: [
+        {
+          execution: {
+            process: [
+              {
+                type: 'SWAP',
+                status: 'PENDING',
+                txHash: routeTxHash,
+              },
+            ],
+          },
+        },
+      ],
+    } as unknown as RouteExtended;
+
+    vi.mocked(executeRoute).mockImplementationOnce(async (_route, executionOptions) => {
+      await executionOptions?.updateTransactionRequestHook?.({
+        requestType: 'approve',
+        to: '0xsourcetoken',
+        data: '0xsourceapprove',
+      });
+      await executionOptions?.updateTransactionRequestHook?.({
+        requestType: 'approve',
+        to: '0xdestinationtoken',
+        data: '0xdestinationapprove',
+      });
+      await executionOptions?.updateTransactionRequestHook?.({
+        requestType: 'transaction',
+        to: '0xbridge',
+        data: '0xbridge',
+      });
+      executionOptions?.updateRouteHook?.(executedRoute);
+      return executedRoute;
+    });
+
+    await createStarter().transfer(createTransferProps(onApprovalRequest));
+
+    expect(onApprovalRequest).toHaveBeenCalledTimes(2);
+    expect(onApprovalRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        to: '0xsourcetoken',
+        data: '0xsourceapprove',
+      }),
+    );
+    expect(onApprovalRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        to: '0xdestinationtoken',
+        data: '0xdestinationapprove',
+      }),
+    );
+  });
+
+  it('waits for the on-chain transaction hash when a wallet first reports a batch id', async () => {
+    const routeWithBatchId = {
+      id: 'route-id',
+      steps: [
+        {
+          execution: {
+            process: [
+              {
+                type: 'CROSS_CHAIN',
+                status: 'PENDING',
+                txHash: batchId,
+                txType: 'batched',
+              },
+            ],
+          },
+        },
+      ],
+    } as unknown as RouteExtended;
+    const routeWithTransactionHash = {
+      id: 'route-id',
+      steps: [
+        {
+          execution: {
+            process: [
+              {
+                type: 'CROSS_CHAIN',
+                status: 'PENDING',
+                txHash: routeTxHash,
+                txType: 'batched',
+                txLink: `https://etherscan.io/tx/${routeTxHash}`,
+              },
+            ],
+          },
+        },
+      ],
+    } as unknown as RouteExtended;
+
+    vi.mocked(executeRoute).mockImplementationOnce(async (_route, executionOptions) => {
+      executionOptions?.updateRouteHook?.(routeWithBatchId);
+      executionOptions?.updateRouteHook?.(routeWithTransactionHash);
+      return routeWithTransactionHash;
+    });
+
+    await expect(createStarter().transfer(createTransferProps(vi.fn()))).resolves.toMatchObject({
+      sourceChainTransaction: {
+        hash: routeTxHash,
+      },
+    });
+  });
+
+  it('reports route failures that happen after the first transaction is submitted', async () => {
+    const executionError = new Error('destination step failed');
+    const onRouteExecutionError = vi.fn();
+    const submittedRoute = {
+      id: 'route-id',
+      steps: [
+        {
+          execution: {
+            process: [
+              {
+                type: 'CROSS_CHAIN',
+                status: 'PENDING',
+                txHash: routeTxHash,
+              },
+            ],
+          },
+        },
+      ],
+    } as unknown as RouteExtended;
+
+    vi.mocked(executeRoute).mockImplementationOnce(async (_route, executionOptions) => {
+      executionOptions?.updateRouteHook?.(submittedRoute);
+      throw executionError;
+    });
+    const transferProps = createTransferProps(vi.fn());
+    transferProps.onRouteExecutionError = onRouteExecutionError;
+
+    await createStarter().transfer(transferProps);
+
+    expect(onRouteExecutionError).toHaveBeenCalledWith(executionError);
+  });
+
+  it('rejects route execution when the approval modal is declined', async () => {
+    const onApprovalRequest = vi.fn().mockResolvedValue(false);
+
+    vi.mocked(executeRoute).mockImplementationOnce(async (_route, executionOptions) => {
+      await executionOptions?.updateTransactionRequestHook?.({
+        requestType: 'approve',
+        to: '0xtoken',
+        data: '0xapprove',
+      });
+      throw new Error('unreachable');
+    });
+
+    await expect(
+      createStarter().transfer(createTransferProps(onApprovalRequest)),
+    ).rejects.toBeInstanceOf(UserRejectedRequestError);
+    expect(onApprovalRequest).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('LifiTransferStarter estimates', () => {
+  it('uses the existing scalar gas estimate for a deposit', async () => {
+    const starter = new LifiTransferStarter({
+      sourceChainProvider: {
+        getNetwork: async () => ({ chainId: 1 }),
+      } as unknown as Provider,
+      destinationChainProvider: {
+        getNetwork: async () => ({ chainId: 42161 }),
+      } as unknown as Provider,
+      lifiData: createLifiData({ gasAmount: BigNumber.from(10) }),
+    });
+
+    await expect(starter.transferEstimateGas()).resolves.toEqual({
+      estimatedParentChainGas: BigNumber.from(10),
+      estimatedChildChainGas: constants.Zero,
+    });
+  });
+});

--- a/packages/arb-token-bridge-ui/src/token-bridge-sdk/LifiTransferStarter.ts
+++ b/packages/arb-token-bridge-ui/src/token-bridge-sdk/LifiTransferStarter.ts
@@ -1,34 +1,32 @@
-import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory';
-import { Config, sendTransaction } from '@wagmi/core';
+import type { Route } from '@lifi/sdk';
 import { BigNumber, constants } from 'ethers';
-import { Address } from 'viem';
+import type { Address } from 'viem';
 
-import { TransactionRequest } from '@/bridge/app/api/crosschain-transfers/lifi';
-import { Token } from '@/bridge/app/api/crosschain-transfers/types';
+import type { Token } from '@/bridge/app/api/crosschain-transfers/types';
 
-import { fetchErc20Allowance } from '../util/TokenUtils';
 import { isDepositMode } from '../util/isDepositMode';
 import {
-  ApproveTokenProps,
   BridgeTransferStarter,
   BridgeTransferStarterProps,
-  RequiresTokenApprovalProps,
   TransferProps,
   TransferType,
 } from './BridgeTransferStarter';
+import { LifiRouteExecutionProps, executeLifiRoute } from './LifiRouteExecutor';
 
 export type AmountWithToken = {
   amount: BigNumber;
   amountUSD: string;
   token: Token;
 };
+
 export type LifiData = {
   spenderAddress: Address;
   gas: AmountWithToken;
   fee: AmountWithToken;
-  transactionRequest?: TransactionRequest;
+  route: Route;
 };
-export type LifiTransferStarterProps = BridgeTransferStarterProps & {
+
+type LifiTransferStarterProps = BridgeTransferStarterProps & {
   lifiData: LifiData;
 };
 
@@ -38,12 +36,7 @@ export class LifiTransferStarter extends BridgeTransferStarter {
 
   constructor(props: LifiTransferStarterProps) {
     super(props);
-    this.lifiData = {
-      spenderAddress: props.lifiData.spenderAddress as Address,
-      gas: props.lifiData.gas,
-      fee: props.lifiData.fee,
-      transactionRequest: props.lifiData.transactionRequest,
-    };
+    this.lifiData = props.lifiData;
   }
 
   public requiresNativeCurrencyApproval = async () => {
@@ -58,51 +51,16 @@ export class LifiTransferStarter extends BridgeTransferStarter {
     // no-op
   };
 
-  public async requiresTokenApproval({
-    amount,
-    owner,
-  }: RequiresTokenApprovalProps): Promise<boolean> {
-    if (!this.sourceChainErc20Address || this.sourceChainErc20Address === constants.AddressZero) {
-      // If we have no sourceChainErc20Address, we assume we want to send ETH
-      return false;
-    }
-
-    const allowance = await fetchErc20Allowance({
-      address: this.sourceChainErc20Address,
-      provider: this.sourceChainProvider,
-      owner,
-      spender: this.lifiData.spenderAddress,
-    });
-
-    return allowance.lt(amount);
+  public async requiresTokenApproval(): Promise<boolean> {
+    return false;
   }
 
-  public async approveToken({ signer, amount }: ApproveTokenProps) {
-    if (!this.sourceChainErc20Address || this.sourceChainErc20Address === constants.AddressZero) {
-      return;
-    }
-
-    const contract = ERC20__factory.connect(this.sourceChainErc20Address, signer);
-
-    return contract.approve(this.lifiData.spenderAddress, amount ?? constants.MaxUint256, {
-      from: await signer.getAddress(),
-    });
+  public async approveToken() {
+    // LiFi SDK handles approval during route execution.
   }
 
-  public async approveTokenEstimateGas({ signer, amount }: ApproveTokenProps) {
-    if (!this.sourceChainErc20Address) {
-      return constants.Zero;
-    }
-
-    const contract = ERC20__factory.connect(this.sourceChainErc20Address, signer);
-
-    return contract.estimateGas.approve(
-      this.lifiData.spenderAddress,
-      amount ?? constants.MaxUint256,
-      {
-        from: await signer.getAddress(),
-      },
-    );
+  public async approveTokenEstimateGas() {
+    return constants.Zero;
   }
 
   public async transferEstimateGas() {
@@ -116,20 +74,19 @@ export class LifiTransferStarter extends BridgeTransferStarter {
     };
   }
 
-  public async transfer({ wagmiConfig }: TransferProps & { wagmiConfig: Config }) {
-    if (!this.lifiData.transactionRequest) {
-      throw new Error('LifiTransferStarter is missing transaction request.');
-    }
-
-    const { to, data, value, chainId } = this.lifiData.transactionRequest;
-    // pinning chainId propagates viem's active-chain assertion to the send
-    const txHash = await sendTransaction(wagmiConfig, {
-      to: to as Address,
-      data: data as Address,
-      value: BigInt(value),
-      chainId,
+  public async transfer({
+    wagmiConfig,
+    switchChainAsync,
+    onApprovalRequest,
+    onRouteExecutionError,
+  }: TransferProps & LifiRouteExecutionProps) {
+    const { txHash } = await executeLifiRoute(this.lifiData.route, {
+      wagmiConfig,
+      switchChainAsync,
+      onApprovalRequest,
+      onRouteExecutionError,
     });
-    const fullTx = await this.sourceChainProvider.getTransaction(txHash);
+    const fullTx = await this.sourceChainProvider.getTransaction(txHash).catch(() => null);
 
     return {
       transferType: this.transferType,

--- a/packages/arb-token-bridge-ui/src/util/LifiTransactionStatus.ts
+++ b/packages/arb-token-bridge-ui/src/util/LifiTransactionStatus.ts
@@ -1,6 +1,50 @@
+import type { ProcessType, RouteExtended } from '@lifi/sdk';
 import type { StatusResponse } from '@lifi/types';
+import { utils } from 'ethers';
 
 import { WithdrawalStatus } from '../state/app/state';
+
+const EXECUTED_ROUTE_PROCESS_TYPES: ReadonlySet<ProcessType> = new Set([
+  'CROSS_CHAIN',
+  'SWAP',
+  'TRANSACTION',
+]);
+
+export function isValidLifiTransactionHash(txHash: string | null | undefined) {
+  return typeof txHash === 'string' && utils.isHexString(txHash, 32);
+}
+
+function getSubmittedLifiRouteProcess(route: RouteExtended | undefined) {
+  for (const step of route?.steps ?? []) {
+    const routeProcess = step.execution?.process.find(
+      (process) =>
+        typeof process.txHash === 'string' &&
+        process.status !== 'FAILED' &&
+        EXECUTED_ROUTE_PROCESS_TYPES.has(process.type),
+    );
+
+    if (routeProcess?.txHash) {
+      return routeProcess;
+    }
+  }
+
+  return undefined;
+}
+
+export function getSubmittedLifiRouteTxHash(route: RouteExtended | undefined) {
+  return getSubmittedLifiRouteProcess(route)?.txHash;
+}
+
+export function getExecutedLifiRouteTxHash(route: RouteExtended | undefined) {
+  const routeProcess = getSubmittedLifiRouteProcess(route);
+  const txHash = routeProcess?.txHash;
+  const isPendingProcessId =
+    routeProcess?.txType !== undefined &&
+    routeProcess.txType !== 'standard' &&
+    typeof routeProcess.txLink !== 'string';
+
+  return !isPendingProcessId && isValidLifiTransactionHash(txHash) ? txHash : undefined;
+}
 
 export function getLifiTransferStatus(statusResponse: StatusResponse): {
   status: WithdrawalStatus;

--- a/packages/arb-token-bridge-ui/src/util/__tests__/isUserRejectedError.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/__tests__/isUserRejectedError.test.ts
@@ -12,6 +12,12 @@ describe('isUserRejectedError', () => {
     expect(isUserRejectedError({ message: 'User Cancelled Request' })).toBe(true);
     expect(
       isUserRejectedError({
+        message:
+          '[TransactionError] User rejected the request. Request Arguments: from: 0x123 Details: MetaMask Tx Signature: User denied transaction signature. Version: viem@2.47.4 LI.FI SDK version: 3.7.0',
+      }),
+    ).toBe(true);
+    expect(
+      isUserRejectedError({
         details: 'MetaMask Tx Signature: User denied transaction signature.',
       }),
     ).toBe(true);

--- a/packages/arb-token-bridge-ui/src/util/isUserRejectedError.ts
+++ b/packages/arb-token-bridge-ui/src/util/isUserRejectedError.ts
@@ -15,6 +15,8 @@ export function isUserRejectedError(error: unknown) {
 
   const hasUserCancelledMessage =
     typeof candidate.message === 'string' && /User Cancelled/.test(candidate.message);
+  const hasUserRejectedRequestMessage =
+    typeof candidate.message === 'string' && /User rejected the request/.test(candidate.message);
 
   const hasWrappedUserRejection =
     error instanceof BaseError && !!error.walk((e) => e instanceof UserRejectedRequestError);
@@ -23,6 +25,7 @@ export function isUserRejectedError(error: unknown) {
     candidate.code === 4001 ||
     candidate.code === 'ACTION_REJECTED' ||
     hasUserCancelledMessage ||
+    hasUserRejectedRequestMessage ||
     error instanceof UserRejectedRequestError ||
     hasWrappedUserRejection ||
     candidate.details === 'MetaMask Tx Signature: User denied transaction signature.' ||


### PR DESCRIPTION
## Summary

- execute the selected LiFi route through the LiFi SDK instead of fetching and submitting a transaction request manually
- delegate token approvals and chain switching to the SDK, with an explicit approval confirmation dialog
- ignore approval hashes and EIP-5792 batch IDs until LiFi reports a valid on-chain transaction hash
- verify legacy version-1 cached LiFi transactions still rehydrate with their transaction request and display metadata intact
