### PR TITLE
fix(bridge): re-enable Trust Wallet transfers

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -30,6 +30,7 @@ import { useAccountType } from '../../hooks/useAccountType';
 import { TabParamEnum, tabToIndex, useArbQueryParams } from '../../hooks/useArbQueryParams';
 import { useBalances } from '../../hooks/useBalances';
 import { useError } from '../../hooks/useError';
+import { useIsTrustWalletConnection } from '../../hooks/useIsTrustWalletConnection';
 import { useLifiMergedTransactionCacheStore } from '../../hooks/useLifiMergedTransactionCacheStore';
 import { useMode } from '../../hooks/useMode';
 import { useSelectedToken } from '../../hooks/useSelectedToken';
@@ -148,6 +149,8 @@ export function TransferPanel() {
 
   const { accountType } = useAccountType();
   const isSmartContractWallet = accountType === 'smart-contract-wallet';
+
+  const isTrustWalletConnection = useIsTrustWalletConnection();
 
   const { current: signer } = useLatest(useEthersSigner({ chainId: networks.sourceChain.id }));
   const wagmiConfig = useConfig();
@@ -286,6 +289,17 @@ export function TransferPanel() {
   const confirmDialog = async (dialogType: DialogType) => {
     const waitForInput = openDialog(dialogType);
     const [confirmed] = await waitForInput();
+    return confirmed;
+  };
+
+  const confirmTrustWalletUpdate = async () => {
+    if (!isTrustWalletConnection) {
+      return true;
+    }
+
+    const confirmed = await confirmDialog('trust_wallet_update');
+    trackEvent('Trust Wallet Update Confirmation', { confirmed });
+
     return confirmed;
   };
 
@@ -1294,6 +1308,10 @@ export function TransferPanel() {
       if (!shouldProceedToNova) {
         return;
       }
+    }
+
+    if (!(await confirmTrustWalletUpdate())) {
+      return;
     }
 
     if (selectedRoute == 'oftV2') {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TrustWalletUpdateDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TrustWalletUpdateDialog.tsx
@@ -1,42 +1,18 @@
-import { useState } from 'react';
-
-import { Checkbox } from '../common/Checkbox';
 import { Dialog, DialogProps } from '../common/Dialog';
 
 export function TrustWalletUpdateDialog(props: DialogProps) {
-  const [acknowledged, setAcknowledged] = useState(false);
-
-  function closeWithReset(confirmed: boolean) {
-    props.onClose(confirmed);
-    setAcknowledged(false);
-  }
-
   return (
     <Dialog
       {...props}
-      onClose={closeWithReset}
       title="Update Trust Wallet"
-      actionButtonTitle="Proceed"
-      actionButtonProps={{ disabled: !acknowledged }}
+      actionButtonTitle="Confirm"
       className="md:max-w-[480px]"
     >
-      <div className="flex flex-col gap-4 py-4 text-sm font-light">
-        <p>
-          Older versions can sign on the wrong network and lose funds. Fixed in mobile{' '}
-          <span className="font-medium">26.30.6</span> and extension{' '}
-          <span className="font-medium">2.91.4</span>.
-        </p>
-
-        <Checkbox
-          label={
-            <span className="font-light">
-              My Trust Wallet is up to date. I proceed at my own risk.
-            </span>
-          }
-          checked={acknowledged}
-          onChange={setAcknowledged}
-        />
-      </div>
+      <p className="py-4 text-sm font-light">
+        Old versions of Trust Wallet can sign on the wrong network and lose funds. Please ensure you
+        are on the latest version of the mobile app or browser extension, and that you sign on the
+        correct network.
+      </p>
     </Dialog>
   );
 }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TrustWalletUpdateDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TrustWalletUpdateDialog.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+
+import { Checkbox } from '../common/Checkbox';
+import { Dialog, DialogProps } from '../common/Dialog';
+
+export function TrustWalletUpdateDialog(props: DialogProps) {
+  const [acknowledged, setAcknowledged] = useState(false);
+
+  function closeWithReset(confirmed: boolean) {
+    props.onClose(confirmed);
+    setAcknowledged(false);
+  }
+
+  return (
+    <Dialog
+      {...props}
+      onClose={closeWithReset}
+      title="Update Trust Wallet"
+      actionButtonTitle="Proceed"
+      actionButtonProps={{ disabled: !acknowledged }}
+      className="md:max-w-[480px]"
+    >
+      <div className="flex flex-col gap-4 py-4 text-sm font-light">
+        <p>
+          Older versions can sign on the wrong network and lose funds. Fixed in mobile{' '}
+          <span className="font-medium">26.30.6</span> and extension{' '}
+          <span className="font-medium">2.91.4</span>.
+        </p>
+
+        <Checkbox
+          label={
+            <span className="font-light">
+              My Trust Wallet is up to date. I proceed at my own risk.
+            </span>
+          }
+          checked={acknowledged}
+          onChange={setAcknowledged}
+        />
+      </div>
+    </Dialog>
+  );
+}

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TrustWalletUpdateDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TrustWalletUpdateDialog.tsx
@@ -4,15 +4,20 @@ export function TrustWalletUpdateDialog(props: DialogProps) {
   return (
     <Dialog
       {...props}
-      title="Update Trust Wallet"
-      actionButtonTitle="Confirm"
+      title="Warning: Trust Wallet"
+      actionButtonTitle="Proceed"
       className="md:max-w-[480px]"
     >
-      <p className="py-4 text-sm font-light">
-        Old versions of Trust Wallet can sign on the wrong network and lose funds. Please ensure you
-        are on the latest version of the mobile app or browser extension, and that you sign on the
-        correct network.
-      </p>
+      <div className="flex flex-col gap-3 py-4 text-sm font-light">
+        <p>We detected you&apos;re connected via Trust Wallet.</p>
+
+        <p>Old versions of Trust Wallet can sign on the wrong network and lose funds.</p>
+
+        <p>
+          Please ensure you are on the latest version of the mobile app or browser extension, and
+          that you sign on the correct network.
+        </p>
+      </div>
     </Dialog>
   );
 }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadiness.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadiness.ts
@@ -1,4 +1,3 @@
-import { useWalletInfo } from '@reown/appkit/react';
 import { useLocalStorage } from '@uidotdev/usehooks';
 import { BigNumber, constants, utils } from 'ethers';
 import { useMemo } from 'react';
@@ -35,7 +34,6 @@ import {
   TransferReadinessRichErrorMessage,
   getInsufficientFundsErrorMessage,
   getInsufficientFundsForGasFeesErrorMessage,
-  getTrustWalletDisabledErrorMessage,
   getWithdrawOnlyChainErrorMessage,
 } from './useTransferReadinessUtils';
 
@@ -228,8 +226,6 @@ export function useTransferReadiness(): UseTransferReadinessResult {
     });
   const { destinationAddressError } = useDestinationAddressError();
   const [tosAccepted] = useLocalStorage<boolean>(TOS_LOCALSTORAGE_KEY);
-  const { walletInfo } = useWalletInfo('eip155');
-  const isTrustWalletConnection = (walletInfo?.name ?? '').toLowerCase().includes('trust wallet');
   const { data: tokensFromLists } = useTokensFromLists();
 
   const ethL1BalanceFloat = ethParentBalance
@@ -311,14 +307,6 @@ export function useTransferReadiness(): UseTransferReadinessResult {
       isSmartContractWallet,
       isDepositMode,
     });
-
-    if (isTrustWalletConnection) {
-      return notReady({
-        errorMessages: {
-          inputAmount1: getTrustWalletDisabledErrorMessage(),
-        },
-      });
-    }
 
     if (!selectedRoute) {
       return notReady();
@@ -733,6 +721,5 @@ export function useTransferReadiness(): UseTransferReadinessResult {
     isSelectedTokenWithdrawOnly,
     isSelectedTokenWithdrawOnlyLoading,
     selectedRouteContext,
-    isTrustWalletConnection,
   ]);
 }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadinessUtils.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/useTransferReadinessUtils.ts
