### PR TITLE
feat(bridge): show moonpay card when widget is disabled

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -61,10 +61,13 @@ The Bridge app requires environment variables for full functionality:
    - `LIFI_KEY = your-lifi-key` (Get from [LiFi dashboard](https://portal.li.fi/))
 
    - `NEXT_PUBLIC_FEATURE_FLAG_ONRAMP = true / false` (Enable onramp functionality)
-   - `NEXT_PUBLIC_FEATURE_FLAG_ONRAMP_SERVICES_ENABLED = moonpay` (Specify onramp services)
+   - `NEXT_PUBLIC_FEATURE_FLAG_ONRAMP_SERVICES_ENABLED = moonpay` (Specify onramp services rendered as an embedded widget. When `moonpay` is omitted, MoonPay falls back to a regular on-ramp card that links out to moonpay.com.)
 
+   Only required when `moonpay` is listed in `NEXT_PUBLIC_FEATURE_FLAG_ONRAMP_SERVICES_ENABLED`:
    - `NEXT_PUBLIC_MOONPAY_PK = your-moonpay-public-key` (Get from [MoonPay dashboard](https://dashboard.moonpay.com/))
    - `MOONPAY_SK = your-moonpay-secret-key` (Get from [MoonPay dashboard](https://dashboard.moonpay.com/))
+
+   Note: these are build-time inlined, so changing them requires a restart in dev and a redeploy in production.
 
 ## Testing
 

--- a/packages/arb-token-bridge-ui/src/components/BuyPanel/BuyPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/BuyPanel/BuyPanel.tsx
@@ -226,10 +226,7 @@ function OnrampServicePanel() {
   const pathname = usePathname();
   const onrampService = pathname.split('/').pop();
 
-  if (onrampService === 'moonpay') {
-    if (!isMoonPayEnabled) {
-      return null;
-    }
+  if (onrampService === 'moonpay' && isMoonPayEnabled) {
     return <MoonPayPanel />;
   }
 

--- a/packages/arb-token-bridge-ui/src/components/BuyPanel/Homepage.tsx
+++ b/packages/arb-token-bridge-ui/src/components/BuyPanel/Homepage.tsx
@@ -8,8 +8,11 @@ import { twMerge } from 'tailwind-merge';
 import { trackEvent } from '@/bridge/util/AnalyticsUtils';
 import MoonPay from '@/images/onramp/moonpay.svg';
 
+import { isOnrampServiceEnabled } from '../../util/featureFlag';
 import { Button } from '../common/Button';
 import { onrampServices } from './utils';
+
+const isMoonPayWidgetEnabled = isOnrampServiceEnabled('moonpay');
 
 function OnrampServiceTile({ name, logo, slug }: { name: string; logo: string; slug: string }) {
   const pathname = usePathname();
@@ -69,10 +72,15 @@ export function Homepage() {
     router.push('/projects?subcategories=fiat-on-ramp');
   }, [router]);
 
+  /** When the embedded widget is enabled, MoonPay gets its own tile instead of a grid card. */
+  const gridServices = isMoonPayWidgetEnabled
+    ? onrampServices.filter((service) => service.slug !== 'moonpay')
+    : onrampServices;
+
   return (
     <div className={twMerge('grid gap-3', 'grid-cols-2 md:grid-cols-3')}>
-      <MoonPayTile />
-      {onrampServices.map((service) => (
+      {isMoonPayWidgetEnabled && <MoonPayTile />}
+      {gridServices.map((service) => (
         <OnrampServiceTile key={service.name} {...service} />
       ))}
       <Button

--- a/packages/arb-token-bridge-ui/src/components/BuyPanel/LinkoutOnrampPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/BuyPanel/LinkoutOnrampPanel.tsx
@@ -30,8 +30,7 @@ export function LinkoutOnrampPanel({ serviceSlug }: { serviceSlug: string }) {
         <div className="flex flex-col gap-1">
           <h2 className="text-xl">{service.name}</h2>
           <p className="text-sm max-w-md">
-            Buy and transfer instantly using your debit card, bank account with Thirdweb{' '}
-            {service.name}.
+            Buy and transfer instantly using your debit card or bank account with {service.name}.
           </p>
         </div>
       </div>

--- a/packages/arb-token-bridge-ui/src/components/BuyPanel/utils.ts
+++ b/packages/arb-token-bridge-ui/src/components/BuyPanel/utils.ts
@@ -6,6 +6,12 @@ export const onrampServices = [
     link: 'https://global.transak.com',
   },
   {
+    name: 'MoonPay',
+    slug: 'moonpay',
+    logo: '/images/onramp/moonpay.svg',
+    link: 'https://www.moonpay.com/buy',
+  },
+  {
     name: 'Ramp',
     slug: 'ramp',
     logo: '/images/onramp/ramp.webp',


### PR DESCRIPTION
- keeping the existing moonpay integration code but removed `moonpay` from `NEXT_PUBLIC_FEATURE_FLAG_ONRAMP_SERVICES_ENABLED`
- when `moonpay` is not on `NEXT_PUBLIC_FEATURE_FLAG_ONRAMP_SERVICES_ENABLED`, show tile UI like other onramp services

Closes FS-2555