### PR TITLE
feat(bridge): improve tx history search analytics

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistorySearchBar.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistorySearchBar.tsx
@@ -160,7 +160,6 @@ export function TransactionHistorySearchBar() {
           return;
         }
 
-        // resubmitting the same hash (enter, blur) is not a new search
         if (isNewSearch(searchInput, sanitizedTxHash)) {
           trackEvent('Search Tx for Tx Hash Click', { isTestnetMode });
         }
@@ -175,7 +174,6 @@ export function TransactionHistorySearchBar() {
         return;
       }
 
-      // resubmitting the same address (enter, blur) is not a new search
       if (isNewSearch(searchInput, sanitizedAddress)) {
         trackEvent('Search Tx for Address Click', {
           isTestnetMode,

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistorySearchBar.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistorySearchBar.tsx
@@ -102,6 +102,10 @@ export function useTxHashSearchState() {
   };
 }
 
+function isNewSearch(searchInput: string, currentSearchValue: string | undefined) {
+  return searchInput.toLowerCase() !== currentSearchValue?.toLowerCase();
+}
+
 export function TransactionHistorySearchBar() {
   const {
     address,
@@ -157,7 +161,7 @@ export function TransactionHistorySearchBar() {
         }
 
         // resubmitting the same hash (enter, blur) is not a new search
-        if (searchInput.toLowerCase() !== sanitizedTxHash?.toLowerCase()) {
+        if (isNewSearch(searchInput, sanitizedTxHash)) {
           trackEvent('Search Tx for Tx Hash Click', { isTestnetMode });
         }
 
@@ -172,7 +176,7 @@ export function TransactionHistorySearchBar() {
       }
 
       // resubmitting the same address (enter, blur) is not a new search
-      if (searchInput.toLowerCase() !== sanitizedAddress?.toLowerCase()) {
+      if (isNewSearch(searchInput, sanitizedAddress)) {
         trackEvent('Search Tx for Address Click', {
           isTestnetMode,
           isConnectedAddress: searchInput.toLowerCase() === connectedAddress?.toLowerCase(),

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistorySearchBar.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistorySearchBar.tsx
@@ -107,6 +107,8 @@ export function TransactionHistorySearchBar() {
     address,
     searchMode,
     searchError,
+    sanitizedAddress,
+    sanitizedTxHash,
     setAddress,
     setSanitizedAddress,
     setSanitizedTxHash,
@@ -117,6 +119,8 @@ export function TransactionHistorySearchBar() {
       address: state.address,
       searchMode: state.searchMode,
       searchError: state.searchError,
+      sanitizedAddress: state.sanitizedAddress,
+      sanitizedTxHash: state.sanitizedTxHash,
       setAddress: state.setAddress,
       setSanitizedAddress: state.setSanitizedAddress,
       setSanitizedTxHash: state.setSanitizedTxHash,
@@ -152,7 +156,10 @@ export function TransactionHistorySearchBar() {
           return;
         }
 
-        trackEvent('Search Tx for Tx Hash Click', { isTestnetMode });
+        // resubmitting the same hash (enter, blur) is not a new search
+        if (searchInput.toLowerCase() !== sanitizedTxHash?.toLowerCase()) {
+          trackEvent('Search Tx for Tx Hash Click', { isTestnetMode });
+        }
 
         setSanitizedTxHash(searchInput);
         setSearchError(undefined);
@@ -164,10 +171,13 @@ export function TransactionHistorySearchBar() {
         return;
       }
 
-      trackEvent('Search Tx for Address Click', {
-        isTestnetMode,
-        isConnectedAddress: searchInput.toLowerCase() === connectedAddress?.toLowerCase(),
-      });
+      // resubmitting the same address (enter, blur) is not a new search
+      if (searchInput.toLowerCase() !== sanitizedAddress?.toLowerCase()) {
+        trackEvent('Search Tx for Address Click', {
+          isTestnetMode,
+          isConnectedAddress: searchInput.toLowerCase() === connectedAddress?.toLowerCase(),
+        });
+      }
 
       setSanitizedAddress(searchInput);
       setSearchError(undefined);
@@ -175,6 +185,8 @@ export function TransactionHistorySearchBar() {
     [
       address,
       searchMode,
+      sanitizedAddress,
+      sanitizedTxHash,
       setSanitizedAddress,
       setSanitizedTxHash,
       setSearchError,

--- a/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTransactionHistory.ts
@@ -32,6 +32,7 @@ import { useCctpFetching } from '../state/cctpState';
 import { ChainId } from '../types/ChainId';
 import { Transaction } from '../types/Transactions';
 import { Address, addressesEqual, findFirstBlockWithNonce, getNonce } from '../util/AddressUtils';
+import { trackEvent } from '../util/AnalyticsUtils';
 import { backOff } from '../util/ExponentialBackoffUtils';
 import { captureSentryErrorWithExtraData } from '../util/SentryUtils';
 import { shouldIncludeReceivedTxs, shouldIncludeSentTxs } from '../util/SubgraphUtils';
@@ -811,6 +812,8 @@ const useTransactionHistoryWithoutStatuses = (
   };
 };
 
+const trackedTxHashSearches = new Set<string>();
+
 /**
  * Resolves a source chain tx hash directly from its receipt instead of
  * fetching the full address history, so it stays fast on chains where that
@@ -871,22 +874,32 @@ function useTransactionHistoryByTxHash(chainFilter: TxHistoryChainFilter) {
         ),
       );
 
-      return (
-        transactions
-          .filter((tx): tx is MergedTransaction => tx !== null)
-          // CCTP/OFT/LiFi lookups are not chain-pair scoped, so apply the
-          // chain filter to their results, same as the address history does
-          .filter((tx) =>
-            isCctpTransfer(tx) || isOftTransfer(tx) || isLifiTransfer(tx)
-              ? matchesChainFilter({
-                  filter: chainFilter,
-                  sourceChainId: tx.sourceChainId,
-                  destinationChainId: tx.destinationChainId,
-                })
-              : true,
-          )
-          .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
-      );
+      const results = transactions
+        .filter((tx): tx is MergedTransaction => tx !== null)
+        // CCTP/OFT/LiFi lookups are not chain-pair scoped, so apply the
+        // chain filter to their results, same as the address history does
+        .filter((tx) =>
+          isCctpTransfer(tx) || isOftTransfer(tx) || isLifiTransfer(tx)
+            ? matchesChainFilter({
+                filter: chainFilter,
+                sourceChainId: tx.sourceChainId,
+                destinationChainId: tx.destinationChainId,
+              })
+            : true,
+        )
+        .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+
+      // once per hash, so refetches and status polls do not count again
+      if (!trackedTxHashSearches.has(_txHash)) {
+        trackedTxHashSearches.add(_txHash);
+        trackEvent('Tx Hash Search Result', {
+          found: results.length > 0,
+          sourceChainId: results[0]?.sourceChainId,
+          isTestnetMode: _isTestnetMode,
+        });
+      }
+
+      return results;
     },
     {
       shouldRetryOnError: false,

--- a/packages/arb-token-bridge-ui/src/util/AnalyticsUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AnalyticsUtils.ts
@@ -73,6 +73,11 @@ type AnalyticsEventMap = {
   'Search Tx for Tx Hash Click': {
     isTestnetMode: boolean;
   };
+  'Tx Hash Search Result': {
+    found: boolean;
+    sourceChainId?: number;
+    isTestnetMode: boolean;
+  };
   'Tx History Network Filter': { network: string };
   'Tx Error: Get Help Click': {
     network: string;


### PR DESCRIPTION
Follow up to #464, based on the first two days of usage data.

- Search click events fire only when the submitted value changes. Enter and click-out resubmits of the same input were inflating per user counts.
- Adds a Tx Hash Search Result event with found, sourceChainId and isTestnetMode, tracked once per hash. This tells us the hit rate, which chains people search, and how often searches dead-end on the chain filter.

Testing: lint and unit tests pass. No behavior change outside analytics.