### PR TITLE
feat(bridge): support ApeChain and Robinhood through LiFi

### DIFF
--- a/packages/app/src/app/api/crosschain-transfers/lifi/tokens/route.ts
+++ b/packages/app/src/app/api/crosschain-transfers/lifi/tokens/route.ts
@@ -1,4 +1,5 @@
 import { TokenList } from '@uniswap/token-lists';
+import { constants } from 'ethers';
 import { NextRequest, NextResponse } from 'next/server';
 
 import {
@@ -27,6 +28,8 @@ const BASE_TOKEN_LIST = {
 
 const ROBINHOOD_SOURCE_TOKEN_ADDRESSES = new Set(
   [
+    constants.AddressZero,
+    CommonAddress.RobinhoodChain.APE,
     CommonAddress.RobinhoodChain.WETH,
     CommonAddress.RobinhoodChain.USDe,
     CommonAddress.RobinhoodChain.sUSDe,

--- a/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/constants.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/constants.ts
@@ -9,9 +9,9 @@ export const lifiDestinationChainIds: Record<number, number[]> = {
   ],
   [ChainId.ArbitrumOne]: [ChainId.Ethereum, ChainId.ApeChain, ChainId.RobinhoodChain],
   [ChainId.ArbitrumNova]: [ChainId.Ethereum, ChainId.ArbitrumOne],
-  [ChainId.ApeChain]: [ChainId.Ethereum, ChainId.ArbitrumOne],
+  [ChainId.ApeChain]: [ChainId.Ethereum, ChainId.ArbitrumOne, ChainId.RobinhoodChain],
   [ChainId.Base]: [ChainId.ArbitrumOne, ChainId.ApeChain, ChainId.RobinhoodChain],
-  [ChainId.RobinhoodChain]: [ChainId.Ethereum, ChainId.ArbitrumOne],
+  [ChainId.RobinhoodChain]: [ChainId.Ethereum, ChainId.ArbitrumOne, ChainId.ApeChain],
 };
 
 export const allowedLifiSourceChainIds: number[] = Object.keys(lifiDestinationChainIds).map((id) =>

--- a/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/lifi.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/lifi.ts
@@ -110,7 +110,9 @@ function isApeToken(tokenAddress: string | undefined, chainId: number) {
     (addressesEqual(tokenAddress, CommonAddress.Ethereum.APE) && chainId === ChainId.Ethereum) ||
     (addressesEqual(tokenAddress, CommonAddress.ArbitrumOne.APE) &&
       chainId === ChainId.ArbitrumOne) ||
-    (addressesEqual(tokenAddress, CommonAddress.Base.APE) && chainId === ChainId.Base)
+    (addressesEqual(tokenAddress, CommonAddress.Base.APE) && chainId === ChainId.Base) ||
+    (addressesEqual(tokenAddress, CommonAddress.RobinhoodChain.APE) &&
+      chainId === ChainId.RobinhoodChain)
   );
 }
 

--- a/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/utils.test.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/utils.test.ts
@@ -79,7 +79,7 @@ function generateBaseDepositTestCases() {
 }
 
 function generateRobinhoodDepositTestCases() {
-  return [ChainId.Ethereum, ChainId.ArbitrumOne, ChainId.Base]
+  return [ChainId.Ethereum, ChainId.ArbitrumOne, ChainId.ApeChain, ChainId.Base]
     .map((sourceChainId) => [
       {
         fromToken: undefined,
@@ -96,7 +96,7 @@ function generateRobinhoodDepositTestCases() {
 }
 
 function generateRobinhoodWithdrawTestCases() {
-  return [ChainId.Ethereum, ChainId.ArbitrumOne]
+  return [ChainId.Ethereum, ChainId.ArbitrumOne, ChainId.ApeChain]
     .map((destinationChainId) => [
       {
         fromToken: undefined,
@@ -338,6 +338,24 @@ describe('isLifiTransfer', () => {
   });
 
   describe('Robinhood pairs', () => {
+    it('ApeChain → Robinhood is a valid LiFi pair', () => {
+      expect(
+        isLifiTransfer({
+          sourceChainId: ChainId.ApeChain,
+          destinationChainId: ChainId.RobinhoodChain,
+        }),
+      ).toBe(true);
+    });
+
+    it('Robinhood → ApeChain is a valid LiFi pair', () => {
+      expect(
+        isLifiTransfer({
+          sourceChainId: ChainId.RobinhoodChain,
+          destinationChainId: ChainId.ApeChain,
+        }),
+      ).toBe(true);
+    });
+
     it('Base → Robinhood is a valid LiFi pair', () => {
       expect(
         isLifiTransfer({
@@ -454,6 +472,36 @@ describe('getTokenOverride', () => {
     // Override on destination chain to ERC20, default to null (Ape on ApeChain)
     expect(apeToArbOverride.source).toEqual(null);
     expect(apeToArbOverride.destination).toEqual(ape);
+  });
+
+  it('maps native ApeChain APE to Robinhood APE in both directions', () => {
+    const apeToRobinhoodOverride = getTokenOverride({
+      fromToken: undefined,
+      sourceChainId: ChainId.ApeChain,
+      destinationChainId: ChainId.RobinhoodChain,
+    });
+    const robinhoodToApeOverride = getTokenOverride({
+      fromToken: undefined,
+      sourceChainId: ChainId.RobinhoodChain,
+      destinationChainId: ChainId.ApeChain,
+    });
+    const apeOnApeChain = {
+      ...ape,
+      address: constants.AddressZero,
+    };
+    const apeOnRobinhood = {
+      ...ape,
+      address: CommonAddress.RobinhoodChain.APE,
+    };
+
+    expect(apeToRobinhoodOverride).toEqual({
+      source: apeOnApeChain,
+      destination: apeOnRobinhood,
+    });
+    expect(robinhoodToApeOverride).toEqual({
+      source: apeOnRobinhood,
+      destination: apeOnApeChain,
+    });
   });
 
   it('For transfers on chain with custom fee token, returns null', () => {

--- a/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/utils.ts
+++ b/packages/arb-token-bridge-ui/src/app/api/crosschain-transfers/utils.ts
@@ -151,6 +151,11 @@ const apeToken = {
   listIds: new Set<string>(),
 } as const;
 
+const nativeApeToken = {
+  ...apeToken,
+  address: constants.AddressZero,
+};
+
 function getApe(chainId: number) {
   return (
     {
@@ -161,6 +166,10 @@ function getApe(chainId: number) {
       [ChainId.ArbitrumOne]: {
         ...apeToken,
         address: CommonAddress.ArbitrumOne.APE,
+      },
+      [ChainId.RobinhoodChain]: {
+        ...apeToken,
+        address: CommonAddress.RobinhoodChain.APE,
       },
       [ChainId.Superposition]: {
         ...ether,
@@ -190,6 +199,18 @@ export function getTokenOverride({
   source: ERC20BridgeToken | null;
   destination: ERC20BridgeToken | null;
 } {
+  const isApeChainRobinhoodRoute =
+    (sourceChainId === ChainId.ApeChain && destinationChainId === ChainId.RobinhoodChain) ||
+    (sourceChainId === ChainId.RobinhoodChain && destinationChainId === ChainId.ApeChain);
+
+  if (!fromToken && isApeChainRobinhoodRoute) {
+    return {
+      source: sourceChainId === ChainId.ApeChain ? nativeApeToken : getApe(sourceChainId),
+      destination:
+        destinationChainId === ChainId.ApeChain ? nativeApeToken : getApe(destinationChainId),
+    };
+  }
+
   // Eth on ApeChain
   if (addressesEqual(fromToken, constants.AddressZero)) {
     if (sourceChainId === ChainId.ApeChain) {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.default-tokens.integration.test.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.default-tokens.integration.test.tsx
@@ -28,6 +28,22 @@ type DefaultTokenCase = {
 
 const defaultTokenCases: DefaultTokenCase[] = [
   {
+    sourceChain: 'robinhood-chain',
+    destinationChain: 'apechain',
+    sourceToken: apeTokenExpectation,
+    destinationToken: apeTokenExpectation,
+    expectedSourcePanelTokens: [nativeApeTokenExpectation],
+    expectedDestinationPanelTokens: [nativeApeTokenExpectation],
+  },
+  {
+    sourceChain: 'apechain',
+    destinationChain: 'robinhood-chain',
+    sourceToken: apeTokenExpectation,
+    destinationToken: apeTokenExpectation,
+    expectedSourcePanelTokens: [nativeApeTokenExpectation],
+    expectedDestinationPanelTokens: [nativeApeTokenExpectation],
+  },
+  {
     sourceChain: 'base',
     destinationChain: 'apechain',
     sourceToken: apeTokenExpectation,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.swap.integration.test.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.swap.integration.test.tsx
@@ -25,6 +25,12 @@ const swapCases: RouteTokenCase[] = [
     destinationToken: nativeEthTokenExpectation,
   },
   {
+    sourceChain: 'apechain',
+    destinationChain: 'robinhood-chain',
+    sourceToken: tokenExpectationsByChain.ApeChain.WETH,
+    destinationToken: nativeEthTokenExpectation,
+  },
+  {
     sourceChain: 'ethereum',
     destinationChain: 'robinhood-chain',
     sourceToken: tokenExpectationsByChain.Ethereum.USDe,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/__tests__/useNativeCurrencyBalances.test.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/__tests__/useNativeCurrencyBalances.test.ts
@@ -1,12 +1,14 @@
 import { renderHook } from '@testing-library/react';
 import { BigNumber } from 'ethers';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getProviderForChainId } from '@/token-bridge-sdk/utils';
 
 import { useBalances } from '../../../../hooks/useBalances';
+import { useNativeCurrency } from '../../../../hooks/useNativeCurrency';
 import { useNetworks } from '../../../../hooks/useNetworks';
 import { ChainId } from '../../../../types/ChainId';
+import { CommonAddress } from '../../../../util/CommonAddressUtils';
 import { getWagmiChain } from '../../../../util/wagmi/getWagmiChain';
 import { useNativeCurrencyBalances } from '../useNativeCurrencyBalances';
 
@@ -16,6 +18,10 @@ vi.mock('../../../../hooks/useNetworks', () => ({
 
 vi.mock('../../../../hooks/useBalances', () => ({
   useBalances: vi.fn(),
+}));
+
+vi.mock('../../../../hooks/useNativeCurrency', () => ({
+  useNativeCurrency: vi.fn(),
 }));
 
 vi.mock('../../../../hooks/useArbQueryParams', () => ({
@@ -32,6 +38,16 @@ vi.mock('wagmi', async () => ({
 describe('useNativeCurrencyBalances', () => {
   const mockedUseNetworks = vi.mocked(useNetworks);
   const mockedUseBalances = vi.mocked(useBalances);
+  const mockedUseNativeCurrency = vi.mocked(useNativeCurrency);
+
+  beforeEach(() => {
+    mockedUseNativeCurrency.mockReturnValue({
+      name: 'Ether',
+      symbol: 'ETH',
+      decimals: 18,
+      isCustom: false,
+    });
+  });
 
   beforeAll(() => {
     mockedUseBalances.mockReturnValue({
@@ -39,6 +55,7 @@ describe('useNativeCurrencyBalances', () => {
       erc20ParentBalances: {
         '0x123': BigNumber.from(200_000),
         '0x222': BigNumber.from(250_000_000),
+        [CommonAddress.RobinhoodChain.APE]: BigNumber.from(500_000),
       },
       ethChildBalance: BigNumber.from(300_000),
       erc20ChildBalances: { '0x234': BigNumber.from(400_000) },
@@ -63,6 +80,32 @@ describe('useNativeCurrencyBalances', () => {
     const { result } = renderHook(useNativeCurrencyBalances);
     expect(result.current).toEqual({
       sourceBalance: BigNumber.from(100_000),
+      destinationBalance: BigNumber.from(300_000),
+    });
+  });
+
+  it('uses the Robinhood APE balance for Robinhood to ApeChain transfers', () => {
+    mockedUseNetworks.mockReturnValue([
+      {
+        sourceChain: getWagmiChain(ChainId.RobinhoodChain),
+        sourceChainProvider: getProviderForChainId(ChainId.RobinhoodChain),
+        destinationChain: getWagmiChain(ChainId.ApeChain),
+        destinationChainProvider: getProviderForChainId(ChainId.ApeChain),
+      },
+      vi.fn(),
+    ]);
+    mockedUseNativeCurrency.mockReturnValue({
+      name: 'ApeCoin',
+      symbol: 'APE',
+      decimals: 18,
+      address: CommonAddress.RobinhoodChain.APE,
+      isCustom: true,
+    });
+
+    const { result } = renderHook(useNativeCurrencyBalances);
+
+    expect(result.current).toEqual({
+      sourceBalance: BigNumber.from(500_000),
       destinationBalance: BigNumber.from(300_000),
     });
   });

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/useMaxAmount.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain/useMaxAmount.ts
@@ -44,6 +44,15 @@ export function useMaxAmount() {
     }
 
     if (
+      nativeCurrency.isCustom &&
+      !isDepositMode &&
+      (typeof estimatedParentChainGasFees === 'undefined' ||
+        typeof estimatedChildChainGasFees === 'undefined')
+    ) {
+      return nativeCurrencyBalanceFormatted;
+    }
+
+    if (
       typeof estimatedParentChainGasFees === 'undefined' ||
       typeof estimatedChildChainGasFees === 'undefined'
     ) {

--- a/packages/arb-token-bridge-ui/src/hooks/useNativeCurrency.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useNativeCurrency.ts
@@ -91,21 +91,21 @@ export async function fetchNativeCurrency({
   });
 
   /**
-   * When transferring Ape token from Base or Ethereum, address from ethBridger is the address on Arbitrum One.
+   * When ApeChain is paired with another parent chain, ethBridger returns the APE address on
+   * Arbitrum One. Use the APE address on the selected parent chain instead.
    * It should be the address of the Ape token on the source chain instead
    */
   const network = await provider.getNetwork();
   const isApeToken = addressesEqual(address, CommonAddress.ArbitrumOne.APE);
-  const isParentBaseOrEthereum =
-    parentChainIdFromQueryParam === ChainId.Base ||
-    parentChainIdFromQueryParam === ChainId.Ethereum;
   const isChildApeChain = network.chainId === ChainId.ApeChain;
 
-  if (isApeToken && isParentBaseOrEthereum && isChildApeChain) {
+  if (isApeToken && isChildApeChain) {
     address =
-      parentChainIdFromQueryParam === ChainId.Base
-        ? CommonAddress.Base.APE
-        : CommonAddress.Ethereum.APE;
+      {
+        [ChainId.Base]: CommonAddress.Base.APE,
+        [ChainId.Ethereum]: CommonAddress.Ethereum.APE,
+        [ChainId.RobinhoodChain]: CommonAddress.RobinhoodChain.APE,
+      }[parentChainIdFromQueryParam ?? 0] ?? address;
   }
 
   return {

--- a/packages/arb-token-bridge-ui/src/util/CommonAddressUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/CommonAddressUtils.ts
@@ -76,6 +76,7 @@ export const CommonAddress = {
     WETH: '0x1fb719f10b56d7a85dcd32f27f897375fb21cfdd',
   },
   RobinhoodChain: {
+    APE: '0x8f86a15ec17cb3369d8b3e666dadbc11daa82b79',
     WETH: '0x0bd7d308f8e1639fab988df18a8011f41eacad73',
     USDe: '0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34',
     sUSDe: '0x211cc4dd073734da055fbf44a2b4667d5e5fe5d2',

--- a/packages/arb-token-bridge-ui/src/util/__tests__/networks.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/__tests__/networks.test.ts
@@ -412,13 +412,13 @@ describe('getDestinationChainIds', () => {
         disableTransfersToNonArbitrumChains: true,
         includeLifiEnabledChainPairs: true,
       });
-      expect(result3).toEqual([ChainId.ArbitrumOne]);
+      expect(result3).toEqual([ChainId.ArbitrumOne, ChainId.RobinhoodChain]);
 
       const result4 = getDestinationChainIds(ChainId.ApeChain, {
         disableTransfersToNonArbitrumChains: false,
         includeLifiEnabledChainPairs: true,
       });
-      expect(result4).toEqual([ChainId.Ethereum, ChainId.ArbitrumOne]);
+      expect(result4).toEqual([ChainId.Ethereum, ChainId.ArbitrumOne, ChainId.RobinhoodChain]);
     });
   });
 

--- a/packages/arb-token-bridge-ui/src/util/getNetworksRelationship.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/getNetworksRelationship.test.ts
@@ -35,6 +35,26 @@ describe('getNetworksRelationship', () => {
         isDepositMode: true,
       },
     },
+    {
+      label: 'Robinhood Chain to ApeChain sibling transfer',
+      sourceChainId: ChainId.RobinhoodChain,
+      destinationChainId: ChainId.ApeChain,
+      expected: {
+        parentChainId: ChainId.RobinhoodChain,
+        childChainId: ChainId.ApeChain,
+        isDepositMode: true,
+      },
+    },
+    {
+      label: 'ApeChain to Robinhood Chain sibling transfer',
+      sourceChainId: ChainId.ApeChain,
+      destinationChainId: ChainId.RobinhoodChain,
+      expected: {
+        parentChainId: ChainId.RobinhoodChain,
+        childChainId: ChainId.ApeChain,
+        isDepositMode: false,
+      },
+    },
   ])('resolves $label', ({ sourceChainId, destinationChainId, expected }) => {
     expect(getNetworksRelationship({ sourceChainId, destinationChainId })).toEqual(expected);
   });

--- a/packages/arb-token-bridge-ui/src/util/isDepositMode.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/isDepositMode.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { ChainId } from '../types/ChainId';
+import { isDepositMode } from './isDepositMode';
+
+describe('isDepositMode', () => {
+  it('treats Robinhood Chain to ApeChain as a deposit', () => {
+    expect(
+      isDepositMode({
+        sourceChainId: ChainId.RobinhoodChain,
+        destinationChainId: ChainId.ApeChain,
+      }),
+    ).toBe(true);
+  });
+
+  it('treats ApeChain to Robinhood Chain as a withdrawal', () => {
+    expect(
+      isDepositMode({
+        sourceChainId: ChainId.ApeChain,
+        destinationChainId: ChainId.RobinhoodChain,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/arb-token-bridge-ui/src/util/isDepositMode.ts
+++ b/packages/arb-token-bridge-ui/src/util/isDepositMode.ts
@@ -1,3 +1,4 @@
+import { ChainId } from '../types/ChainId';
 import { isNetwork } from '../util/networks';
 
 export function isDepositMode({
@@ -7,6 +8,14 @@ export function isDepositMode({
   sourceChainId: number;
   destinationChainId: number;
 }) {
+  const isApeChainRobinhoodPair =
+    (sourceChainId === ChainId.RobinhoodChain && destinationChainId === ChainId.ApeChain) ||
+    (sourceChainId === ChainId.ApeChain && destinationChainId === ChainId.RobinhoodChain);
+
+  if (isApeChainRobinhoodPair) {
+    return sourceChainId === ChainId.RobinhoodChain;
+  }
+
   const {
     isEthereumMainnetOrTestnet: isSourceChainEthereum,
     isArbitrum: isSourceChainArbitrum,


### PR DESCRIPTION
## Summary

- enable single-step LiFi routes between ApeChain and Robinhood Chain in both directions
- preserve the curated Robinhood source-token allowlist and add Robinhood APE
- map ApeChain native APE to Robinhood APE so APE is selected by default on both sides
- add bidirectional route, override, and table-driven TransferPanel integration coverage

## Tests

- Robinhood Chain to ApeChain defaultTokenCases row: passed
- ApeChain to Robinhood Chain defaultTokenCases row: passed
- arb-token-bridge-ui utils.test.ts: 63 passed
- Prettier check passed
- ESLint passed with 4 pre-existing non-null assertion warnings in the LiFi token route