### PR TITLE
fix(bridge): shrink Edu Chain tx history block batch size

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -66,6 +66,7 @@ import {
 
 const BATCH_FETCH_BLOCKS: { [key: number]: number } = {
   33139: 100_000, // ApeChain
+  41923: 20_000, // Edu Chain
   1628: 10_000, // T-REX
   869: 10_000, // World Mobile Chain
   680: 10_000, // JASMY Chain


### PR DESCRIPTION
Edu Chain RPC times out (504) on large `eth_getLogs` ranges, so withdrawals were missing from transaction history. This adds Edu Chain (41923) to `BATCH_FETCH_BLOCKS` with a 20k block batch size.

20k is the measured healthy ceiling for `rpc.educhain.xyz` (Cloudflare-fronted with a 10s origin timeout). Load-testing the app's exact query mix at 10 concurrent batches: