### PR TITLE
build(deps): bump js-yaml to v4.3.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ overrides:
   '@types/react': 19.2.14
   '@types/react-dom': 19.2.3
   '@types/node': 22.19.19
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   undici: 6.28.0
   h3: 1.15.10
   lodash: 4.18.1
@@ -6880,8 +6880,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -10916,7 +10916,7 @@ snapshots:
       execa: 4.1.0
       globby: 11.1.0
       istanbul-lib-coverage: 3.2.2
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       nyc: 15.1.0
       webpack: 5.106.2(postcss@8.5.25)
     transitivePeerDependencies:
@@ -11138,7 +11138,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.2.4
       import-fresh: 3.3.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -11668,7 +11668,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -18493,7 +18493,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ overrides:
   '@types/react': 19.2.14
   '@types/react-dom': 19.2.3
   '@types/node': 22.19.19
-  'js-yaml': 4.3.0
+  'js-yaml': 4.3.1
   'undici': 6.28.0
   'h3': 1.15.10
   'lodash': 4.18.1


### PR DESCRIPTION
## Summary

`audit-ci` was failing on one new advisory. Resolved by bumping the existing pnpm override.

| Advisory | Package | Severity | Strategy | Justification |
| --- | --- | --- | --- | --- |
| [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | `js-yaml` | High (CVSS 7.5) | **Bump** 4.3.0 to 4.3.1 | Quadratic CPU consumption in `resolveYamlOmap()`. `!!omap` is registered in the default schema, so `yaml.load()` on untrusted input can block the event loop. Affects `>= 4.0.0, < 4.3.1`; upstream published 4.3.1. We already pin `js-yaml` via a pnpm override, so this is a one-line bump. |

## Changes

- `pnpm-workspace.yaml`: `js-yaml` override 4.3.0 to 4.3.1
- `pnpm-lock.yaml`: regenerated

## Allowlist

No changes to `audit-ci.jsonc`. Every existing allowlist entry still maps to a live advisory path, so there is nothing stale to prune.

## Verification

- `pnpm audit:ci` exits 0
- `pnpm lint` passes (0 errors, warnings unchanged) — confirms the eslint/`@eslint/eslintrc` config loading path, the main consumer of `js-yaml`, still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)