### PR TITLE
fix: resolve npm audit advisories

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -73,6 +73,10 @@
     // decompress arbitrary file write (Zip Slip) via a symlink race on ZIP archives with duplicate paths (CVE-2026-10732)
     // No upstream fix: decompress is unmaintained, 4.2.1 is the latest published version
     //
+    // https://github.com/advisories/GHSA-jwp9-9v96-94mx
+    // decompress allows arbitrary hardlink creation via unvalidated linkname during archive extraction (CVE-2026-39243)
+    // No upstream fix: decompress is unmaintained, 4.2.1 is the latest published version
+    //
     // https://github.com/advisories/GHSA-xv26-6w52-cph6
     // websocket-driver message corruption via abuse of protocol length headers
     //
@@ -98,6 +102,7 @@
     "GHSA-64mm-vxmg-q3vj",
     "GHSA-mp2f-45pm-3cg9",
     "GHSA-h39j-r5qq-r9mm",
+    "GHSA-jwp9-9v96-94mx",
     "GHSA-xv26-6w52-cph6",
     "GHSA-mp7j-qc5w-4988",
     //


### PR DESCRIPTION
audit-ci started failing on a new advisory:

- [GHSA-jwp9-9v96-94mx](https://github.com/advisories/GHSA-jwp9-9v96-94mx) — `decompress` <=4.2.1, moderate: arbitrary hardlink creation via unvalidated `linkname` during archive extraction (CVE-2026-39243).

**Strategy: allowlist.** No patched version exists (4.2.1 is the latest published version; decompress is unmaintained). Dev-only dependency, pulled in via `@synthetixio/synpress>download>decompress` in the bridge E2E tooling; not part of production builds or runtime code. Added to the existing synpress decompress group in `audit-ci.jsonc`.

`pnpm audit:ci` now passes.