### PR TITLE
build(deps): resolve npm audit advisories

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -14,11 +14,6 @@
     // from: arb-token-bridge-ui>@lifi/sdk>bitcoinjs-lib>valibot
     "GHSA-5qjj-4xww-7phc",
     //
-    // https://github.com/advisories/GHSA-mh99-v99m-4gvg
-    // brace-expansion DoS via unbounded expansion length causing an out-of-memory process crash (CVE-2026-14257)
-    // Reason to ignore: Only reachable via dev tooling (eslint plugins, typescript-estree, glob in test coverage), where expansion patterns come from our own config, not attacker input. The only patched version (5.0.8) is a major bump whose CJS export shape is incompatible with the minimatch 3.x consumers in the eslint chain.
-    // from: eslint>minimatch>brace-expansion
-    "GHSA-mh99-v99m-4gvg",
     // https://github.com/advisories/GHSA-848j-6mx2-7j84
     // Elliptic Uses a Cryptographic Primitive with a Risky Implementation
     // CVE-2025-14505: ECDSA implementation generates incorrect signatures if interim value 'k' has leading zeros

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ overrides:
   '@types/react-dom': 19.2.3
   '@types/node': 22.19.19
   js-yaml: 4.3.0
-  undici: 6.27.0
+  undici: 6.28.0
   h3: 1.15.10
   lodash: 4.18.1
   lodash-es: 4.18.1
@@ -32,18 +32,18 @@ overrides:
   bn.js: 5.2.3
   flatted: 3.4.2
   defu: 6.1.6
-  brace-expansion: 1.1.16
+  brace-expansion: 1.1.18
   '@typescript-eslint/eslint-plugin': 8.59.3
   '@typescript-eslint/parser': 8.59.3
   next-query-params>next: 16.2.11
   '@reown/appkit-adapter-wagmi>@wagmi/core': 2.22.1
   eslint-plugin-react-hooks: 7.1.1
   utf-8-validate: 6.0.6
-  hono: 4.12.31
-  fast-uri: 3.1.4
+  hono: 4.12.34
+  fast-uri: 3.1.5
   sharp: 0.35.3
   follow-redirects: 1.16.0
-  postcss: 8.5.18
+  postcss: 8.5.25
   uuid: 14.0.0
   vite@>=7.0.0 <7.3.5: 7.3.5
   vite@>=6.0.0 <6.4.3: 6.4.3
@@ -62,6 +62,7 @@ overrides:
   joi@>=17.0.0 <17.13.4: 17.13.4
   joi@>=18.0.0 <18.2.1: 18.2.1
   '@babel/core': 7.29.6
+  socket.io-parser: 4.2.7
 
 importers:
 
@@ -214,10 +215,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.14(postcss@8.5.18)
+        version: 10.4.14(postcss@8.5.25)
       postcss:
-        specifier: 8.5.18
-        version: 8.5.18
+        specifier: 8.5.25
+        version: 8.5.25
       tailwindcss:
         specifier: ^3.4.16
         version: 3.4.16(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
@@ -371,7 +372,7 @@ importers:
         version: 0.2.2(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)))
       '@synthetixio/synpress':
         specifier: 3.7.3
-        version: 3.7.3(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(@types/react@19.2.14)(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)))(bufferutil@4.0.9)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.18))(zod@3.25.76)
+        version: 3.7.3(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(@types/react@19.2.14)(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)))(bufferutil@4.0.9)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.25))(zod@3.25.76)
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -398,7 +399,7 @@ importers:
         version: 17.0.33
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.14(postcss@8.5.18)
+        version: 10.4.14(postcss@8.5.25)
       cypress-terminal-report:
         specifier: ^7.1.0
         version: 7.2.1(cypress@12.17.3)
@@ -412,8 +413,8 @@ importers:
         specifier: ^1.16.0
         version: 1.16.0
       postcss:
-        specifier: 8.5.18
-        version: 8.5.18
+        specifier: 8.5.25
+        version: 8.5.25
       satori:
         specifier: ^0.12.2
         version: 0.12.2
@@ -513,10 +514,10 @@ importers:
         version: 3.2.3
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.14(postcss@8.5.18)
+        version: 10.4.14(postcss@8.5.25)
       postcss:
-        specifier: 8.5.18
-        version: 8.5.18
+        specifier: 8.5.25
+        version: 8.5.25
       tailwindcss:
         specifier: ^3.4.16
         version: 3.4.16(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
@@ -4414,7 +4415,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.25
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -4598,8 +4599,8 @@ packages:
   bowser@2.11.0:
     resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5654,7 +5655,7 @@ packages:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
   eslint-plugin-zustand-rules@https://codeload.github.com/OffchainLabs/eslint-plugin-zustand-rules/tar.gz/cae011989384e6b9a022d536f3219fc7ea340444:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/OffchainLabs/eslint-plugin-zustand-rules/tar.gz/cae011989384e6b9a022d536f3219fc7ea340444}
+    resolution: {gitHosted: true, integrity: sha512-/k+IruBinGs6QH3L055xYeHdhgVvw79hJv4eB8xr2DkqrXYX29xp8OzdYdbyXqdh/pkqG2CdagSy6as13mhU4A==, tarball: https://codeload.github.com/OffchainLabs/eslint-plugin-zustand-rules/tar.gz/cae011989384e6b9a022d536f3219fc7ea340444}
     version: 1.0.2
     peerDependencies:
       eslint: ^8.0.0
@@ -5871,8 +5872,8 @@ packages:
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastest-stable-stringify@2.0.2:
     resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
@@ -6337,8 +6338,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.31:
-    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hpack.js@2.1.6:
@@ -7843,19 +7844,19 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.25
 
   postcss-js@4.0.1:
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.25
 
   postcss-load-config@4.0.2:
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.25
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       postcss:
@@ -7867,7 +7868,7 @@ packages:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.25
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -7876,8 +7877,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   posthog-js@1.273.0:
@@ -8574,8 +8575,8 @@ packages:
     resolution: {integrity: sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==}
     engines: {node: '>=10.0.0'}
 
-  socket.io-parser@4.2.6:
-    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
     engines: {node: '>=10.0.0'}
 
   sockjs@0.3.24:
@@ -9219,8 +9220,8 @@ packages:
   undici-types@7.26.0:
     resolution: {integrity: sha512-OY7qWYg4TsPpqg/kL2FfNnGA8cmAhPpLt45XQ2jd8p9UobYQ7Q09LeiCq5QwZhlKNLBj0iTUlBNhs4M2AVFmxA==}
 
-  undici@6.27.0:
-    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
   unfetch@4.2.0:
@@ -9955,7 +9956,7 @@ snapshots:
   '@actions/http-client@2.2.3':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.27.0
+      undici: 6.28.0
 
   '@adraffy/ens-normalize@1.10.0': {}
 
@@ -10902,12 +10903,12 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@cypress/code-coverage@3.14.6(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)))(cypress@12.17.3)(webpack@5.106.2(postcss@8.5.18))':
+  '@cypress/code-coverage@3.14.6(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)))(cypress@12.17.3)(webpack@5.106.2(postcss@8.5.25))':
     dependencies:
       '@babel/core': 7.29.6
       '@babel/preset-env': 7.29.5(@babel/core@7.29.6)
-      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)))(webpack@5.106.2(postcss@8.5.18))
-      babel-loader: 10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18))
+      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)))(webpack@5.106.2(postcss@8.5.25))
+      babel-loader: 10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25))
       chalk: 4.1.2
       cypress: 12.17.3
       dayjs: 1.11.13
@@ -10917,7 +10918,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       js-yaml: 4.3.0
       nyc: 15.1.0
-      webpack: 5.106.2(postcss@8.5.18)
+      webpack: 5.106.2(postcss@8.5.25)
     transitivePeerDependencies:
       - supports-color
 
@@ -10942,17 +10943,17 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 14.0.0
 
