### PR TITLE
fix: resolve npm audit advisories

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -108,5 +108,15 @@
     // Patched version (3.0.7) is a major bump from react-use's pinned 2.x.
     // from: react-use>js-cookie
     "GHSA-qjx8-664m-686j",
+    //
+    // https://github.com/advisories/GHSA-jmr9-qjv8-65gv
+    // extract-zip does not validate symlink targets during extraction, so a malicious
+    // archive can read or write files outside the target directory (CVE-2026-56876)
+    // Reason to ignore: No patched version available (2.0.1 is the latest published
+    // version). Dev-only: cypress uses it to unpack its own binary from the official
+    // Cypress CDN, so we never extract untrusted archives. Not in production builds.
+    // from: arb-token-bridge-ui>@synthetixio/synpress>cypress>extract-zip
+    // from: arb-token-bridge-ui>cypress-terminal-report>cypress>extract-zip
+    "GHSA-jmr9-qjv8-65gv",
   ],
 }


### PR DESCRIPTION
## Summary

`pnpm audit:ci` was failing on one newly published advisory. All previously triaged advisories are unchanged and still pass.

## Advisories

| Advisory | Package | Severity | Strategy | Justification |
| --- | --- | --- | --- | --- |
| [GHSA-jmr9-qjv8-65gv](https://github.com/advisories/GHSA-jmr9-qjv8-65gv) (CVE-2026-56876) | `extract-zip` <=2.0.1 | High | Allowlist | No patched version exists (2.0.1 is still the latest published release), so neither a bump nor a pnpm override can fix it. Dev-only transitive dep of `cypress`, which uses it to unpack its own binary from the official Cypress CDN, so we never extract untrusted archives. Not present in production builds. |

Dependency paths:

```
arb-token-bridge-ui > @synthetixio/synpress > cypress > extract-zip
arb-token-bridge-ui > cypress-terminal-report > cypress > extract-zip
```

## Verification

`pnpm audit:ci` exits 0. `prettier --check audit-ci.jsonc` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)