### PR TITLE
feat(bridge): discover unmatched LiFi tokens

### DIFF
--- a/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/utils.test.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/utils.test.ts
@@ -2,9 +2,10 @@ import { constants } from 'ethers';
 import { describe, expect, it, test } from 'vitest';
 
 import { APE_TOKEN_LOGO, WETH_TOKEN_LOGO } from '../../../constants';
-import { ContractStorage, ERC20BridgeToken } from '../../../hooks/arbTokenBridge.types';
+import { ContractStorage, ERC20BridgeToken, TokenType } from '../../../hooks/arbTokenBridge.types';
 import { ChainId } from '../../../types/ChainId';
 import { CommonAddress } from '../../../util/CommonAddressUtils';
+import { LIFI_TRANSFER_LIST_ID } from '../../../util/TokenListUtils';
 import { getTokenOverride, isLifiTransfer, isValidLifiTransfer } from './utils';
 
 function generateTestCases({
@@ -232,6 +233,29 @@ describe('isValidLifiTransfer', () => {
         fromToken: CommonAddress.ArbitrumOne.USDC,
         sourceChainId: ChainId.ArbitrumOne,
         destinationChainId: ChainId.Ethereum,
+        tokensFromLists,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not block regular token-list tokens that share LiFi list membership', () => {
+    const tokenAddress = '0x0000000000000000000000000000000000000300';
+    const tokensFromLists: ContractStorage<ERC20BridgeToken> = {
+      [tokenAddress]: {
+        address: tokenAddress,
+        decimals: 18,
+        listIds: new Set(['regular-list', LIFI_TRANSFER_LIST_ID]),
+        name: 'Regular Token',
+        symbol: 'REG',
+        type: TokenType.ERC20,
+      },
+    };
+
+    expect(
+      isValidLifiTransfer({
+        fromToken: tokenAddress,
+        sourceChainId: ChainId.Ethereum,
+        destinationChainId: ChainId.ArbitrumOne,
         tokensFromLists,
       }),
     ).toBe(true);

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useIsSwapTransfer.test.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/hooks/useIsSwapTransfer.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react';
+import { DecodedValueMap } from 'use-query-params';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ERC20BridgeToken, TokenType } from '../../../hooks/arbTokenBridge.types';
+import { queryParamProviderOptions, useArbQueryParams } from '../../../hooks/useArbQueryParams';
+import { useSelectedToken } from '../../../hooks/useSelectedToken';
+import { LIFI_TRANSFER_LIST_ID } from '../../../util/TokenListUtils';
+import { useIsSwapTransfer } from './useIsSwapTransfer';
+
+type ArbQueryParams = DecodedValueMap<typeof queryParamProviderOptions.params>;
+
+const defaultQueryParams: ArbQueryParams = {
+  sourceChain: undefined,
+  destinationChain: undefined,
+  amount: '',
+  amount2: '',
+  destinationAddress: undefined,
+  token: undefined,
+  destinationToken: undefined,
+  settingsOpen: false,
+  tab: 0,
+  disabledFeatures: [],
+  theme: {},
+  debugLevel: 'silent',
+  experiments: undefined,
+};
+
+vi.mock('../../../hooks/useArbQueryParams', () => ({
+  useArbQueryParams: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useSelectedToken', () => ({
+  useSelectedToken: vi.fn(),
+}));
+
+describe('useIsSwapTransfer', () => {
+  const mockedUseArbQueryParams = vi.mocked(useArbQueryParams);
+  const mockedUseSelectedToken = vi.mocked(useSelectedToken);
+
+  const selectedToken: ERC20BridgeToken = {
+    address: '0x0000000000000000000000000000000000000300',
+    decimals: 18,
+    listIds: new Set([LIFI_TRANSFER_LIST_ID]),
+    name: 'Robinhood Stock Token',
+    symbol: 'STOCK',
+    type: TokenType.ERC20,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseSelectedToken.mockReturnValue([selectedToken, vi.fn()]);
+    mockedUseArbQueryParams.mockReturnValue([
+      { ...defaultQueryParams, destinationToken: selectedToken.address },
+      vi.fn(),
+    ]);
+  });
+
+  it('returns false when the same regular token is selected on both sides', () => {
+    const { result } = renderHook(useIsSwapTransfer);
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/useDestinationToken.test.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/useDestinationToken.test.ts
@@ -6,8 +6,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getProviderForChainId } from '@/token-bridge-sdk/utils';
 
 import { getTokenOverride } from '../../app/api/crosschain-transfers/utils';
+import { useTokensFromLists } from '../../components/TransferPanel/TokenSearchUtils';
 import { Context, useAppState } from '../../state';
 import { ChainId } from '../../types/ChainId';
+import { LIFI_TRANSFER_LIST_ID } from '../../util/TokenListUtils';
 import { getWagmiChain } from '../../util/wagmi/getWagmiChain';
 import { ERC20BridgeToken, TokenType } from '../arbTokenBridge.types';
 import { queryParamProviderOptions, useArbQueryParams } from '../useArbQueryParams';
@@ -53,12 +55,17 @@ vi.mock('../../app/api/crosschain-transfers/utils', () => ({
   getTokenOverride: vi.fn(),
 }));
 
+vi.mock('../../components/TransferPanel/TokenSearchUtils', () => ({
+  useTokensFromLists: vi.fn(),
+}));
+
 describe.sequential('useDestinationToken', () => {
   const mockedUseArbQueryParams = vi.mocked(useArbQueryParams);
   const mockedUseSelectedToken = vi.mocked(useSelectedToken);
   const mockedUseNetworks = vi.mocked(useNetworks);
   const mockedUseAppState = vi.mocked(useAppState);
   const mockedGetTokenOverride = vi.mocked(getTokenOverride);
+  const mockedUseTokensFromLists = vi.mocked(useTokensFromLists);
 
   const mockSelectedToken: ERC20BridgeToken = {
     type: TokenType.ERC20,
@@ -111,6 +118,7 @@ describe.sequential('useDestinationToken', () => {
     } as Context['state']);
 
     mockedUseSelectedToken.mockReturnValue([mockSelectedToken, vi.fn()]);
+    mockedUseTokensFromLists.mockReturnValue({ data: {}, isLoading: false });
 
     mockedUseArbQueryParams.mockReturnValue([
       { ...defaultQueryParams, destinationToken: mockSelectedToken.address },
@@ -194,6 +202,40 @@ describe.sequential('useDestinationToken', () => {
 
         const { result } = renderHook(useDestinationToken);
         expect(result.current).toBeNull();
+      });
+
+      it('should return token from token lists when bridgeTokens has not loaded it yet', () => {
+        const tokenListDestinationToken: ERC20BridgeToken = {
+          type: TokenType.ERC20,
+          decimals: 18,
+          name: 'Robinhood Stock Token',
+          symbol: 'STOCK',
+          address: '0xstock',
+          listIds: new Set([LIFI_TRANSFER_LIST_ID]),
+        };
+
+        mockedUseNetworks.mockReturnValue([
+          {
+            sourceChain: getWagmiChain(ChainId.Ethereum),
+            sourceChainProvider: getProviderForChainId(ChainId.Ethereum),
+            destinationChain: getWagmiChain(ChainId.RobinhoodChain),
+            destinationChainProvider: getProviderForChainId(ChainId.RobinhoodChain),
+          },
+          vi.fn(),
+        ]);
+        mockedUseArbQueryParams.mockReturnValue([
+          { ...defaultQueryParams, destinationToken: tokenListDestinationToken.address },
+          vi.fn(),
+        ]);
+        mockedUseTokensFromLists.mockReturnValue({
+          data: {
+            [tokenListDestinationToken.address]: tokenListDestinationToken,
+          },
+          isLoading: false,
+        });
+
+        const { result } = renderHook(useDestinationToken);
+        expect(result.current).toEqual(tokenListDestinationToken);
       });
     });
 

--- a/packages/arb-token-bridge-ui/src/hooks/useDestinationToken.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useDestinationToken.ts
@@ -1,7 +1,7 @@
 import { constants } from 'ethers';
-import { useMemo } from 'react';
 
 import { getTokenOverride } from '../app/api/crosschain-transfers/utils';
+import { useTokensFromLists } from '../components/TransferPanel/TokenSearchUtils';
 import { useIsSwapTransfer } from '../components/TransferPanel/hooks/useIsSwapTransfer';
 import { useAppState } from '../state';
 import { addressesEqual } from '../util/AddressUtils';
@@ -15,7 +15,7 @@ import { useSelectedToken } from './useSelectedToken';
  *
  * - If destinationToken === selectedToken.address: return selectedToken
  * - If destinationToken is the zeroAddress: return ETH token (happen on chain with custom gas token)
- * - If destinationToken is set to a specific address: return that token from bridgeTokens
+ * - If destinationToken is set to a specific address: return that token from token storage
  * - If destinationToken is null: return null
  */
 export function useDestinationToken(): ERC20BridgeToken | null {
@@ -27,28 +27,28 @@ export function useDestinationToken(): ERC20BridgeToken | null {
       arbTokenBridge: { bridgeTokens },
     },
   } = useAppState();
+  const { data: tokensFromLists } = useTokensFromLists();
   const isSwapTransfer = useIsSwapTransfer();
-  const overrideToken = useMemo(
-    () =>
-      getTokenOverride({
-        fromToken: constants.AddressZero,
-        sourceChainId: networks.sourceChain.id,
-        destinationChainId: networks.destinationChain.id,
-      }),
-    [networks.destinationChain.id, networks.sourceChain.id],
-  );
 
   if (!isSwapTransfer) return selectedToken;
 
   // Case 1: destinationToken is the zeroAddress -> Return ETH
   // Use getTokenOverride to handle special cases like ApeChain WETH
-  if (destinationToken && addressesEqual(destinationToken, constants.AddressZero)) {
-    return overrideToken.destination;
+  if (addressesEqual(destinationToken, constants.AddressZero)) {
+    return getTokenOverride({
+      fromToken: constants.AddressZero,
+      sourceChainId: networks.sourceChain.id,
+      destinationChainId: networks.destinationChain.id,
+    }).destination;
   }
 
   // Case 2: destinationToken is set to a specific token address
-  if (destinationToken && bridgeTokens) {
-    return bridgeTokens[destinationToken.toLowerCase()] ?? null;
+  if (destinationToken) {
+    const destinationTokenAddress = destinationToken.toLowerCase();
+
+    return (
+      bridgeTokens?.[destinationTokenAddress] ?? tokensFromLists[destinationTokenAddress] ?? null
+    );
   }
 
   // For regular chains (native ETH): return null (button will show native ETH)


### PR DESCRIPTION
## Stack

This is PR 3 of 3. It builds on #442.

## Summary

This PR lets the transfer panel resolve a destination token that exists in the loaded token lists but has not been added to `bridgeTokens`.

LI.FI can return a valid destination token that has no canonical bridge pairing. The destination address is already present in the URL and the LI.FI token list, but the old lookup returned `null` unless `bridgeTokens` contained the token. The UI then lacked the token metadata needed to display the selection and request a route.

`useDestinationToken` now checks `bridgeTokens` first, then falls back to the searchable token-list storage. Native-token overrides and non-swap transfers keep their existing behavior.

## What to review

Please focus on these cases:

- The destination-token lookup remains case-insensitive.
- A token already in `bridgeTokens` still wins over token-list data.
- A Robinhood-only LI.FI token resolves from the token lists when bridge storage does not contain it.
- Selecting the same regular token on both sides remains a non-swap transfer, even when that token also belongs to the LI.FI list.
- Native-token and ApeChain overrides still use `getTokenOverride`.

## Manual test

1. Select Arbitrum One as the source and Robinhood Chain as the destination.
2. Select a Robinhood-only LI.FI destination token that has no canonical bridge pairing. `0x4a0e65a3eccec6dbe60ae065f2e7bb85fae35eea` is one example.
3. Confirm that the destination selector shows the token symbol, decimals, and logo, and that the transfer panel requests a route.
4. Reload the page with the `destinationToken` query parameter intact. Confirm that the token still resolves before bridge storage imports it.
5. Select the same regular paired token on both sides. Confirm that the panel treats it as a normal transfer rather than a swap.
6. Check a native-token route and an ApeChain route. Confirm that their destination-token overrides are unchanged.

## Automated checks

```sh
pnpm --filter arb-token-bridge-ui exec vitest run src/hooks/__tests__/useDestinationToken.test.ts src/components/TransferPanel/hooks/useIsSwapTransfer.test.ts src/app/api/crosschain-transfers/utils.test.ts
pnpm --filter arb-token-bridge-ui exec tsc --noEmit --pretty false
```