-  '@cypress/webpack-dev-server@3.11.0(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.18))':
+  '@cypress/webpack-dev-server@3.11.0(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.25))':
     dependencies:
       find-up: 6.3.0
       fs-extra: 9.1.0
-      html-webpack-plugin-4: html-webpack-plugin@4.5.2(webpack@5.106.2(postcss@8.5.18))
-      html-webpack-plugin-5: html-webpack-plugin@5.6.7(webpack@5.106.2(postcss@8.5.18))
+      html-webpack-plugin-4: html-webpack-plugin@4.5.2(webpack@5.106.2(postcss@8.5.25))
+      html-webpack-plugin-5: html-webpack-plugin@5.6.7(webpack@5.106.2(postcss@8.5.25))
       local-pkg: 0.4.1
       semver: 7.8.1
-      speed-measure-webpack-plugin: 1.4.2(webpack@5.106.2(postcss@8.5.18))
+      speed-measure-webpack-plugin: 1.4.2(webpack@5.106.2(postcss@8.5.25))
       tslib: 2.8.1
-      webpack-dev-server: 4.15.2(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.18))
+      webpack-dev-server: 4.15.2(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.25))
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@rspack/core'
@@ -10963,16 +10964,16 @@ snapshots:
       - webpack
       - webpack-cli
 
-  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)))(webpack@5.106.2(postcss@8.5.18))':
+  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)))(webpack@5.106.2(postcss@8.5.25))':
     dependencies:
       '@babel/core': 7.29.6
       '@babel/preset-env': 7.29.5(@babel/core@7.29.6)
-      babel-loader: 10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18))
+      babel-loader: 10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25))
       bluebird: 3.7.1
       debug: 4.4.3(supports-color@8.1.1)
       lodash: 4.18.1
       semver: 7.8.1
-      webpack: 5.106.2(postcss@8.5.18)
+      webpack: 5.106.2(postcss@8.5.25)
     transitivePeerDependencies:
       - supports-color
 
@@ -13772,10 +13773,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@synthetixio/synpress@3.7.3(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(@types/react@19.2.14)(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)))(bufferutil@4.0.9)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.18))(zod@3.25.76)':
+  '@synthetixio/synpress@3.7.3(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(@types/react@19.2.14)(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)))(bufferutil@4.0.9)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.25))(zod@3.25.76)':
     dependencies:
-      '@cypress/code-coverage': 3.14.6(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)))(cypress@12.17.3)(webpack@5.106.2(postcss@8.5.18))
-      '@cypress/webpack-dev-server': 3.11.0(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.18))
+      '@cypress/code-coverage': 3.14.6(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)))(cypress@12.17.3)(webpack@5.106.2(postcss@8.5.25))
+      '@cypress/webpack-dev-server': 3.11.0(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.25))
       '@drptbl/gremlins.js': 2.2.1
       '@foundry-rs/easy-foundryup': 0.1.3
       '@playwright/test': 1.56.0
@@ -15355,7 +15356,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -15562,14 +15563,14 @@ snapshots:
       semver: 7.7.3
       yargs: 17.7.2
 
-  autoprefixer@10.4.14(postcss@8.5.18):
+  autoprefixer@10.4.14(postcss@8.5.25):
     dependencies:
       browserslist: 4.26.3
       caniuse-lite: 1.0.30001749
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.5.18
+      postcss: 8.5.25
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -15599,12 +15600,12 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.18)):
+  babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)):
     dependencies:
       '@babel/core': 7.29.6
       find-up: 5.0.0
     optionalDependencies:
-      webpack: 5.106.2(postcss@8.5.18)
+      webpack: 5.106.2(postcss@8.5.25)
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
@@ -15788,7 +15789,7 @@ snapshots:
 
   bowser@2.11.0: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -15962,7 +15963,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 6.27.0
+      undici: 6.28.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -17409,7 +17410,7 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastest-stable-stringify@2.0.2: {}
 
