### PR TITLE
ci(monitoring): use pnpm to run arbitrum-monitoring

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-      - run: cd ./arbitrum-monitoring && yarn install
+      - run: cd ./arbitrum-monitoring && pnpm install --frozen-lockfile
 
       - name: Load configuration
         id: config
@@ -73,7 +73,7 @@ jobs:
         run: cp ./packages/arb-token-bridge-ui/public/${{ steps.config.outputs.config_file }} ./arbitrum-monitoring/config.json
 
       - name: Run monitoring command
-        run: cd ./arbitrum-monitoring && yarn ${{ inputs.monitor }}-monitor --enableAlerting --writeToNotion ${{ inputs.chain == 'core' && 'true' || 'false' }} ${{ inputs.monitor == 'retryable' && '--autoRedeem' || '' }}
+        run: cd ./arbitrum-monitoring && pnpm ${{ inputs.monitor }}-monitor --enableAlerting --writeToNotion ${{ inputs.chain == 'core' && 'true' || 'false' }} ${{ inputs.monitor == 'retryable' && '--autoRedeem' || '' }}
         env:
           RETRYABLE_MONITORING_SLACK_TOKEN: ${{ secrets[steps.config.outputs.slack_token] }}
           RETRYABLE_MONITORING_SLACK_CHANNEL: ${{ secrets[steps.config.outputs.slack_channel] }}


### PR DESCRIPTION
`arbitrum-monitoring` migrated from yarn to pnpm, so this reusable workflow must install/invoke it with pnpm.

- `yarn install` → `pnpm install --frozen-lockfile`
- `yarn <monitor>-monitor …` → `pnpm <monitor>-monitor …` (root script names unchanged, so args are identical)

pnpm is already set up in this job; no other changes needed.

⚠️ Must merge in lockstep with the migration PR: OffchainLabs/arbitrum-monitoring#127