@@ -43,7 +43,3 @@ export function getInsufficientFundsForGasFeesErrorMessage({
 export function getWithdrawOnlyChainErrorMessage(chainName: string) {
   return `${chainName} has currently suspended deposits. You can only withdraw assets from this chain.`;
 }
-
-export function getTrustWalletDisabledErrorMessage() {
-  return 'Bridging with Trust Wallet is temporarily disabled due to a high rate of failed transactions. Please connect with a different wallet to continue.';
-}

--- a/packages/arb-token-bridge-ui/src/components/common/Dialog2.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Dialog2.tsx
@@ -17,6 +17,7 @@ import { SettingsDialog } from '../TransferPanel/SettingsDialog';
 import { TokenApprovalDialog } from '../TransferPanel/TokenApprovalDialog';
 import { TokenDepositCheckDialog } from '../TransferPanel/TokenDepositCheckDialog';
 import { TokenSearch } from '../TransferPanel/TokenSearch';
+import { TrustWalletUpdateDialog } from '../TransferPanel/TrustWalletUpdateDialog';
 import { CctpUsdcDepositConfirmationDialog } from '../TransferPanel/USDCDeposit/CctpUsdcDepositConfirmationDialog';
 import { UsdcDepositConfirmationDialog } from '../TransferPanel/USDCDeposit/UsdcDepositConfirmationDialog';
 import { CctpUsdcWithdrawalConfirmationDialog } from '../TransferPanel/USDCWithdrawal/CctpUsdcWithdrawalConfirmationDialog';
@@ -62,6 +63,7 @@ export type DialogType =
   | 'destination_network_selection'
   | 'buy_panel_network_selection'
   | 'nova_deposit_warning'
+  | 'trust_wallet_update'
   | 'earn_tos';
 
 export function useDialog2(): UseDialogResult {
@@ -163,6 +165,8 @@ export function DialogWrapper(props: DialogProps) {
       return <BuyPanelNetworkSelectionContainer {...commonProps} />;
     case 'nova_deposit_warning':
       return <NovaDepositWarningDialog {...commonProps} />;
+    case 'trust_wallet_update':
+      return <TrustWalletUpdateDialog {...commonProps} />;
     case 'earn_tos':
       return <EarnToSPopupDialog {...commonProps} />;
     default:

--- a/packages/arb-token-bridge-ui/src/hooks/useIsTrustWalletConnection.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useIsTrustWalletConnection.ts
@@ -1,0 +1,7 @@
+import { useWalletInfo } from '@reown/appkit/react';
+
+export function useIsTrustWalletConnection() {
+  const { walletInfo } = useWalletInfo('eip155');
+
+  return (walletInfo?.name ?? '').toLowerCase().includes('trust wallet');
+}

--- a/packages/arb-token-bridge-ui/src/util/AnalyticsUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AnalyticsUtils.ts
@@ -42,6 +42,7 @@ type AnalyticsEventMap = {
     amount: number;
   };
   'Connect Wallet Click': { walletName: string };
+  'Trust Wallet Update Confirmation': { confirmed: boolean };
   'Fast Bridge Click': {
     bridge: FastBridgeName;
     tokenSymbol?: SpecialTokenSymbol.USDC;


### PR DESCRIPTION
Trust Wallet fixed the wrong-chain bug in mobile 26.30.6 and extension 2.91.4, so transfers are enabled again. Reverts the block from #400.

A dapp can't read the wallet's version, so Trust Wallet users see a short confirmation dialog before transferring instead.

## Changes

- Remove the block in `useTransferReadiness`
- Add `TrustWalletUpdateDialog`, shown on Move funds before any route
- Track `Trust Wallet Update Confirmation` for accept vs cancel rates

## Screenshot

<!-- drag trust-wallet-dialog.png here -->

## Test plan

- Trust Wallet: dialog on Move funds; Confirm proceeds, Cancel aborts
- Other wallets: unchanged
- `pnpm lint` clean; tests match the master baseline