### PR TITLE
fix(bridge): load tokens on Token Search Panel first render

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.test.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.test.ts
@@ -1,7 +1,8 @@
+import type { TokenList } from '@uniswap/token-lists';
 import { describe, expect, it } from 'vitest';
 
 import { LIFI_TRANSFER_LIST_ID, type TokenListWithId } from '../../util/TokenListUtils';
-import { tokenListsToSearchableTokenStorage } from './TokenSearchUtils';
+import { mergeLifiTokenList, tokenListsToSearchableTokenStorage } from './TokenSearchUtils';
 
 describe('tokenListsToSearchableTokenStorage', () => {
   it('keeps existing fields when a later non-LiFi token merges the same L1 token', () => {
@@ -128,5 +129,101 @@ describe('tokenListsToSearchableTokenStorage', () => {
     expect(tokens[l1Address]?.logoURI).toBe('/images/pyusd.svg');
     expect(tokens[l1Address]?.l2Address).toBe(lifiL2Address);
     expect(tokens[l1Address]?.listIds).toEqual(new Set([LIFI_TRANSFER_LIST_ID, '1']));
+  });
+});
+
+describe('mergeLifiTokenList', () => {
+  const childChainId = 42161;
+
+  function buildTokenList({ symbol }: { symbol: string }): TokenList {
+    return {
+      name: 'LiFi Tokens',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      version: { major: 1, minor: 0, patch: 0 },
+      tokens: [
+        {
+          chainId: childChainId,
+          address: '0x46850ad61c2b7d64d08c9c754f45254596696984',
+          name: 'PayPal USD OFT',
+          symbol,
+          decimals: 6,
+        },
+      ],
+    };
+  }
+
+  function buildListWithId({ bridgeTokenListId }: { bridgeTokenListId: string }): TokenListWithId {
+    return {
+      ...buildTokenList({ symbol: 'stale' }),
+      name: `List ${bridgeTokenListId}`,
+      l2ChainId: String(childChainId),
+      bridgeTokenListId,
+    };
+  }
+
+  it('returns an empty list when the token lists have not loaded', () => {
+    expect(
+      mergeLifiTokenList({
+        tokenLists: undefined,
+        lifiTokenList: buildTokenList({ symbol: 'fresh' }),
+        childChainId,
+      }),
+    ).toEqual([]);
+  });
+
+  it('returns the same array reference when there is nothing to overlay', () => {
+    const tokenLists = [buildListWithId({ bridgeTokenListId: LIFI_TRANSFER_LIST_ID })];
+
+    // Referential stability matters: the result feeds an SWR key that deep-hashes every token.
+    expect(mergeLifiTokenList({ tokenLists, lifiTokenList: undefined, childChainId })).toBe(
+      tokenLists,
+    );
+  });
+
+  it('overlays the refreshed payload onto the LiFi entry, keeping its list identity', () => {
+    const tokenLists = [buildListWithId({ bridgeTokenListId: LIFI_TRANSFER_LIST_ID })];
+
+    const merged = mergeLifiTokenList({
+      tokenLists,
+      lifiTokenList: buildTokenList({ symbol: 'fresh' }),
+      childChainId,
+    });
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.tokens[0]?.symbol).toBe('fresh');
+    expect(merged[0]?.bridgeTokenListId).toBe(LIFI_TRANSFER_LIST_ID);
+    expect(merged[0]?.l2ChainId).toBe(String(childChainId));
+  });
+
+  it('leaves non-LiFi lists untouched by reference', () => {
+    const canonicalList = buildListWithId({ bridgeTokenListId: '1' });
+    const tokenLists = [
+      canonicalList,
+      buildListWithId({ bridgeTokenListId: LIFI_TRANSFER_LIST_ID }),
+    ];
+
+    const merged = mergeLifiTokenList({
+      tokenLists,
+      lifiTokenList: buildTokenList({ symbol: 'fresh' }),
+      childChainId,
+    });
+
+    expect(merged[0]).toBe(canonicalList);
+    expect(merged[1]?.tokens[0]?.symbol).toBe('fresh');
+  });
+
+  it('adds the refreshed list when the load-time fetch of it failed', () => {
+    const tokenLists = [buildListWithId({ bridgeTokenListId: '1' })];
+
+    const merged = mergeLifiTokenList({
+      tokenLists,
+      lifiTokenList: buildTokenList({ symbol: 'fresh' }),
+      childChainId,
+    });
+
+    expect(merged).toHaveLength(2);
+    expect(merged[1]?.bridgeTokenListId).toBe(LIFI_TRANSFER_LIST_ID);
+    expect(merged[1]?.l2ChainId).toBe(String(childChainId));
+    expect(merged[1]?.tokens[0]?.symbol).toBe('fresh');
   });
 });

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
@@ -4,21 +4,40 @@ import useSWRImmutable from 'swr/immutable';
 import { ContractStorage, ERC20BridgeToken, TokenType } from '../../hooks/arbTokenBridge.types';
 import { useNetworks } from '../../hooks/useNetworks';
 import { useNetworksRelationship } from '../../hooks/useNetworksRelationship';
-import { useTokenLists } from '../../hooks/useTokenLists';
+import { useLifiTokenList, useTokenLists } from '../../hooks/useTokenLists';
 import { useAppState } from '../../state';
-import { TokenListWithId } from '../../util/TokenListUtils';
+import { LIFI_TRANSFER_LIST_ID, TokenListWithId } from '../../util/TokenListUtils';
 import { mergeBridgeTokens } from '../../util/mergeBridgeTokens';
 
 // keeps the reference stable
 const emptyData: ContractStorage<ERC20BridgeToken> = {};
+const emptyTokenLists: TokenListWithId[] = [];
 
 export function useTokensFromLists() {
   const [networks] = useNetworks();
   const { childChain, parentChain } = useNetworksRelationship(networks);
   const { data: tokenLists, isLoading: isLoadingTokenLists } = useTokenLists(childChain.id);
+  const { data: refreshedLifiTokenList } = useLifiTokenList();
+
+  // Memoized for referential stability: this feeds an SWR key that deep-hashes every token.
+  const mergedTokenLists = useMemo(() => {
+    if (!tokenLists) {
+      return emptyTokenLists;
+    }
+
+    if (!refreshedLifiTokenList) {
+      return tokenLists;
+    }
+
+    return tokenLists.map((tokenList) =>
+      tokenList.bridgeTokenListId === LIFI_TRANSFER_LIST_ID
+        ? { ...tokenList, ...refreshedLifiTokenList }
+        : tokenList,
+    );
+  }, [tokenLists, refreshedLifiTokenList]);
 
   const { data = emptyData, isLoading } = useSWRImmutable(
-    [tokenLists ?? [], parentChain.id, childChain.id, 'useTokensFromLists'],
+    [mergedTokenLists, parentChain.id, childChain.id, 'useTokensFromLists'],
     ([_tokenLists, _parentChainId, _childChainId]) =>
       tokenListsToSearchableTokenStorage(
         _tokenLists,

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearchUtils.ts
@@ -1,3 +1,4 @@
+import { TokenList } from '@uniswap/token-lists';
 import { useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
 
@@ -13,6 +14,58 @@ import { mergeBridgeTokens } from '../../util/mergeBridgeTokens';
 const emptyData: ContractStorage<ERC20BridgeToken> = {};
 const emptyTokenLists: TokenListWithId[] = [];
 
+/**
+ * Overlays the separately refreshed LiFi token list onto the lists from `useTokenLists`, so the
+ * token panel picks up fresh `priceUSD` without the two sharing an SWR key.
+ *
+ * Returns `tokenLists` unchanged when there is nothing to overlay, since the result feeds an SWR key
+ * that deep-hashes every token and a new array identity forces a full re-walk.
+ */
+export function mergeLifiTokenList({
+  tokenLists,
+  lifiTokenList,
+  childChainId,
+}: {
+  tokenLists: TokenListWithId[] | undefined;
+  lifiTokenList: TokenList | undefined;
+  childChainId: number;
+}): TokenListWithId[] {
+  if (!tokenLists) {
+    return emptyTokenLists;
+  }
+
+  if (!lifiTokenList) {
+    return tokenLists;
+  }
+
+  let didReplace = false;
+  const merged = tokenLists.map((tokenList) => {
+    if (tokenList.bridgeTokenListId !== LIFI_TRANSFER_LIST_ID) {
+      return tokenList;
+    }
+
+    didReplace = true;
+    return { ...tokenList, ...lifiTokenList };
+  });
+
+  if (didReplace) {
+    return merged;
+  }
+
+  /**
+   * `fetchTokenLists` drops any list whose fetch returned no data, so a failed LiFi request at load
+   * leaves nothing to overlay. Add the refreshed list instead of discarding it.
+   */
+  return [
+    ...merged,
+    {
+      ...lifiTokenList,
+      l2ChainId: String(childChainId),
+      bridgeTokenListId: LIFI_TRANSFER_LIST_ID,
+    },
+  ];
+}
+
 export function useTokensFromLists() {
   const [networks] = useNetworks();
   const { childChain, parentChain } = useNetworksRelationship(networks);
@@ -20,21 +73,15 @@ export function useTokensFromLists() {
   const { data: refreshedLifiTokenList } = useLifiTokenList();
 
   // Memoized for referential stability: this feeds an SWR key that deep-hashes every token.
-  const mergedTokenLists = useMemo(() => {
-    if (!tokenLists) {
-      return emptyTokenLists;
-    }
-
-    if (!refreshedLifiTokenList) {
-      return tokenLists;
-    }
-
-    return tokenLists.map((tokenList) =>
-      tokenList.bridgeTokenListId === LIFI_TRANSFER_LIST_ID
-        ? { ...tokenList, ...refreshedLifiTokenList }
-        : tokenList,
-    );
-  }, [tokenLists, refreshedLifiTokenList]);
+  const mergedTokenLists = useMemo(
+    () =>
+      mergeLifiTokenList({
+        tokenLists,
+        lifiTokenList: refreshedLifiTokenList,
+        childChainId: childChain.id,
+      }),
+    [tokenLists, refreshedLifiTokenList, childChain.id],
+  );
 
   const { data = emptyData, isLoading } = useSWRImmutable(
     [mergedTokenLists, parentChain.id, childChain.id, 'useTokensFromLists'],

--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/useTokenListPriceUpdater.test.tsx
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/useTokenListPriceUpdater.test.tsx
@@ -1,0 +1,130 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { SWRConfig } from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChainId } from '../../types/ChainId';
+import { fetchBridgeTokenList } from '../../util/TokenListUtils';
+import { useNetworks } from '../useNetworks';
+import { useNetworksRelationship } from '../useNetworksRelationship';
+import { useTokenListPriceUpdater } from '../useTokenListPriceUpdater';
+import { useLifiTokenList, useTokenLists } from '../useTokenLists';
+
+const { FETCH_DELAY_MS, tokenListFixture } = vi.hoisted(() => ({
+  // Long enough that the initial useTokenLists fetch is still in flight when the price
+  // updater mounts, which is the window the regression lived in.
+  FETCH_DELAY_MS: 50,
+  tokenListFixture: {
+    name: 'Test list',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    version: { major: 1, minor: 0, patch: 0 },
+    tokens: [
+      {
+        chainId: 42161,
+        address: '0x46850ad61c2b7d64d08c9c754f45254596696984',
+        name: 'Test token',
+        symbol: 'TEST',
+        decimals: 18,
+      },
+    ],
+  },
+}));
+
+vi.mock('../../util/TokenListUtils', async () => {
+  const actual = await vi.importActual<typeof import('../../util/TokenListUtils')>(
+    '../../util/TokenListUtils',
+  );
+
+  return {
+    ...actual,
+    // Single implementation rather than per-call mocking, since this package runs tests
+    // concurrently and per-call mocks race across files.
+    fetchBridgeTokenList: vi.fn(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, FETCH_DELAY_MS);
+      });
+      return { data: tokenListFixture };
+    }),
+  };
+});
+
+vi.mock('../useNetworks', () => ({ useNetworks: vi.fn() }));
+vi.mock('../useNetworksRelationship', () => ({ useNetworksRelationship: vi.fn() }));
+
+const addTokensFromList = vi.fn();
+vi.mock('../../state', () => ({
+  useAppState: () => ({
+    app: {
+      arbTokenBridge: { token: { addTokensFromList } },
+      arbTokenBridgeLoaded: true,
+    },
+  }),
+}));
+
+// Ethereum to Arbitrum One, a pair that has a LiFi token list.
+const parentChain = { id: ChainId.Ethereum };
+const childChain = { id: ChainId.ArbitrumOne };
+
+function wrapper({ children }: PropsWithChildren) {
+  // Fresh cache per render, so one test cannot satisfy another from cache.
+  return <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>;
+}
+
+describe.sequential('useTokenListPriceUpdater', () => {
+  beforeEach(() => {
+    vi.mocked(useNetworks).mockReturnValue([
+      { sourceChain: parentChain, destinationChain: childChain },
+      vi.fn(),
+    ] as unknown as ReturnType<typeof useNetworks>);
+
+    vi.mocked(useNetworksRelationship).mockReturnValue({
+      childChain,
+      parentChain,
+    } as unknown as ReturnType<typeof useNetworksRelationship>);
+
+    vi.mocked(fetchBridgeTokenList).mockClear();
+    addTokensFromList.mockClear();
+  });
+
+  it('does not discard the in-flight token list fetch it overlaps', async () => {
+    const { result } = renderHook(
+      () => {
+        useTokenListPriceUpdater();
+        return useTokenLists(childChain.id);
+      },
+      { wrapper },
+    );
+
+    // Before the fix the price updater called mutate() on the useTokenLists key while its
+    // initial fetch was in flight. SWR discarded the response and, with revalidation
+    // disabled, never retried, so data stayed undefined forever.
+    await waitFor(
+      () => {
+        expect(result.current.data?.length).toBeGreaterThan(0);
+      },
+      { timeout: 3_000 },
+    );
+
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('fetches the LiFi list from the polling owner', async () => {
+    renderHook(() => useTokenListPriceUpdater(), { wrapper });
+
+    await waitFor(() => {
+      expect(vi.mocked(fetchBridgeTokenList)).toHaveBeenCalled();
+    });
+  });
+
+  it('does not fetch from passive subscribers', async () => {
+    // Polling, focus and reconnect revalidation are per hook instance in SWR, and this hook
+    // is read in ~18 places including once per virtualized token row. Only the owner fetches.
+    renderHook(() => useLifiTokenList(), { wrapper });
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, FETCH_DELAY_MS * 3);
+    });
+
+    expect(vi.mocked(fetchBridgeTokenList)).not.toHaveBeenCalled();
+  });
+});

--- a/packages/arb-token-bridge-ui/src/hooks/useTokenListPriceUpdater.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTokenListPriceUpdater.ts
@@ -6,12 +6,14 @@ import { useLifiTokenList } from './useTokenLists';
 
 /**
  * Keeps the bridge tokens in sync with the polled LiFi token list, so token prices stay fresh.
+ *
+ * This is the single polling owner for the LiFi token list. It is mounted once, from `MainContent`.
  */
 export function useTokenListPriceUpdater(): void {
   const {
     app: { arbTokenBridge, arbTokenBridgeLoaded },
   } = useAppState();
-  const { data: lifiTokenList } = useLifiTokenList();
+  const { data: lifiTokenList } = useLifiTokenList({ poll: true });
   const arbTokenBridgeRef = useRef(arbTokenBridge);
 
   useEffect(() => {

--- a/packages/arb-token-bridge-ui/src/hooks/useTokenListPriceUpdater.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTokenListPriceUpdater.ts
@@ -1,73 +1,28 @@
-import { useCallback, useEffect, useRef } from 'react';
-import { useInterval } from 'react-use';
+import { useEffect, useRef } from 'react';
 
 import { useAppState } from '../state';
-import {
-  LIFI_TRANSFER_LIST_ID,
-  fetchBridgeTokenList,
-  getLifiTokenListForNetworks,
-} from '../util/TokenListUtils';
-import { useNetworks } from './useNetworks';
-import { useNetworksRelationship } from './useNetworksRelationship';
-import { useTokenLists } from './useTokenLists';
+import { LIFI_TRANSFER_LIST_ID } from '../util/TokenListUtils';
+import { useLifiTokenList } from './useTokenLists';
 
-const DEFAULT_REFRESH_INTERVAL_MS = 31_000; // API cache response for 30 seconds, we want to ensure we're getting fresh data
-
-export function useTokenListPriceUpdater({
-  intervalMs = DEFAULT_REFRESH_INTERVAL_MS,
-}: { intervalMs?: number } = {}): void {
+/**
+ * Keeps the bridge tokens in sync with the polled LiFi token list, so token prices stay fresh.
+ */
+export function useTokenListPriceUpdater(): void {
   const {
     app: { arbTokenBridge, arbTokenBridgeLoaded },
   } = useAppState();
-  const [networks] = useNetworks();
-  const { childChain, parentChain } = useNetworksRelationship(networks);
-  const { mutate } = useTokenLists(childChain.id);
+  const { data: lifiTokenList } = useLifiTokenList();
   const arbTokenBridgeRef = useRef(arbTokenBridge);
 
   useEffect(() => {
     arbTokenBridgeRef.current = arbTokenBridge;
   }, [arbTokenBridge]);
 
-  const refreshLifiTokenList = useCallback(() => {
-    const lifiTokenList = getLifiTokenListForNetworks({
-      childChainId: childChain.id,
-      parentChainId: parentChain.id,
-    });
-
-    if (!lifiTokenList) {
+  useEffect(() => {
+    if (!arbTokenBridgeLoaded || !lifiTokenList) {
       return;
     }
 
-    mutate(async (current) => {
-      if (!current) {
-        return current;
-      }
-
-      const { data } = await fetchBridgeTokenList(lifiTokenList);
-      if (!data) {
-        return current;
-      }
-
-      if (arbTokenBridgeLoaded) {
-        arbTokenBridgeRef.current.token?.addTokensFromList(data, LIFI_TRANSFER_LIST_ID);
-      }
-
-      return current.map((tokenList) => {
-        if (tokenList.bridgeTokenListId !== LIFI_TRANSFER_LIST_ID) {
-          return tokenList;
-        }
-
-        return {
-          ...tokenList,
-          ...data,
-        };
-      });
-    }, false);
-  }, [arbTokenBridgeLoaded, childChain.id, parentChain.id, mutate]);
-
-  useInterval(refreshLifiTokenList, intervalMs);
-
-  useEffect(() => {
-    refreshLifiTokenList();
-  }, [refreshLifiTokenList, parentChain.id, childChain.id]);
+    arbTokenBridgeRef.current.token?.addTokensFromList(lifiTokenList, LIFI_TRANSFER_LIST_ID);
+  }, [arbTokenBridgeLoaded, lifiTokenList]);
 }

--- a/packages/arb-token-bridge-ui/src/hooks/useTokenLists.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTokenLists.ts
@@ -1,10 +1,12 @@
-import { SWRResponse } from 'swr';
+import { TokenList } from '@uniswap/token-lists';
+import useSWR, { SWRResponse } from 'swr';
 import useSWRImmutable from 'swr/immutable';
 
 import {
   TokenListWithId,
   fetchBridgeTokenList,
   getBridgeTokenListsForNetworks,
+  getLifiTokenListForNetworks,
 } from '../util/TokenListUtils';
 import { isNetwork } from '../util/networks';
 import { useNetworks } from './useNetworks';
@@ -70,6 +72,43 @@ export function useTokenLists(forL2ChainId: number): SWRResponse<TokenListWithId
       shouldRetryOnError: true,
       errorRetryCount: 2,
       errorRetryInterval: 1_000,
+    },
+  );
+}
+
+// The LiFi tokens API caches its response for 30 seconds, so poll just above that for fresh prices.
+const LIFI_TOKEN_LIST_REFRESH_INTERVAL_MS = 31_000;
+
+/**
+ * Polls the LiFi token list on its own SWR key so `priceUSD` stays fresh.
+ *
+ * The key is deliberately separate from {@link useTokenLists}. Refreshing by calling `mutate` on the
+ * `useTokenLists` key meant that whenever a refresh overlapped the initial fetch, SWR discarded the
+ * in-flight response and left every consumer with no token data until a new subscriber mounted.
+ */
+export function useLifiTokenList(): SWRResponse<TokenList | undefined> {
+  const [networks] = useNetworks();
+  const { childChain, parentChain } = useNetworksRelationship(networks);
+
+  return useSWR(
+    [childChain.id, parentChain.id, 'useLifiTokenList'] as const,
+    async ([_childChainId, _parentChainId]) => {
+      const lifiTokenList = getLifiTokenListForNetworks({
+        childChainId: _childChainId,
+        parentChainId: _parentChainId,
+      });
+
+      if (!lifiTokenList) {
+        return undefined;
+      }
+
+      const { data } = await fetchBridgeTokenList(lifiTokenList);
+      return data;
+    },
+    {
+      // `useTokenLists` already fetches this list, so only fetch here to pick up later price updates.
+      revalidateOnMount: false,
+      refreshInterval: LIFI_TOKEN_LIST_REFRESH_INTERVAL_MS,
     },
   );
 }

--- a/packages/arb-token-bridge-ui/src/hooks/useTokenLists.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTokenLists.ts
@@ -80,13 +80,20 @@ export function useTokenLists(forL2ChainId: number): SWRResponse<TokenListWithId
 const LIFI_TOKEN_LIST_REFRESH_INTERVAL_MS = 31_000;
 
 /**
- * Polls the LiFi token list on its own SWR key so `priceUSD` stays fresh.
+ * Reads the LiFi token list from its own SWR key, so `priceUSD` stays fresh.
  *
  * The key is deliberately separate from {@link useTokenLists}. Refreshing by calling `mutate` on the
  * `useTokenLists` key meant that whenever a refresh overlapped the initial fetch, SWR discarded the
  * in-flight response and left every consumer with no token data until a new subscriber mounted.
+ *
+ * Pass `poll` from exactly one owner. SWR schedules polling, focus and reconnect revalidation per
+ * hook instance rather than per cache key, and this hook is read by many components, some of them
+ * once per token row inside the virtualized list. Every other caller subscribes to the same cache
+ * entry passively: it receives each update without scheduling a fetch of its own.
  */
-export function useLifiTokenList(): SWRResponse<TokenList | undefined> {
+export function useLifiTokenList({ poll = false }: { poll?: boolean } = {}): SWRResponse<
+  TokenList | undefined
+> {
   const [networks] = useNetworks();
   const { childChain, parentChain } = useNetworksRelationship(networks);
 
@@ -106,9 +113,13 @@ export function useLifiTokenList(): SWRResponse<TokenList | undefined> {
       return data;
     },
     {
-      // `useTokenLists` already fetches this list, so only fetch here to pick up later price updates.
-      revalidateOnMount: false,
-      refreshInterval: LIFI_TOKEN_LIST_REFRESH_INTERVAL_MS,
+      refreshInterval: poll ? LIFI_TOKEN_LIST_REFRESH_INTERVAL_MS : 0,
+      // The owner refetches on mount so prices are current after navigating back to the bridge,
+      // where the SWR cache outlives the unmounted components and would otherwise serve stale
+      // prices until the first poll.
+      revalidateOnMount: poll,
+      revalidateOnFocus: poll,
+      revalidateOnReconnect: poll,
     },
   );
 }


### PR DESCRIPTION
### Summary

The bug this PR fixed: Opening the token search panel within the first seconds after load showed only the native currency row, and it never recovered. Reopening the dialog fixed it.

`useTokenListPriceUpdater.ts`‎ was calling `const { mutate } = useTokenLists(childChain.id);`
and because `useTokenLists` is called at multiple components, there was a race condition when it was called first at another component, while mutate is happening

but because `useTokenLists` uses `useSWRImmutable`, it doesn’t revalidate when the data is stale after mutation, so the mutation result got discarded

so if user opens the token search panel (`TokenSearchUtils` calls `useTokenLists`) before mutate finishes (open in `useTokenListPriceUpdater.ts`‎, which is in `MainContent`, the token list data is empty

but if user only opens the token search panel after mutate has finished, the tokens would have loaded

---

`useTokenListPriceUpdater` refreshed LiFi prices by calling `mutate()` on the `useTokenLists` SWR key. That routinely overlapped the key's own initial fetch, and SWR's mutation-vs-revalidation guard discards the in-flight response. With `revalidate: false` plus `useSWRImmutable`, nothing retriggered it, so `useTokenLists` sat on `data: undefined` permanently.

Fix: give the price refresh its own SWR key.

1. `063aa729a` — add `useLifiTokenList` with its own key. The updater reacts to it instead of mutating a shared key; `useTokensFromLists` overlays the refreshed list at read time to keep `priceUSD` fresh.
2. `61a4cb3d7` — SWR polls per hook instance, not per key, and this hook is read from 18 call sites (two of them per token row). A `poll` option makes `useTokenListPriceUpdater` the single polling owner.
3. `5a6fcbf6d` — append the refreshed list when the load-time fetch failed, leaving no entry to overlay.

### Steps to test

Hard-reload, click the token selector immediately. Master: 1 row, never recovers. Here: full list.

`vitest`: 10 passed. `pnpm lint`: 0 errors. Prettier clean on changed files.

Closes FS-2554
