### PR TITLE
build(deps): resolve npm audit advisories

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -7,6 +7,18 @@
     // Reason to ignore: Not used directly. Patched version is a major bump (v1.2.0).
     // from: arb-token-bridge-ui>@lifi/sdk>bitcoinjs-lib>valibot
     "GHSA-vqpr-j7v3-hqw9",
+    //
+    // https://github.com/advisories/GHSA-5qjj-4xww-7phc
+    // Valibot record() issue paths can make flatten() throw for inherited Object property names
+    // Reason to ignore: Not used directly and we never call valibot's flatten(). Patched version (1.4.2) is a major bump the parents don't support (they pin ^0.36/^0.38).
+    // from: arb-token-bridge-ui>@lifi/sdk>bitcoinjs-lib>valibot
+    "GHSA-5qjj-4xww-7phc",
+    //
+    // https://github.com/advisories/GHSA-mh99-v99m-4gvg
+    // brace-expansion DoS via unbounded expansion length causing an out-of-memory process crash (CVE-2026-14257)
+    // Reason to ignore: Only reachable via dev tooling (eslint plugins, typescript-estree, glob in test coverage), where expansion patterns come from our own config, not attacker input. The only patched version (5.0.8) is a major bump whose CJS export shape is incompatible with the minimatch 3.x consumers in the eslint chain.
+    // from: eslint>minimatch>brace-expansion
+    "GHSA-mh99-v99m-4gvg",
     // https://github.com/advisories/GHSA-848j-6mx2-7j84
     // Elliptic Uses a Cryptographic Primitive with a Risky Implementation
     // CVE-2025-14505: ECDSA implementation generates incorrect signatures if interim value 'k' has leading zeros

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ overrides:
   fast-uri: 3.1.4
   sharp: 0.35.3
   follow-redirects: 1.16.0
-  postcss: 8.5.12
+  postcss: 8.5.18
   uuid: 14.0.0
   vite@>=7.0.0 <7.3.5: 7.3.5
   vite@>=6.0.0 <6.4.3: 6.4.3
@@ -214,10 +214,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.14(postcss@8.5.12)
+        version: 10.4.14(postcss@8.5.18)
       postcss:
-        specifier: 8.5.12
-        version: 8.5.12
+        specifier: 8.5.18
+        version: 8.5.18
       tailwindcss:
         specifier: ^3.4.16
         version: 3.4.16(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
@@ -371,7 +371,7 @@ importers:
         version: 0.2.2(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)))
       '@synthetixio/synpress':
         specifier: 3.7.3
-        version: 3.7.3(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(@types/react@19.2.14)(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.12)))(bufferutil@4.0.9)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.12))(zod@3.25.76)
+        version: 3.7.3(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(@types/react@19.2.14)(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)))(bufferutil@4.0.9)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.18))(zod@3.25.76)
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -398,7 +398,7 @@ importers:
         version: 17.0.33
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.14(postcss@8.5.12)
+        version: 10.4.14(postcss@8.5.18)
       cypress-terminal-report:
         specifier: ^7.1.0
         version: 7.2.1(cypress@12.17.3)
@@ -412,8 +412,8 @@ importers:
         specifier: ^1.16.0
         version: 1.16.0
       postcss:
-        specifier: 8.5.12
-        version: 8.5.12
+        specifier: 8.5.18
+        version: 8.5.18
       satori:
         specifier: ^0.12.2
         version: 0.12.2
@@ -513,10 +513,10 @@ importers:
         version: 3.2.3
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.14(postcss@8.5.12)
+        version: 10.4.14(postcss@8.5.18)
       postcss:
