### PR TITLE
build(deps): resolve npm audit advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ overrides:
   fast-uri: 3.1.5
   sharp: 0.35.3
   follow-redirects: 1.16.0
-  postcss: 8.5.25
+  postcss: 8.5.26
   uuid: 14.0.0
   vite@>=7.0.0 <7.3.5: 7.3.5
   vite@>=6.0.0 <6.4.3: 6.4.3
@@ -215,10 +215,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.14(postcss@8.5.25)
+        version: 10.4.14(postcss@8.5.26)
       postcss:
-        specifier: 8.5.25
-        version: 8.5.25
+        specifier: 8.5.26
+        version: 8.5.26
       tailwindcss:
         specifier: ^3.4.16
         version: 3.4.16(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
@@ -372,7 +372,7 @@ importers:
         version: 0.2.2(tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)))
       '@synthetixio/synpress':
         specifier: 3.7.3
-        version: 3.7.3(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(@types/react@19.2.14)(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)))(bufferutil@4.0.9)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.25))(zod@3.25.76)
+        version: 3.7.3(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(@types/react@19.2.14)(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.26)))(bufferutil@4.0.9)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.26))(zod@3.25.76)
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -399,7 +399,7 @@ importers:
         version: 17.0.33
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.14(postcss@8.5.25)
+        version: 10.4.14(postcss@8.5.26)
       cypress-terminal-report:
         specifier: ^7.1.0
         version: 7.2.1(cypress@12.17.3)
@@ -413,8 +413,8 @@ importers:
         specifier: ^1.16.0
         version: 1.16.0
       postcss:
-        specifier: 8.5.25
-        version: 8.5.25
+        specifier: 8.5.26
+        version: 8.5.26
       satori:
         specifier: ^0.12.2
         version: 0.12.2
@@ -514,10 +514,10 @@ importers:
         version: 3.2.3
       autoprefixer:
         specifier: ^10.4.13
-        version: 10.4.14(postcss@8.5.25)
+        version: 10.4.14(postcss@8.5.26)
       postcss:
-        specifier: 8.5.25
-        version: 8.5.25
+        specifier: 8.5.26
+        version: 8.5.26
       tailwindcss:
         specifier: ^3.4.16
         version: 3.4.16(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
@@ -4415,7 +4415,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: 8.5.25
+      postcss: 8.5.26
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -7297,8 +7297,8 @@ packages:
       react: '*'
       react-dom: '*'
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7844,19 +7844,19 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: 8.5.25
+      postcss: 8.5.26
 
   postcss-js@4.0.1:
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: 8.5.25
+      postcss: 8.5.26
 
   postcss-load-config@4.0.2:
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
-      postcss: 8.5.25
+      postcss: 8.5.26
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       postcss:
@@ -7868,7 +7868,7 @@ packages:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: 8.5.25
+      postcss: 8.5.26
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -7877,8 +7877,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.25:
-    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   posthog-js@1.273.0:
@@ -10903,12 +10903,12 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@cypress/code-coverage@3.14.6(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)))(cypress@12.17.3)(webpack@5.106.2(postcss@8.5.25))':
+  '@cypress/code-coverage@3.14.6(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.26)))(cypress@12.17.3)(webpack@5.106.2(postcss@8.5.26))':
     dependencies:
       '@babel/core': 7.29.6
       '@babel/preset-env': 7.29.5(@babel/core@7.29.6)
-      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)))(webpack@5.106.2(postcss@8.5.25))
-      babel-loader: 10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25))
+      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.26)))(webpack@5.106.2(postcss@8.5.26))
+      babel-loader: 10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.26))
       chalk: 4.1.2
       cypress: 12.17.3
       dayjs: 1.11.13
@@ -10918,7 +10918,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       js-yaml: 4.3.1
       nyc: 15.1.0
-      webpack: 5.106.2(postcss@8.5.25)
+      webpack: 5.106.2(postcss@8.5.26)
     transitivePeerDependencies:
       - supports-color
 