@@ -17918,7 +17919,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.31: {}
+  hono@4.12.34: {}
 
   hpack.js@2.1.6:
     dependencies:
@@ -17951,7 +17952,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.48.0
 
-  html-webpack-plugin@4.5.2(webpack@5.106.2(postcss@8.5.18)):
+  html-webpack-plugin@4.5.2(webpack@5.106.2(postcss@8.5.25)):
     dependencies:
       '@types/html-minifier-terser': 5.1.2
       '@types/tapable': 1.0.12
@@ -17962,9 +17963,9 @@ snapshots:
       pretty-error: 2.1.2
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 5.106.2(postcss@8.5.18)
+      webpack: 5.106.2(postcss@8.5.25)
 
-  html-webpack-plugin@5.6.7(webpack@5.106.2(postcss@8.5.18)):
+  html-webpack-plugin@5.6.7(webpack@5.106.2(postcss@8.5.25)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -17972,7 +17973,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.106.2(postcss@8.5.18)
+      webpack: 5.106.2(postcss@8.5.25)
 
   htmlparser2@10.1.0:
     dependencies:
@@ -18850,15 +18851,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 
@@ -18943,7 +18944,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.29
       caniuse-lite: 1.0.30001792
-      postcss: 8.5.18
+      postcss: 8.5.25
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.6)(react@19.2.6)
@@ -19489,7 +19490,7 @@ snapshots:
   porto@0.2.35(@tanstack/react-query@5.63.0(react@19.2.6))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.62.16)(@types/react@19.2.14)(immer@10.2.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))(immer@10.2.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@19.2.6))(@types/react@19.2.14)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)):
     dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.62.16)(@types/react@19.2.14)(immer@10.2.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
-      hono: 4.12.31
+      hono: 4.12.34
       idb-keyval: 6.2.1
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.14(typescript@5.9.3)(zod@4.1.12)
@@ -19509,7 +19510,7 @@ snapshots:
   porto@0.2.35(@tanstack/react-query@5.63.0(react@19.2.6))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.62.16)(@types/react@19.2.14)(immer@10.2.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.6))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)))(immer@10.2.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.6))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.62.16)(@tanstack/react-query@5.63.0(react@19.2.6))(@types/react@19.2.14)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@6.0.6))(zod@3.25.76)):
     dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.62.16)(@types/react@19.2.14)(immer@10.2.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.6))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76))
-      hono: 4.12.31
+      hono: 4.12.34
       idb-keyval: 6.2.1
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.14(typescript@5.9.3)(zod@4.1.12)
@@ -19531,37 +19532,37 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.18):
+  postcss-import@15.1.0(postcss@8.5.25):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.25
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-js@4.0.1(postcss@8.5.18):
+  postcss-js@4.0.1(postcss@8.5.25):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.18
+      postcss: 8.5.25
 
-  postcss-load-config@4.0.2(postcss@8.5.18)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2)):
+  postcss-load-config@4.0.2(postcss@8.5.25)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
     optionalDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.25
       ts-node: 10.9.2(@types/node@22.19.19)(typescript@5.9.2)
 
-  postcss-load-config@4.0.2(postcss@8.5.18)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.5.25)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
     optionalDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.25
       ts-node: 10.9.2(@types/node@22.19.19)(typescript@5.9.3)
 
-  postcss-nested@6.2.0(postcss@8.5.18):
+  postcss-nested@6.2.0(postcss@8.5.25):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.25
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -19571,7 +19572,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.18:
+  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -20338,13 +20339,13 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.3.7
       engine.io-client: 6.6.2(bufferutil@4.0.9)(utf-8-validate@6.0.6)
-      socket.io-parser: 4.2.6
+      socket.io-parser: 4.2.7
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.6:
+  socket.io-parser@4.2.7:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@8.1.1)
@@ -20422,10 +20423,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  speed-measure-webpack-plugin@1.4.2(webpack@5.106.2(postcss@8.5.18)):
+  speed-measure-webpack-plugin@1.4.2(webpack@5.106.2(postcss@8.5.25)):
     dependencies:
       chalk: 4.1.2