-        specifier: 8.5.12
-        version: 8.5.12
+        specifier: 8.5.18
+        version: 8.5.18
       tailwindcss:
         specifier: ^3.4.16
         version: 3.4.16(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
@@ -4414,7 +4414,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -7296,8 +7296,8 @@ packages:
       react: '*'
       react-dom: '*'
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7843,19 +7843,19 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
 
   postcss-js@4.0.1:
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
 
   postcss-load-config@4.0.2:
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       postcss:
@@ -7867,7 +7867,7 @@ packages:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -7876,8 +7876,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.12:
-    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   posthog-js@1.273.0:
@@ -10902,12 +10902,12 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@cypress/code-coverage@3.14.6(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.12)))(cypress@12.17.3)(webpack@5.106.2(postcss@8.5.12))':
+  '@cypress/code-coverage@3.14.6(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)))(cypress@12.17.3)(webpack@5.106.2(postcss@8.5.18))':
     dependencies:
       '@babel/core': 7.29.6
       '@babel/preset-env': 7.29.5(@babel/core@7.29.6)
-      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.12)))(webpack@5.106.2(postcss@8.5.12))
-      babel-loader: 10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.12))
+      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)))(webpack@5.106.2(postcss@8.5.18))
+      babel-loader: 10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18))
       chalk: 4.1.2
       cypress: 12.17.3
       dayjs: 1.11.13
@@ -10917,7 +10917,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       js-yaml: 4.3.0
       nyc: 15.1.0
-      webpack: 5.106.2(postcss@8.5.12)
+      webpack: 5.106.2(postcss@8.5.18)
     transitivePeerDependencies:
       - supports-color
 
@@ -10942,17 +10942,17 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 14.0.0
 
-  '@cypress/webpack-dev-server@3.11.0(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.12))':
+  '@cypress/webpack-dev-server@3.11.0(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.18))':
     dependencies:
       find-up: 6.3.0
       fs-extra: 9.1.0
-      html-webpack-plugin-4: html-webpack-plugin@4.5.2(webpack@5.106.2(postcss@8.5.12))
-      html-webpack-plugin-5: html-webpack-plugin@5.6.7(webpack@5.106.2(postcss@8.5.12))
+      html-webpack-plugin-4: html-webpack-plugin@4.5.2(webpack@5.106.2(postcss@8.5.18))
+      html-webpack-plugin-5: html-webpack-plugin@5.6.7(webpack@5.106.2(postcss@8.5.18))
       local-pkg: 0.4.1
       semver: 7.8.1
-      speed-measure-webpack-plugin: 1.4.2(webpack@5.106.2(postcss@8.5.12))
+      speed-measure-webpack-plugin: 1.4.2(webpack@5.106.2(postcss@8.5.18))
       tslib: 2.8.1
-      webpack-dev-server: 4.15.2(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.12))
+      webpack-dev-server: 4.15.2(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.18))
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@rspack/core'
@@ -10963,16 +10963,16 @@ snapshots:
       - webpack
       - webpack-cli
 
-  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.12)))(webpack@5.106.2(postcss@8.5.12))':
+  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)))(webpack@5.106.2(postcss@8.5.18))':
     dependencies:
       '@babel/core': 7.29.6
       '@babel/preset-env': 7.29.5(@babel/core@7.29.6)
-      babel-loader: 10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.12))
+      babel-loader: 10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18))
       bluebird: 3.7.1
       debug: 4.4.3(supports-color@8.1.1)
       lodash: 4.18.1
       semver: 7.8.1
-      webpack: 5.106.2(postcss@8.5.12)
+      webpack: 5.106.2(postcss@8.5.18)
     transitivePeerDependencies:
       - supports-color
 
@@ -13772,10 +13772,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@synthetixio/synpress@3.7.3(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(@types/react@19.2.14)(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.12)))(bufferutil@4.0.9)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.12))(zod@3.25.76)':
+  '@synthetixio/synpress@3.7.3(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(@types/react@19.2.14)(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)))(bufferutil@4.0.9)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.18))(zod@3.25.76)':
     dependencies:
-      '@cypress/code-coverage': 3.14.6(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.12)))(cypress@12.17.3)(webpack@5.106.2(postcss@8.5.12))
-      '@cypress/webpack-dev-server': 3.11.0(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.12))
+      '@cypress/code-coverage': 3.14.6(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)))(cypress@12.17.3)(webpack@5.106.2(postcss@8.5.18))
+      '@cypress/webpack-dev-server': 3.11.0(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.18))
       '@drptbl/gremlins.js': 2.2.1
       '@foundry-rs/easy-foundryup': 0.1.3
       '@playwright/test': 1.56.0