@@ -10943,17 +10943,17 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 14.0.0
 
-  '@cypress/webpack-dev-server@3.11.0(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.25))':
+  '@cypress/webpack-dev-server@3.11.0(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.26))':
     dependencies:
       find-up: 6.3.0
       fs-extra: 9.1.0
-      html-webpack-plugin-4: html-webpack-plugin@4.5.2(webpack@5.106.2(postcss@8.5.25))
-      html-webpack-plugin-5: html-webpack-plugin@5.6.7(webpack@5.106.2(postcss@8.5.25))
+      html-webpack-plugin-4: html-webpack-plugin@4.5.2(webpack@5.106.2(postcss@8.5.26))
+      html-webpack-plugin-5: html-webpack-plugin@5.6.7(webpack@5.106.2(postcss@8.5.26))
       local-pkg: 0.4.1
       semver: 7.8.1
-      speed-measure-webpack-plugin: 1.4.2(webpack@5.106.2(postcss@8.5.25))
+      speed-measure-webpack-plugin: 1.4.2(webpack@5.106.2(postcss@8.5.26))
       tslib: 2.8.1
-      webpack-dev-server: 4.15.2(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.25))
+      webpack-dev-server: 4.15.2(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.26))
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@rspack/core'
@@ -10964,16 +10964,16 @@ snapshots:
       - webpack
       - webpack-cli
 
-  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)))(webpack@5.106.2(postcss@8.5.25))':
+  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.26)))(webpack@5.106.2(postcss@8.5.26))':
     dependencies:
       '@babel/core': 7.29.6
       '@babel/preset-env': 7.29.5(@babel/core@7.29.6)
-      babel-loader: 10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25))
+      babel-loader: 10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.26))
       bluebird: 3.7.1
       debug: 4.4.3(supports-color@8.1.1)
       lodash: 4.18.1
       semver: 7.8.1
-      webpack: 5.106.2(postcss@8.5.25)
+      webpack: 5.106.2(postcss@8.5.26)
     transitivePeerDependencies:
       - supports-color
 
@@ -13773,10 +13773,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@synthetixio/synpress@3.7.3(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(@types/react@19.2.14)(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)))(bufferutil@4.0.9)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.25))(zod@3.25.76)':
+  '@synthetixio/synpress@3.7.3(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(@types/react@19.2.14)(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.26)))(bufferutil@4.0.9)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.26))(zod@3.25.76)':
     dependencies:
-      '@cypress/code-coverage': 3.14.6(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)))(cypress@12.17.3)(webpack@5.106.2(postcss@8.5.25))
-      '@cypress/webpack-dev-server': 3.11.0(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.25))
+      '@cypress/code-coverage': 3.14.6(@babel/core@7.29.6)(@babel/preset-env@7.29.5(@babel/core@7.29.6))(babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.26)))(cypress@12.17.3)(webpack@5.106.2(postcss@8.5.26))
+      '@cypress/webpack-dev-server': 3.11.0(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.26))
       '@drptbl/gremlins.js': 2.2.1
       '@foundry-rs/easy-foundryup': 0.1.3
       '@playwright/test': 1.56.0
@@ -15563,14 +15563,14 @@ snapshots:
       semver: 7.7.3
       yargs: 17.7.2
 
-  autoprefixer@10.4.14(postcss@8.5.25):
+  autoprefixer@10.4.14(postcss@8.5.26):
     dependencies:
       browserslist: 4.26.3
       caniuse-lite: 1.0.30001749
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.5.25
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -15600,12 +15600,12 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.25)):
+  babel-loader@10.1.1(@babel/core@7.29.6)(webpack@5.106.2(postcss@8.5.26)):
     dependencies:
       '@babel/core': 7.29.6
       find-up: 5.0.0
     optionalDependencies:
-      webpack: 5.106.2(postcss@8.5.25)
+      webpack: 5.106.2(postcss@8.5.26)
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
@@ -17952,7 +17952,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.48.0
 
