### PR TITLE
fix(bridge): testnet toggle hidden on mobile

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
@@ -546,7 +546,7 @@ export const NetworkSelectionContainer = React.memo(
           actionButtonProps={{ hidden: true }}
           isFooterHidden={true}
           className={twMerge(
-            'h-screen overflow-hidden md:h-[calc(100vh_-_220px)] md:max-h-[900px] md:max-w-[500px]',
+            'h-[100dvh] overflow-hidden md:h-[calc(100vh_-_220px)] md:max-h-[900px] md:max-w-[500px]',
             embedMode && 'md:h-full',
           )}
         >

--- a/packages/arb-token-bridge-ui/src/components/common/SearchPanel/SearchPanelTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/SearchPanel/SearchPanelTable.tsx
@@ -62,7 +62,7 @@ export const SearchPanelTable = ({
       )}
       <div
         className={twMerge(
-          'sm:shadow-search-panel h-[calc(100vh_-_200px)] rounded',
+          'sm:shadow-search-panel h-[calc(100dvh_-_200px)] rounded',
           isDialog ? 'md:max-h-[700px]' : 'md:max-h-[400px]',
           embedMode ? 'h-[calc(100vh_-_150px)]' : 'md:h-[calc(100vh_-_390px)] min-h-[180px]',
         )}


### PR DESCRIPTION
On mobile, the network selection dialog is sized with `100vh`, which on mobile browsers is the large viewport (as if the URL bar were collapsed). The footer holding the testnet toggle ended up behind the browser's bottom bar, so users couldn't enable testnet mode.

This switches the dialog and the shared search list height to `dvh`, which tracks the visible viewport. The toggle now sits inside the visible area and is tappable.

Tested locally at a 390x844 viewport: the toggle is visible at the bottom of the dialog and switching it on loads the testnet networks.