@@ -15562,14 +15562,14 @@ snapshots:
       semver: 7.7.3
       yargs: 17.7.2
 
-  autoprefixer@10.4.14(postcss@8.5.12):
+  autoprefixer@10.4.14(postcss@8.5.18):
     dependencies:
       browserslist: 4.26.3
       caniuse-lite: 1.0.30001749
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.5.12
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -15599,12 +15599,12 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.12)):
+  babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)):
     dependencies:
       '@babel/core': 7.29.6
       find-up: 5.0.0
     optionalDependencies:
-      webpack: 5.106.2(postcss@8.5.12)
+      webpack: 5.106.2(postcss@8.5.18)
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
@@ -17951,7 +17951,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.48.0
 
-  html-webpack-plugin@4.5.2(webpack@5.106.2(postcss@8.5.12)):
+  html-webpack-plugin@4.5.2(webpack@5.106.2(postcss@8.5.18)):
     dependencies:
       '@types/html-minifier-terser': 5.1.2
       '@types/tapable': 1.0.12
@@ -17962,9 +17962,9 @@ snapshots:
       pretty-error: 2.1.2
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 5.106.2(postcss@8.5.12)
+      webpack: 5.106.2(postcss@8.5.18)
 
-  html-webpack-plugin@5.6.7(webpack@5.106.2(postcss@8.5.12)):
+  html-webpack-plugin@5.6.7(webpack@5.106.2(postcss@8.5.18)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -17972,7 +17972,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.106.2(postcss@8.5.12)
+      webpack: 5.106.2(postcss@8.5.18)
 
   htmlparser2@10.1.0:
     dependencies:
@@ -18918,7 +18918,7 @@ snapshots:
       stacktrace-js: 2.0.2
       stylis: 4.3.4
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.16: {}
 
   napi-postinstall@0.3.2: {}
 
@@ -18943,7 +18943,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.29
       caniuse-lite: 1.0.30001792
-      postcss: 8.5.12
+      postcss: 8.5.18
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.6)(react@19.2.6)
@@ -19531,37 +19531,37 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.12):
+  postcss-import@15.1.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-js@4.0.1(postcss@8.5.12):
+  postcss-js@4.0.1(postcss@8.5.18):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.12
+      postcss: 8.5.18
 
-  postcss-load-config@4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2)):
+  postcss-load-config@4.0.2(postcss@8.5.18)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
     optionalDependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
       ts-node: 10.9.2(@types/node@22.19.19)(typescript@5.9.2)
 
-  postcss-load-config@4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.5.18)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
     optionalDependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
       ts-node: 10.9.2(@types/node@22.19.19)(typescript@5.9.3)
 
-  postcss-nested@6.2.0(postcss@8.5.12):
+  postcss-nested@6.2.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -19571,9 +19571,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.12:
+  postcss@8.5.18:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -20422,10 +20422,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  speed-measure-webpack-plugin@1.4.2(webpack@5.106.2(postcss@8.5.12)):
+  speed-measure-webpack-plugin@1.4.2(webpack@5.106.2(postcss@8.5.18)):
     dependencies:
       chalk: 4.1.2
-      webpack: 5.106.2(postcss@8.5.12)
+      webpack: 5.106.2(postcss@8.5.18)
 
   split-on-first@1.1.0: {}
 
@@ -20722,11 +20722,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.12
-      postcss-import: 15.1.0(postcss@8.5.12)
-      postcss-js: 4.0.1(postcss@8.5.12)
-      postcss-load-config: 4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
-      postcss-nested: 6.2.0(postcss@8.5.12)
+      postcss: 8.5.18
+      postcss-import: 15.1.0(postcss@8.5.18)
+      postcss-js: 4.0.1(postcss@8.5.18)
+      postcss-load-config: 4.0.2(postcss@8.5.18)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
+      postcss-nested: 6.2.0(postcss@8.5.18)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
       sucrase: 3.35.0