-      webpack: 5.106.2(postcss@8.5.18)
+      webpack: 5.106.2(postcss@8.5.25)
 
   split-on-first@1.1.0: {}
 
@@ -20722,11 +20723,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.18
-      postcss-import: 15.1.0(postcss@8.5.18)
-      postcss-js: 4.0.1(postcss@8.5.18)
-      postcss-load-config: 4.0.2(postcss@8.5.18)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
-      postcss-nested: 6.2.0(postcss@8.5.18)
+      postcss: 8.5.25
+      postcss-import: 15.1.0(postcss@8.5.25)
+      postcss-js: 4.0.1(postcss@8.5.25)
+      postcss-load-config: 4.0.2(postcss@8.5.25)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
+      postcss-nested: 6.2.0(postcss@8.5.25)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
       sucrase: 3.35.0
@@ -20749,11 +20750,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.18
-      postcss-import: 15.1.0(postcss@8.5.18)
-      postcss-js: 4.0.1(postcss@8.5.18)
-      postcss-load-config: 4.0.2(postcss@8.5.18)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
-      postcss-nested: 6.2.0(postcss@8.5.18)
+      postcss: 8.5.25
+      postcss-import: 15.1.0(postcss@8.5.25)
+      postcss-js: 4.0.1(postcss@8.5.25)
+      postcss-load-config: 4.0.2(postcss@8.5.25)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      postcss-nested: 6.2.0(postcss@8.5.25)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
       sucrase: 3.35.0
@@ -20774,15 +20775,15 @@ snapshots:
       to-buffer: 1.2.2
       xtend: 4.0.2
 
-  terser-webpack-plugin@5.6.1(postcss@8.5.18)(webpack@5.106.2(postcss@8.5.18)):
+  terser-webpack-plugin@5.6.1(postcss@8.5.25)(webpack@5.106.2(postcss@8.5.25)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.106.2(postcss@8.5.18)
+      webpack: 5.106.2(postcss@8.5.25)
     optionalDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.25
 
   terser@4.8.1:
     dependencies:
@@ -21068,7 +21069,7 @@ snapshots:
 
   undici-types@7.26.0: {}
 
-  undici@6.27.0: {}
+  undici@6.28.0: {}
 
   unfetch@4.2.0: {}
 
@@ -21339,7 +21340,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.25
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -21354,7 +21355,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.25
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -21500,16 +21501,16 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  webpack-dev-middleware@5.3.4(webpack@5.106.2(postcss@8.5.18)):
+  webpack-dev-middleware@5.3.4(webpack@5.106.2(postcss@8.5.25)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.6.0
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.3
-      webpack: 5.106.2(postcss@8.5.18)
+      webpack: 5.106.2(postcss@8.5.25)
 
-  webpack-dev-server@4.15.2(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.18)):
+  webpack-dev-server@4.15.2(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.25)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -21539,10 +21540,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.106.2(postcss@8.5.18))
+      webpack-dev-middleware: 5.3.4(webpack@5.106.2(postcss@8.5.25))
       ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
     optionalDependencies:
-      webpack: 5.106.2(postcss@8.5.18)
+      webpack: 5.106.2(postcss@8.5.25)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -21557,7 +21558,7 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.106.2(postcss@8.5.18):
+  webpack@5.106.2(postcss@8.5.25):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -21580,7 +21581,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(postcss@8.5.18)(webpack@5.106.2(postcss@8.5.18))
+      terser-webpack-plugin: 5.6.1(postcss@8.5.25)(webpack@5.106.2(postcss@8.5.25))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ overrides:
   '@types/react-dom': 19.2.3
   '@types/node': 22.19.19
   'js-yaml': 4.3.0
-  'undici': 6.27.0
+  'undici': 6.28.0
   'h3': 1.15.10
   'lodash': 4.18.1
   'lodash-es': 4.18.1
