### PR TITLE
chore: update RecycleFarm withdrawal time to 70 mins

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/orbitChainsData.json
+++ b/packages/arb-token-bridge-ui/src/util/orbitChainsData.json
@@ -1787,7 +1787,7 @@
           "symbol": "tRCF",
           "logoUrl": "/images/RECYCLEFARMCarbonNetworkTestnet_NativeTokenLogo.png"
         },
-        "fastWithdrawalTime": 900000
+        "fastWithdrawalTime": 4200000
       }
     }
   ]


### PR DESCRIPTION
Updates `fastWithdrawalTime` for RECYCLEFARM Carbon Network Testnet (chainId 787878) from 15 minutes to 70 minutes.

The 15-minute value was based on a misreading of `confirmPeriodBlocks`. The chain operator has since tuned batch and assertion posting and measured real end-to-end withdrawal times of 61-66 minutes, and requested 70 minutes as the advertised value. The bridge UI will display this as ~1 hour.