@@ -20749,11 +20749,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.12
-      postcss-import: 15.1.0(postcss@8.5.12)
-      postcss-js: 4.0.1(postcss@8.5.12)
-      postcss-load-config: 4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
-      postcss-nested: 6.2.0(postcss@8.5.12)
+      postcss: 8.5.18
+      postcss-import: 15.1.0(postcss@8.5.18)
+      postcss-js: 4.0.1(postcss@8.5.18)
+      postcss-load-config: 4.0.2(postcss@8.5.18)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      postcss-nested: 6.2.0(postcss@8.5.18)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
       sucrase: 3.35.0
@@ -20774,15 +20774,15 @@ snapshots:
       to-buffer: 1.2.2
       xtend: 4.0.2
 
-  terser-webpack-plugin@5.6.1(postcss@8.5.12)(webpack@5.106.2(postcss@8.5.12)):
+  terser-webpack-plugin@5.6.1(postcss@8.5.18)(webpack@5.106.2(postcss@8.5.18)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.106.2(postcss@8.5.12)
+      webpack: 5.106.2(postcss@8.5.18)
     optionalDependencies:
-      postcss: 8.5.12
+      postcss: 8.5.18
 
   terser@4.8.1:
     dependencies:
@@ -21339,7 +21339,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.12
+      postcss: 8.5.18
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -21354,7 +21354,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.12
+      postcss: 8.5.18
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -21500,16 +21500,16 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  webpack-dev-middleware@5.3.4(webpack@5.106.2(postcss@8.5.12)):
+  webpack-dev-middleware@5.3.4(webpack@5.106.2(postcss@8.5.18)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.6.0
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.3
-      webpack: 5.106.2(postcss@8.5.12)
+      webpack: 5.106.2(postcss@8.5.18)
 
-  webpack-dev-server@4.15.2(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.12)):
+  webpack-dev-server@4.15.2(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.18)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -21539,10 +21539,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.106.2(postcss@8.5.12))
+      webpack-dev-middleware: 5.3.4(webpack@5.106.2(postcss@8.5.18))
       ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
     optionalDependencies:
-      webpack: 5.106.2(postcss@8.5.12)
+      webpack: 5.106.2(postcss@8.5.18)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -21557,7 +21557,7 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.106.2(postcss@8.5.12):
+  webpack@5.106.2(postcss@8.5.18):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -21580,7 +21580,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(postcss@8.5.12)(webpack@5.106.2(postcss@8.5.12))
+      terser-webpack-plugin: 5.6.1(postcss@8.5.18)(webpack@5.106.2(postcss@8.5.18))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,7 +40,7 @@ overrides:
   'fast-uri': 3.1.4
   'sharp': 0.35.3
   'follow-redirects': 1.16.0
-  'postcss': 8.5.12
+  'postcss': 8.5.18
   'uuid': 14.0.0
   'vite@>=7.0.0 <7.3.5': 7.3.5
   'vite@>=6.0.0 <6.4.3': 6.4.3


### PR DESCRIPTION
Resolves the 3 new advisories failing `audit:ci`:

### Bumped

- **postcss** [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) (high) — path traversal in source map auto-loading. Bumped the existing override from `8.5.12` to the patched `8.5.18`.

### Allowlisted

- **valibot** [GHSA-5qjj-4xww-7phc](https://github.com/advisories/GHSA-5qjj-4xww-7phc) (moderate) — `record()` issue paths can make `flatten()` throw. Not used directly and we never call `flatten()`; the patched version (1.4.2) is a major bump the parents don't support (`@lifi/sdk>bitcoinjs-lib`/`@mysten/sui` pin `^0.36`/`^0.38`). Same chain as the existing valibot entry.
- **brace-expansion** [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (high) — DoS via unbounded expansion length. Only reachable via dev tooling (eslint plugins, typescript-estree, glob in test coverage), where patterns come from our own config. The only patched version (5.0.8) exports a named `expand` instead of a callable module, which is incompatible with the minimatch 3.x consumers in the eslint chain, so it can't be overridden safely.

`pnpm audit:ci` now exits 0. Lockfile changes are limited to postcss `8.5.18` and its transitive dep nanoid.