@@ -29,18 +29,18 @@ overrides:
   'bn.js': 5.2.3
   'flatted': 3.4.2
   'defu': 6.1.6
-  'brace-expansion': 1.1.16
+  'brace-expansion': 1.1.18
   '@typescript-eslint/eslint-plugin': 8.59.3
   '@typescript-eslint/parser': 8.59.3
   'next-query-params>next': 16.2.11
   '@reown/appkit-adapter-wagmi>@wagmi/core': 2.22.1
   'eslint-plugin-react-hooks': 7.1.1
   'utf-8-validate': 6.0.6
-  'hono': 4.12.31
-  'fast-uri': 3.1.4
+  'hono': 4.12.34
+  'fast-uri': 3.1.5
   'sharp': 0.35.3
   'follow-redirects': 1.16.0
-  'postcss': 8.5.18
+  'postcss': 8.5.25
   'uuid': 14.0.0
   'vite@>=7.0.0 <7.3.5': 7.3.5
   'vite@>=6.0.0 <6.4.3': 6.4.3
@@ -59,6 +59,7 @@ overrides:
   'joi@>=17.0.0 <17.13.4': 17.13.4
   'joi@>=18.0.0 <18.2.1': 18.2.1
   '@babel/core': 7.29.6
+  'socket.io-parser': 4.2.7
 
 autoInstallPeers: true
 shamefullyHoist: true


### PR DESCRIPTION
`audit-ci` was failing on eight new advisories. All eight have patch-level fixes available, so every one is resolved by bumping the pinned override in `pnpm-workspace.yaml` — nothing new was added to the allowlist.

## Advisories

| Advisory | Severity | Package | Strategy | Notes |
| --- | --- | --- | --- | --- |
| [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) | moderate | postcss | bump `8.5.18` → `8.5.25` | Attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset (CVE-2026-69153). Patched in 8.5.23. |
| [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) | moderate | undici | bump `6.27.0` → `6.28.0` | Downstream response desynchronization via retry interceptor (CVE-2026-16728). |
| [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) | moderate | undici | bump `6.27.0` → `6.28.0` | CRLF injection via blob-like body `type` property (CVE-2026-15157). |
| [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) | moderate | undici | bump `6.27.0` → `6.28.0` | Cookie attribute injection via unsanitized domain / unparsed `setCookie` fields (CVE-2026-16729). |
| [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) | high | brace-expansion | bump `1.1.16` → `1.1.18` | DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation. Backported to the 1.x line in 1.1.18. |
| [GHSA-8j4g-w8fx-2239](https://github.com/advisories/GHSA-8j4g-w8fx-2239) | moderate | hono | bump `4.12.31` → `4.12.34` | ReDoS in CORS middleware via `Access-Control-Request-Headers` (CVE-2026-69207). |
| [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) | high | fast-uri | bump `3.1.4` → `3.1.5` | Host confusion via backslash authority introducer (CVE-2026-18446). |
| [GHSA-2m8v-j782-fhvr](https://github.com/advisories/GHSA-2m8v-j782-fhvr) | high | socket.io-parser | new override `4.2.7` | Zero-attachment memory exhaustion (CVE-2026-69185). Reached via `@metamask/sdk` → `socket.io-client`. |

## Allowlist cleanup

Removed [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (brace-expansion OOM DoS, CVE-2026-14257). The old justification said the only fix was a major bump to 5.0.8, but upstream has since backported it to `1.1.17`. Since we now pin `1.1.18`, the exception is no longer needed.

All bumps stay within the existing major line, so no `minimumReleaseAge` or `trustPolicy` exemptions were needed (hono stays on `4.12.x` rather than `4.13.0`, which is under the 24h release-age floor).

## Verification

- `pnpm audit:ci` exits 0
- `pnpm lint` passes (0 errors, warnings only, unchanged from master)
- `pnpm --filter app css:build` succeeds with postcss 8.5.25
- `pnpm test:unit`: only pre-existing failures, all `ECONNREFUSED` against `localhost:3000` (these tests require a local dev server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)