### PR TITLE
fix(bridge): load tokens on Token Search Panel first render

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/useTokenListPriceUpdater.test.tsx
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/useTokenListPriceUpdater.test.tsx
@@ -10,12 +10,24 @@ import { useNetworksRelationship } from '../useNetworksRelationship';
 import { useTokenListPriceUpdater } from '../useTokenListPriceUpdater';
 import { useTokenLists } from '../useTokenLists';
 
-const { FETCH_DELAY_MS, buildTokenList } = vi.hoisted(() => ({
-  // Long enough that the initial useTokenLists fetch is still in flight when the price
-  // updater mounts, which is the window the regression lived in.
-  FETCH_DELAY_MS: 50,
-  buildTokenList: (symbol: string) => ({
-    name: 'Test list',
+const { FETCH_DELAY_MS, MOCK_BRIDGE_TOKEN_LISTS, MOCK_TOKEN_LISTS } = vi.hoisted(() => {
+  const arbitrumTokenList = {
+    name: 'Mock Arbitrum Token list',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    version: { major: 1, minor: 0, patch: 0 },
+    tokens: [
+      {
+        chainId: 42161,
+        address: '0x912ce59144191c1204e64559fe8253a0e49e6548',
+        name: 'Arbitrum',
+        symbol: 'ARB',
+        decimals: 18,
+      },
+    ],
+  };
+
+  const lifiTokenList = {
+    name: 'Mock LiFi list',
     timestamp: '2026-01-01T00:00:00.000Z',
     version: { major: 1, minor: 0, patch: 0 },
     tokens: [
@@ -23,12 +35,43 @@ const { FETCH_DELAY_MS, buildTokenList } = vi.hoisted(() => ({
         chainId: 42161,
         address: '0x46850ad61c2b7d64d08c9c754f45254596696984',
         name: 'Test token',
-        symbol,
+        symbol: 'TEST',
         decimals: 18,
       },
     ],
-  }),
-}));
+  };
+
+  return {
+    // Long enough that the initial useTokenLists fetch is still in flight when the price
+    // updater mounts, which is the window the regression lived in.
+    FETCH_DELAY_MS: 50,
+    // The bridge token lists every chain pair resolves to, so the assertions below don't
+    // depend on the real list config.
+    MOCK_BRIDGE_TOKEN_LISTS: [
+      {
+        id: 'mock-arbitrum-token-list',
+        name: 'Mock Arbitrum Token list',
+        originChainID: 0,
+        url: 'https://example.com/arbitrum-token-list.json',
+        isDefault: true,
+        isArbitrumTokenTokenList: true,
+        logoURI: '/images/lists/ArbitrumLogo.png',
+      },
+      {
+        id: 'lifi-token-list',
+        name: 'Mock LiFi list',
+        originChainID: 0,
+        url: 'https://example.com/lifi.json',
+        isDefault: true,
+        logoURI: '/images/lists/ArbitrumLogo.png',
+      },
+    ],
+    MOCK_TOKEN_LISTS: {
+      'mock-arbitrum-token-list': arbitrumTokenList,
+      'lifi-token-list': lifiTokenList,
+    } as Record<string, typeof arbitrumTokenList | undefined>,
+  };
+});
 
 vi.mock('../../util/TokenListUtils', async () => {
   const actual = await vi.importActual<typeof import('../../util/TokenListUtils')>(
@@ -37,13 +80,15 @@ vi.mock('../../util/TokenListUtils', async () => {
 
   return {
     ...actual,
+    getBridgeTokenListsForNetworks: vi.fn(() => MOCK_BRIDGE_TOKEN_LISTS),
+    getLifiTokenListForNetworks: vi.fn(() => MOCK_BRIDGE_TOKEN_LISTS[1]),
     // Keyed by argument rather than per call, since this package runs tests concurrently
     // and per-call mocks race.
     fetchBridgeTokenList: vi.fn(async (bridgeTokenList: { id: string }) => {
       await new Promise((resolve) => {
         setTimeout(resolve, FETCH_DELAY_MS);
       });
-      return { data: buildTokenList(bridgeTokenList.id) };
+      return { data: MOCK_TOKEN_LISTS[bridgeTokenList.id] };
     }),
   };
 });
@@ -61,9 +106,13 @@ vi.mock('../../state', () => ({
   }),
 }));
 
-// Ethereum to Arbitrum One, a pair that has a LiFi token list.
 const parentChain = { id: ChainId.Ethereum };
 const childChain = { id: ChainId.ArbitrumOne };
+// Another child chain to switch to, which moves the mounted hooks onto a new useTokenLists key.
+const otherChildChain = { id: ChainId.ApeChain };
+
+// Mutable so a rerender can move the mounted hooks onto a different useTokenLists key.
+let currentChildChain = childChain;
 
 function wrapper({ children }: PropsWithChildren) {
   // Fresh cache per render, so one test cannot satisfy another from cache.
@@ -74,15 +123,23 @@ function wrapper({ children }: PropsWithChildren) {
 
 describe.sequential('useTokenListPriceUpdater', () => {
   beforeEach(() => {
-    vi.mocked(useNetworks).mockReturnValue([
-      { sourceChain: parentChain, destinationChain: childChain },
-      vi.fn(),
-    ] as unknown as ReturnType<typeof useNetworks>);
+    currentChildChain = childChain;
 
-    vi.mocked(useNetworksRelationship).mockReturnValue({
-      childChain,
-      parentChain,
-    } as unknown as ReturnType<typeof useNetworksRelationship>);
+    vi.mocked(useNetworks).mockImplementation(
+      () =>
+        [
+          { sourceChain: parentChain, destinationChain: currentChildChain },
+          vi.fn(),
+        ] as unknown as ReturnType<typeof useNetworks>,
+    );
+
+    vi.mocked(useNetworksRelationship).mockImplementation(
+      () =>
+        ({
+          childChain: currentChildChain,
+          parentChain,
+        }) as unknown as ReturnType<typeof useNetworksRelationship>,
+    );
 
     vi.mocked(fetchBridgeTokenList).mockClear();
     addTokensFromList.mockClear();
@@ -102,7 +159,40 @@ describe.sequential('useTokenListPriceUpdater', () => {
     // with, so refreshing during the initial fetch used to leave data undefined forever.
     await waitFor(
       () => {
-        expect(result.current.data?.length).toBeGreaterThan(0);
+        expect(result.current.data).toEqual([
+          {
+            l2ChainId: '42161',
+            bridgeTokenListId: 'mock-arbitrum-token-list',
+            name: 'Mock Arbitrum Token list',
+            timestamp: '2026-01-01T00:00:00.000Z',
+            version: { major: 1, minor: 0, patch: 0 },
+            tokens: [
+              {
+                chainId: 42161,
+                address: '0x912ce59144191c1204e64559fe8253a0e49e6548',
+                name: 'Arbitrum',
+                symbol: 'ARB',
+                decimals: 18,
+              },
+            ],
+          },
+          {
+            l2ChainId: '42161',
+            bridgeTokenListId: 'lifi-token-list',
+            name: 'Mock LiFi list',
+            timestamp: '2026-01-01T00:00:00.000Z',
+            version: { major: 1, minor: 0, patch: 0 },
+            tokens: [
+              {
+                chainId: 42161,
+                address: '0x46850ad61c2b7d64d08c9c754f45254596696984',
+                name: 'Test token',
+                symbol: 'TEST',
+                decimals: 18,
+              },
+            ],
+          },
+        ]);
       },
       { timeout: 3_000 },
     );
@@ -122,9 +212,122 @@ describe.sequential('useTokenListPriceUpdater', () => {
     await waitFor(
       () => {
         expect(addTokensFromList).toHaveBeenCalledWith(
-          expect.objectContaining({ tokens: expect.any(Array) }),
+          {
+            name: 'Mock LiFi list',
+            timestamp: '2026-01-01T00:00:00.000Z',
+            version: { major: 1, minor: 0, patch: 0 },
+            tokens: [
+              {
+                chainId: 42161,
+                address: '0x46850ad61c2b7d64d08c9c754f45254596696984',
+                name: 'Test token',
+                symbol: 'TEST',
+                decimals: 18,
+              },
+            ],
+          },
           LIFI_TRANSFER_LIST_ID,
         );
+      },
+      { timeout: 3_000 },
+    );
+  });
+
+  it('loads the new token lists when the chain pair changes', async () => {
+    const { result, rerender } = renderHook(
+      () => {
+        useTokenListPriceUpdater();
+        return useTokenLists(currentChildChain.id);
+      },
+      { wrapper },
+    );
+
+    await waitFor(
+      () => {
+        expect(result.current.data).toEqual([
+          {
+            l2ChainId: '42161',
+            bridgeTokenListId: 'mock-arbitrum-token-list',
+            name: 'Mock Arbitrum Token list',
+            timestamp: '2026-01-01T00:00:00.000Z',
+            version: { major: 1, minor: 0, patch: 0 },
+            tokens: [
+              {
+                chainId: 42161,
+                address: '0x912ce59144191c1204e64559fe8253a0e49e6548',
+                name: 'Arbitrum',
+                symbol: 'ARB',
+                decimals: 18,
+              },
+            ],
+          },
+          {
+            l2ChainId: '42161',
+            bridgeTokenListId: 'lifi-token-list',
+            name: 'Mock LiFi list',
+            timestamp: '2026-01-01T00:00:00.000Z',
+            version: { major: 1, minor: 0, patch: 0 },
+            tokens: [
+              {
+                chainId: 42161,
+                address: '0x46850ad61c2b7d64d08c9c754f45254596696984',
+                name: 'Test token',
+                symbol: 'TEST',
+                decimals: 18,
+              },
+            ],
+          },
+        ]);
+      },
+      { timeout: 3_000 },
+    );
+
+    // Switching chains moves an already-mounted useTokenLists onto a brand new key, with an
+    // empty cache entry and its own fetch in flight. That is the same window as the initial
+    // mount, so the updater must not mutate until the new key has its own data. Note that
+    // `isLoading` is not a usable guard here: SWR only reports it from a cached entry or, as
+    // a fallback, from a first-render flag that is already spent by this point.
+    currentChildChain = otherChildChain;
+    rerender();
+
+    // Exact match on `l2ChainId`, so returning the previous chain's lists (for example via
+    // `keepPreviousData`) fails here rather than looking correct.
+    await waitFor(
+      () => {
+        expect(result.current.data).toEqual([
+          {
+            l2ChainId: '33139',
+            bridgeTokenListId: 'mock-arbitrum-token-list',
+            name: 'Mock Arbitrum Token list',
+            timestamp: '2026-01-01T00:00:00.000Z',
+            version: { major: 1, minor: 0, patch: 0 },
+            tokens: [
+              {
+                chainId: 42161,
+                address: '0x912ce59144191c1204e64559fe8253a0e49e6548',
+                name: 'Arbitrum',
+                symbol: 'ARB',
+                decimals: 18,
+              },
+            ],
+          },
+          {
+            l2ChainId: '33139',
+            bridgeTokenListId: 'lifi-token-list',
+            name: 'Mock LiFi list',
+            timestamp: '2026-01-01T00:00:00.000Z',
+            version: { major: 1, minor: 0, patch: 0 },
+            tokens: [
+              {
+                chainId: 42161,
+                address: '0x46850ad61c2b7d64d08c9c754f45254596696984',
+                name: 'Test token',
+                symbol: 'TEST',
+                decimals: 18,
+              },
+            ],
+          },
+        ]);
       },
       { timeout: 3_000 },
     );

--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/useTokenListPriceUpdater.test.tsx
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/useTokenListPriceUpdater.test.tsx
@@ -67,7 +67,7 @@ const childChain = { id: ChainId.ArbitrumOne };
 
 function wrapper({ children }: PropsWithChildren) {
   // Fresh cache per render, so one test cannot satisfy another from cache.
-  return <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>;
+  return <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>;
 }
 
 describe.sequential('useTokenListPriceUpdater', () => {

--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/useTokenListPriceUpdater.test.tsx
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/useTokenListPriceUpdater.test.tsx
@@ -67,7 +67,9 @@ const childChain = { id: ChainId.ArbitrumOne };
 
 function wrapper({ children }: PropsWithChildren) {
   // Fresh cache per render, so one test cannot satisfy another from cache.
-  return <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>;
+  return (
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>
+  );
 }
 
 describe.sequential('useTokenListPriceUpdater', () => {

--- a/packages/arb-token-bridge-ui/src/hooks/__tests__/useTokenListPriceUpdater.test.tsx
+++ b/packages/arb-token-bridge-ui/src/hooks/__tests__/useTokenListPriceUpdater.test.tsx
@@ -1,0 +1,130 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { SWRConfig } from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChainId } from '../../types/ChainId';
+import { LIFI_TRANSFER_LIST_ID, fetchBridgeTokenList } from '../../util/TokenListUtils';
+import { useNetworks } from '../useNetworks';
+import { useNetworksRelationship } from '../useNetworksRelationship';
+import { useTokenListPriceUpdater } from '../useTokenListPriceUpdater';
+import { useTokenLists } from '../useTokenLists';
+
+const { FETCH_DELAY_MS, buildTokenList } = vi.hoisted(() => ({
+  // Long enough that the initial useTokenLists fetch is still in flight when the price
+  // updater mounts, which is the window the regression lived in.
+  FETCH_DELAY_MS: 50,
+  buildTokenList: (symbol: string) => ({
+    name: 'Test list',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    version: { major: 1, minor: 0, patch: 0 },
+    tokens: [
+      {
+        chainId: 42161,
+        address: '0x46850ad61c2b7d64d08c9c754f45254596696984',
+        name: 'Test token',
+        symbol,
+        decimals: 18,
+      },
+    ],
+  }),
+}));
+
+vi.mock('../../util/TokenListUtils', async () => {
+  const actual = await vi.importActual<typeof import('../../util/TokenListUtils')>(
+    '../../util/TokenListUtils',
+  );
+
+  return {
+    ...actual,
+    // Keyed by argument rather than per call, since this package runs tests concurrently
+    // and per-call mocks race.
+    fetchBridgeTokenList: vi.fn(async (bridgeTokenList: { id: string }) => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, FETCH_DELAY_MS);
+      });
+      return { data: buildTokenList(bridgeTokenList.id) };
+    }),
+  };
+});
+
+vi.mock('../useNetworks', () => ({ useNetworks: vi.fn() }));
+vi.mock('../useNetworksRelationship', () => ({ useNetworksRelationship: vi.fn() }));
+
+const addTokensFromList = vi.fn();
+vi.mock('../../state', () => ({
+  useAppState: () => ({
+    app: {
+      arbTokenBridge: { token: { addTokensFromList } },
+      arbTokenBridgeLoaded: true,
+    },
+  }),
+}));
+
+// Ethereum to Arbitrum One, a pair that has a LiFi token list.
+const parentChain = { id: ChainId.Ethereum };
+const childChain = { id: ChainId.ArbitrumOne };
+
+function wrapper({ children }: PropsWithChildren) {
+  // Fresh cache per render, so one test cannot satisfy another from cache.
+  return <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>;
+}
+
+describe.sequential('useTokenListPriceUpdater', () => {
+  beforeEach(() => {
+    vi.mocked(useNetworks).mockReturnValue([
+      { sourceChain: parentChain, destinationChain: childChain },
+      vi.fn(),
+    ] as unknown as ReturnType<typeof useNetworks>);
+
+    vi.mocked(useNetworksRelationship).mockReturnValue({
+      childChain,
+      parentChain,
+    } as unknown as ReturnType<typeof useNetworksRelationship>);
+
+    vi.mocked(fetchBridgeTokenList).mockClear();
+    addTokensFromList.mockClear();
+  });
+
+  it('leaves the token lists intact when it mounts during their initial fetch', async () => {
+    const { result } = renderHook(
+      () => {
+        useTokenListPriceUpdater();
+        return useTokenLists(childChain.id);
+      },
+      { wrapper },
+    );
+
+    // The updater mutates the useTokenLists key. SWR discards any response that overlaps a
+    // mutation on the same key, and useSWRImmutable has no revalidation left to recover
+    // with, so refreshing during the initial fetch used to leave data undefined forever.
+    await waitFor(
+      () => {
+        expect(result.current.data?.length).toBeGreaterThan(0);
+      },
+      { timeout: 3_000 },
+    );
+
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('still refreshes the LiFi list once the token lists have loaded', async () => {
+    renderHook(
+      () => {
+        useTokenListPriceUpdater();
+        return useTokenLists(childChain.id);
+      },
+      { wrapper },
+    );
+
+    await waitFor(
+      () => {
+        expect(addTokensFromList).toHaveBeenCalledWith(
+          expect.objectContaining({ tokens: expect.any(Array) }),
+          LIFI_TRANSFER_LIST_ID,
+        );
+      },
+      { timeout: 3_000 },
+    );
+  });
+});

--- a/packages/arb-token-bridge-ui/src/hooks/useTokenListPriceUpdater.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTokenListPriceUpdater.ts
@@ -21,14 +21,34 @@ export function useTokenListPriceUpdater({
   } = useAppState();
   const [networks] = useNetworks();
   const { childChain, parentChain } = useNetworksRelationship(networks);
-  const { mutate } = useTokenLists(childChain.id);
+  const { data: tokenLists, mutate } = useTokenLists(childChain.id);
   const arbTokenBridgeRef = useRef(arbTokenBridge);
+
+  /**
+   * Deliberately a boolean rather than the list itself. Mutating writes a new array, so depending on
+   * `tokenLists` here would give this callback a new identity on every refresh and the effect below
+   * would re-trigger it in a loop.
+   */
+  const hasTokenLists = typeof tokenLists !== 'undefined';
 
   useEffect(() => {
     arbTokenBridgeRef.current = arbTokenBridge;
   }, [arbTokenBridge]);
 
   const refreshLifiTokenList = useCallback(() => {
+    /**
+     * Never mutate this key while its own fetch is in flight. SWR discards any response that
+     * overlaps a mutation on the same key, and `useTokenLists` is `useSWRImmutable`, so there is no
+     * revalidation left to recover the discarded token lists with: every consumer would be stuck
+     * with no tokens until a new subscriber mounted.
+     *
+     * Data being present is a sufficient check only because `useTokenLists` never revalidates once
+     * it has data. Revisit this if that changes.
+     */
+    if (!hasTokenLists) {
+      return;
+    }
+
     const lifiTokenList = getLifiTokenListForNetworks({
       childChainId: childChain.id,
       parentChainId: parentChain.id,
@@ -63,7 +83,7 @@ export function useTokenListPriceUpdater({
         };
       });
     }, false);
-  }, [arbTokenBridgeLoaded, childChain.id, parentChain.id, mutate]);
+  }, [arbTokenBridgeLoaded, hasTokenLists, childChain.id, parentChain.id, mutate]);
 
   useInterval(refreshLifiTokenList, intervalMs);
 


### PR DESCRIPTION
### Summary

**The bug.** Opening the token search panel within the first seconds after load showed only the native currency row, and it never recovered. Reopening the dialog fixed it.

**What was happening.**

`useTokenListPriceUpdater.ts` was calling

```ts
const { mutate } = useTokenLists(childChain.id);
```

and because `useTokenLists` is called from multiple components, there was a race: another component starts the fetch first, and then this `mutate` runs while that fetch is still in flight.

SWR discards any fetch response that overlaps a `mutate` on the same key. Normally the mutation would schedule a fresh revalidation to recover, but `useTokenLists` uses `useSWRImmutable`, so it does not revalidate, and the fetched token lists are just lost.

So:

- If the user opens the token search panel (`TokenSearchUtils` calls `useTokenLists`) before that `mutate` finishes, the token list data is empty, and nothing ever refetches it.
- If the user opens the panel after the `mutate` has finished, the tokens load normally.

Reopening the dialog worked because it remounts `TokenSearch`, and a brand new subscriber runs its own fetch with no mutation in the way.

The `mutate` comes from the mount effect in `useTokenListPriceUpdater`, which lives in `MainContent`, so it fires on every bridge page load.

**The fix.** Return early from `refreshLifiTokenList` until `useTokenLists` has data, so the price refresh can never overlap the initial fetch.

Two notes for reading the diff:

- The guard is a `hasTokenLists` **boolean**, not `tokenLists` itself. `mutate` writes a new array, so depending on the array would change the callback identity on every refresh and the effect would re-trigger it in a loop.
- "Has data" is a sufficient guard only because `useTokenLists` never revalidates once it has data. That assumption is called out in a comment at the check.

**Not the fix:** changing what the `mutate` callback returns. The response is discarded regardless of what it returns, so the mutation simply must not be in flight during that window.

**Alternative considered:** giving the price refresh its own SWR key. It works, but `refreshInterval` then lands on a hook read from 18 call sites (two of them per-row inside the virtualized token list), so every call site schedules its own timer, and dropping `useSWRImmutable` silently changes the revalidate-on-mount/focus/reconnect behaviour. Guarding the existing `mutate` keeps polling on the single `useTokenListPriceUpdater` instance, as originally designed.

**Out of scope:** if the load-time LiFi request fails there is no list entry for a later refresh to merge into, so refreshed tokens are dropped from the token lists (they still reach `bridgeTokens` via `addTokensFromList`). Pre-existing, unchanged here.

### Steps to test

**Manual repro:** hard-reload `/bridge?sourceChain=ethereum&destinationChain=arbitrum-one`, then click the token selector within the first few seconds, while the token list request is still in flight.

- Before: 1 row (`ETH`), never recovers.
- After: full list on the first open (113 rows in Chromium, matching what the second open gives).

Also checked on `ethereum -> apechain`: 5 rows immediately (`APE, ETH, WETH, USDT, USDC`), price poll fires once at +32.8s, so the refresh itself still works.

**Automated:**

```bash
# Node 22 (see .nvmrc). On Node 26, happy-dom's localStorage is shadowed and unrelated tests fail.
cd packages/arb-token-bridge-ui
pnpm vitest run src/hooks/__tests__/useTokenListPriceUpdater.test.tsx
```

The new test mounts the price updater alongside `useTokenLists` with a delayed fetch so the two overlap. Both cases pass here and fail when the hook is reverted to `master`.

`pnpm lint` and `pnpm prettier:check` are clean. Full `pnpm test:ci` has one failure, `TransferPanel.swap.integration.test.tsx > 'base' -> 'robinhood-chain'`, which fails identically on unmodified `master`.

### References

- Introduced by 69dec824a `feat(bridge): add LiFi swap (#150)`
- The SWR guard that discards the response: `swr@2.3.3`, `dist/index/index.mjs:382-396`

Closes FS-2554