-  html-webpack-plugin@4.5.2(webpack@5.106.2(postcss@8.5.25)):
+  html-webpack-plugin@4.5.2(webpack@5.106.2(postcss@8.5.26)):
     dependencies:
       '@types/html-minifier-terser': 5.1.2
       '@types/tapable': 1.0.12
@@ -17963,9 +17963,9 @@ snapshots:
       pretty-error: 2.1.2
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 5.106.2(postcss@8.5.25)
+      webpack: 5.106.2(postcss@8.5.26)
 
-  html-webpack-plugin@5.6.7(webpack@5.106.2(postcss@8.5.25)):
+  html-webpack-plugin@5.6.7(webpack@5.106.2(postcss@8.5.26)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -17973,7 +17973,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.106.2(postcss@8.5.25)
+      webpack: 5.106.2(postcss@8.5.26)
 
   htmlparser2@10.1.0:
     dependencies:
@@ -18919,7 +18919,7 @@ snapshots:
       stacktrace-js: 2.0.2
       stylis: 4.3.4
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.2: {}
 
@@ -18944,7 +18944,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.29
       caniuse-lite: 1.0.30001792
-      postcss: 8.5.25
+      postcss: 8.5.26
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.6)(react@19.2.6)
@@ -19532,37 +19532,37 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.25):
+  postcss-import@15.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.25
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-js@4.0.1(postcss@8.5.25):
+  postcss-js@4.0.1(postcss@8.5.26):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.25
+      postcss: 8.5.26
 
-  postcss-load-config@4.0.2(postcss@8.5.25)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2)):
+  postcss-load-config@4.0.2(postcss@8.5.26)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
     optionalDependencies:
-      postcss: 8.5.25
+      postcss: 8.5.26
       ts-node: 10.9.2(@types/node@22.19.19)(typescript@5.9.2)
 
-  postcss-load-config@4.0.2(postcss@8.5.25)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.5.26)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
     optionalDependencies:
-      postcss: 8.5.25
+      postcss: 8.5.26
       ts-node: 10.9.2(@types/node@22.19.19)(typescript@5.9.3)
 
-  postcss-nested@6.2.0(postcss@8.5.25):
+  postcss-nested@6.2.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.25
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -19572,9 +19572,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.25:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -20423,10 +20423,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  speed-measure-webpack-plugin@1.4.2(webpack@5.106.2(postcss@8.5.25)):
+  speed-measure-webpack-plugin@1.4.2(webpack@5.106.2(postcss@8.5.26)):
     dependencies:
       chalk: 4.1.2
-      webpack: 5.106.2(postcss@8.5.25)
+      webpack: 5.106.2(postcss@8.5.26)
 
   split-on-first@1.1.0: {}
 
@@ -20723,11 +20723,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.25
-      postcss-import: 15.1.0(postcss@8.5.25)
-      postcss-js: 4.0.1(postcss@8.5.25)
-      postcss-load-config: 4.0.2(postcss@8.5.25)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
-      postcss-nested: 6.2.0(postcss@8.5.25)
+      postcss: 8.5.26
+      postcss-import: 15.1.0(postcss@8.5.26)
+      postcss-js: 4.0.1(postcss@8.5.26)
+      postcss-load-config: 4.0.2(postcss@8.5.26)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.2))
+      postcss-nested: 6.2.0(postcss@8.5.26)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
       sucrase: 3.35.0
@@ -20750,11 +20750,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.25
-      postcss-import: 15.1.0(postcss@8.5.25)
-      postcss-js: 4.0.1(postcss@8.5.25)
-      postcss-load-config: 4.0.2(postcss@8.5.25)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
-      postcss-nested: 6.2.0(postcss@8.5.25)
+      postcss: 8.5.26
+      postcss-import: 15.1.0(postcss@8.5.26)
+      postcss-js: 4.0.1(postcss@8.5.26)
+      postcss-load-config: 4.0.2(postcss@8.5.26)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      postcss-nested: 6.2.0(postcss@8.5.26)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
       sucrase: 3.35.0
@@ -20775,15 +20775,15 @@ snapshots:
       to-buffer: 1.2.2
       xtend: 4.0.2
 
-  terser-webpack-plugin@5.6.1(postcss@8.5.25)(webpack@5.106.2(postcss@8.5.25)):
+  terser-webpack-plugin@5.6.1(postcss@8.5.26)(webpack@5.106.2(postcss@8.5.26)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.106.2(postcss@8.5.25)
+      webpack: 5.106.2(postcss@8.5.26)
     optionalDependencies:
-      postcss: 8.5.25
+      postcss: 8.5.26
 
   terser@4.8.1:
     dependencies:
@@ -21340,7 +21340,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.25
+      postcss: 8.5.26
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -21355,7 +21355,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.25
+      postcss: 8.5.26
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -21501,16 +21501,16 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  webpack-dev-middleware@5.3.4(webpack@5.106.2(postcss@8.5.25)):
+  webpack-dev-middleware@5.3.4(webpack@5.106.2(postcss@8.5.26)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.6.0
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.3
-      webpack: 5.106.2(postcss@8.5.25)
+      webpack: 5.106.2(postcss@8.5.26)
 
-  webpack-dev-server@4.15.2(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.25)):
+  webpack-dev-server@4.15.2(bufferutil@4.0.9)(debug@4.4.3)(utf-8-validate@6.0.6)(webpack@5.106.2(postcss@8.5.26)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -21540,10 +21540,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.106.2(postcss@8.5.25))
+      webpack-dev-middleware: 5.3.4(webpack@5.106.2(postcss@8.5.26))
       ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
     optionalDependencies:
-      webpack: 5.106.2(postcss@8.5.25)
+      webpack: 5.106.2(postcss@8.5.26)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -21558,7 +21558,7 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.106.2(postcss@8.5.25):
+  webpack@5.106.2(postcss@8.5.26):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -21581,7 +21581,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(postcss@8.5.25)(webpack@5.106.2(postcss@8.5.25))
+      terser-webpack-plugin: 5.6.1(postcss@8.5.26)(webpack@5.106.2(postcss@8.5.26))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,7 +40,7 @@ overrides:
   'fast-uri': 3.1.5
   'sharp': 0.35.3
   'follow-redirects': 1.16.0
-  'postcss': 8.5.25
+  'postcss': 8.5.26
   'uuid': 14.0.0
   'vite@>=7.0.0 <7.3.5': 7.3.5
   'vite@>=6.0.0 <6.4.3': 6.4.3


### PR DESCRIPTION
## Summary

`audit-ci` was failing on one new advisory. Resolved by a version bump, no new allowlist entries.

## Advisories

| Advisory | Severity | Package | Strategy | Justification |
| --- | --- | --- | --- | --- |
| [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) | high | `nanoid < 3.3.17` | **Bump** | Custom generators can loop indefinitely when `size` is zero (CWE-835). `nanoid` enters the tree only via `postcss`, which we already pin with a pnpm override. `postcss@8.5.26` requires `nanoid ^3.3.17`, so bumping the existing override from `8.5.25` to `8.5.26` pulls in a patched `nanoid` (resolves to `3.3.18`) without needing a new override entry. |

## Changes

- `pnpm-workspace.yaml`: `postcss` override `8.5.25` -> `8.5.26`
- `pnpm-lock.yaml`: `nanoid` `3.3.16` -> `3.3.18`

## Notes

- `postcss@8.5.26` was published 2026-08-06, clearing the repo's 24h `minimumReleaseAge` supply-chain gate.
- No `audit-ci.jsonc` changes. All 22 existing allowlist entries are still live (none have gone stale).

## Verification

- `pnpm audit:ci` exits 0 ("Passed pnpm security audit")
- `prettier --check` passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)