### PR TITLE
fix(bridge): shrink ApeChain tx history block batch size

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -65,7 +65,7 @@ import {
 } from './useOftTransactionHistory';
 
 const BATCH_FETCH_BLOCKS: { [key: number]: number } = {
-  33139: 5_000_000, // ApeChain
+  33139: 100_000, // ApeChain
   1628: 10_000, // T-REX
   869: 10_000, // World Mobile Chain
   680: 10_000, // JASMY Chain
@@ -459,10 +459,10 @@ export async function fetchWithdrawalsInBatches(
     // for that block (~log2(latestBlock) RPCs) and use it as the lower bound
     // to skip empty pre-history.
     //
-    // Only do this when BATCH_FETCH_BLOCKS is small. On chains like ApeChain
-    // (5M batch size, ~8 total batches), the ~25 sequential probe calls cost
-    // more than they save. On Mind/T-REX (10k batch size, hundreds/thousands
-    // of batches), the savings dominate.
+    // Only do this when BATCH_FETCH_BLOCKS is small. With a batch size in the
+    // millions (~a handful of total batches), the ~25 sequential probe calls
+    // cost more than they save. On chains with a small batch size (hundreds or
+    // thousands of batches), the savings dominate.
     const SMALL_BATCH_SIZE_THRESHOLD = 100_000;
     const batchSizeIsSmall =
       typeof params.batchSizeBlocks === 'number' &&

--- a/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchBatchedWithdrawals.test.ts
+++ b/packages/arb-token-bridge-ui/src/util/withdrawals/__tests__/fetchBatchedWithdrawals.test.ts
@@ -179,7 +179,7 @@ describe.sequential('fetchWithdrawalsInBatches binary-search optimization on Orb
     fetchSpy.mockRestore();
   });
 
-  it('skips the binary search when batch size is above the threshold (e.g. ApeChain)', async () => {
+  it('skips the binary search when batch size is above the threshold', async () => {
     const latestBlock = 38_000_000;
     const provider = createMockProvider({
       chainId: JASMY_CHAIN_ID,


### PR DESCRIPTION
### Summary

Canonical ApeChain withdrawals never appear in transaction history. Selecting ApeChain in the chain filter spins for minutes, then shows nothing plus the failed-chain-pair warning.

`BATCH_FETCH_BLOCKS` gave ApeChain a 5,000,000 block batch size, but ApeChain's public RPC can't serve an `eth_getLogs` that wide. It times out server-side at 30s with `-32002 request timed out`.

`100_000` is the largest value that satisfies both constraints:

- **Upper:** measured on the same RPC, 250k ranges always succeed, 1M is past the safety margin, 2M+ always time out.
- **Lower:** `SMALL_BATCH_SIZE_THRESHOLD` is `100_000`, so anything larger disables the `findFirstBlockWithNonce` lower bound. That bound is what makes ApeChain viable: 3 batches / 5.6s with it, 460 batches / ~19 min without.

Changing to 250k only speeds it up by ~0.5s and we don't know if the rpc would further decrease the block range for `eth_getLogs`, so better keep it at 100k block range.

Also updates a comment and a test title that cited ApeChain as the example of an *above*-threshold chain, since it's now below it.

### Steps to test

Connect a wallet with an ApeChain withdrawal, open transaction history, select **ApeChain** in the chain filter. The withdrawal should appear within seconds instead of hanging.

Reference tx: [`0xb17f1969…a359740`](https://apescan.io/tx/0xb17f1969b491b3826da979c0e7b2a07130b1fe932fa003e824efa6015a359740) (74.9 USDC, ApeChain → Arbitrum One, wallet `0xf7789fa9…43ec7`)

In devtools, `eth_getLogs` requests to `apechain.calderachain.xyz` should show `fromBlock` near `0x2BA…` (bounded) rather than `0x2`, and there should be a handful of them rather than hundreds.

- Withdrawal + tx-history unit tests: 20 files / 198 tests pass (run on Node 22 per `.nvmrc`; Node 25+ gives 16 unrelated happy-dom failures)