### PR TITLE
ci: fix add-orbit-chain workflow build failure

### DIFF
--- a/.github/workflows/add-orbit-chain.yml
+++ b/.github/workflows/add-orbit-chain.yml
@@ -18,19 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.ref_name }}
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
+      - uses: pnpm/setup@v2
         with:
-          node-version: '22'
-          package-manager-cache: false
+          version: 11
+          runtime: node@24
+          cache: true
+          install: false
 
       - name: Install node_modules
         uses: OffchainLabs/actions/node-modules/install@main
@@ -43,7 +41,7 @@ jobs:
 
       - name: Get issue details
         id: issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issue = await github.rest.issues.get({

--- a/.github/workflows/add-orbit-chain.yml
+++ b/.github/workflows/add-orbit-chain.yml
@@ -25,7 +25,6 @@ jobs:
 
       - uses: pnpm/setup@v2
         with:
-          version: 11
           runtime: node@24
           cache: true
           install: false

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "keywords": [],
   "author": "",
-  "packageManager": "pnpm@11.13.0",
+  "packageManager": "pnpm@11.21.0",
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
     "@headlessui/react": "^2.2.8",

--- a/packages/scripts/vite.config.ts
+++ b/packages/scripts/vite.config.ts
@@ -1,8 +1,13 @@
+import { builtinModules } from 'module';
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
   build: {
+    // these scripts only ever run in Node (see .nvmrc), not in a browser.
+    // vite's default target ('modules') includes safari14, which esbuild 0.28
+    // treats as not supporting destructuring, and it cannot lower it.
+    target: 'node22',
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
       formats: ['cjs', 'es'],
@@ -10,23 +15,21 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        // keep node builtins as real requires. otherwise vite swaps them for
+        // empty browser shims, e.g. dotenv's `os`/`crypto`, which fails
+        // silently at runtime instead of at build time.
+        ...builtinModules,
+        ...builtinModules.map((builtin) => `node:${builtin}`),
         '@actions/core',
         '@actions/github',
         'axios',
         'commander',
         'ethers',
-        'fs',
-        'path',
         'sharp',
       ],
     },
   },
   optimizeDeps: {
     exclude: ['sharp'],
-  },
-  resolve: {
-    alias: {
-      path: 'path',
-    },
   },
 });


### PR DESCRIPTION
### Summary

The Add Orbit Chain workflow has failed at the **Build scripts** step since 2026-07-03 (last green run 2026-05-28), so new Orbit chains cannot be added via the automation.

Three independent problems, one commit each:

**1. Vite build (the original failure).** esbuild 0.28 rejected vite's default `modules` target, which expands to a browser matrix including `safari14`:

```
ERROR: Transforming destructuring to the configured target
environment ("chrome87", ..., "safari14" + 2 overrides) is not supported yet
```

These scripts only run in Node, so the browser target was wrong to begin with. Set `build.target: 'node22'`. Also externalized all Node builtins, replacing a hand-maintained `fs`/`path` list. Everything else was resolving to empty browser shims that fail silently at runtime.

**2. Deprecated actions.** Every run warned that `checkout@v4` was force-run on Node 24. Bumped checkout to v7 and github-script to v8, and replaced the `action-setup` + `setup-node` pair with `pnpm/setup@v2`.

**3. pnpm install, surfaced by fixing 2.** With `pnpm/setup@v2` in place, the job failed earlier than before, at toolchain setup:

```
Downloading pnpm 11.13.0 from the npm registry
Error: ENOENT: no such file or directory, rename
'/home/runner/setup-pnpm/.unpack/@pnpm-linux-x64/package/pnpm' -> '/home/runner/setup-pnpm/pnpm'
```

The mutable `v2` tag moved from v2.0.1 to v2.0.2, which switched pnpm provisioning from GitHub releases to the npm registry ([pnpm/setup#24](https://github.com/pnpm/setup/pull/24)) and expects the native binary at `@pnpm/<platform>/package/pnpm`. Unpacking the tarballs:

| version | `@pnpm/linux-x64` contents |
| --- | --- |
| 11.13.0 | README, package.json, LICENSE, CHANGELOG (no binary) |
| 11.13.1 → 11.21.0 | includes `package/pnpm` |

11.13.0 is the last release whose platform package is a stub, and `packageManager` was pinned to exactly it. Bumped to `pnpm@11.21.0` (current `latest`).

Rejected alternatives: pinning the action to `d36251dc` (v2.0.1) works but strands this workflow on a superseded release for as long as [pnpm/setup#29](https://github.com/pnpm/setup/issues/29) stays open, and reverting to `action-setup` + `setup-node` undoes the modernization for a bug that is not in that pairing.

> [!IMPORTANT]
> Item 3 is a **repo wide toolchain bump**, not a workflow local one. The other workflows use `pnpm/action-setup@v5`, which reads `packageManager` too, so they move from 11.13.0 to 11.21.0 as well. The install is a no-op against the existing lockfile, but it changes the pnpm version for every developer and every CI job.

### Steps to test

```bash
pnpm --version                            # 11.21.0, provisioned from packageManager
pnpm install --frozen-lockfile            # lockfile up to date, pnpm-lock.yaml unchanged
pnpm --filter scripts build
node packages/scripts/dist/scripts.cjs.js --help
```

Then dispatch the workflow from this branch to verify the CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
