### PR TITLE
fix(bridge): select OFT transfer log by emitter

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.integration.test.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.integration.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 
 import { LayerZeroTransaction } from '../state/app/state';
 import { ChainId } from '../types/ChainId';
-import { addressesEqual } from '../util/AddressUtils';
 import { CommonAddress } from '../util/CommonAddressUtils';
 import { AssetType } from './arbTokenBridge.types';
 import { updateAdditionalLayerZeroData } from './useOftTransactionHistory';
@@ -13,6 +12,7 @@ import { updateAdditionalLayerZeroData } from './useOftTransactionHistory';
 // is what makes EIP-7708 prepend a protocol Transfer log to this receipt after Glamsterdam.
 const USDT0_SEND_TX = '0xb7ccb326d0b383eea44343a60e6f0563c7a7e0a5d3b96696ea39bb7cf76fe3ad';
 const USDT0_SEND_BLOCK = 25799541;
+const USDT0_SEND_DESTINATION = '0x36d16e71d630ba8c5bfb7ac8a459aebdac1276aa';
 const USDT_AMOUNT = '2500.0';
 // what the amount would read as if the ETH fee were decoded as USDT instead
 const ETH_FEE_AS_USDT = '37964723.338644';
@@ -37,7 +37,7 @@ const transaction = {
   sourceChainId: ChainId.Ethereum,
   destinationChainId: ChainId.ArbitrumOne,
   destinationTxHash: null,
-} as LayerZeroTransaction;
+} satisfies LayerZeroTransaction;
 
 describe('updateAdditionalLayerZeroData against a real USDT0 transfer', () => {
   it('resolves the transferred token amount from the live receipt', async () => {
@@ -46,10 +46,8 @@ describe('updateAdditionalLayerZeroData against a real USDT0 transfer', () => {
     expect(result.value).toBe(USDT_AMOUNT);
     expect(result.value).not.toBe(ETH_FEE_AS_USDT);
     expect(result.asset).toBe('USDT');
-    expect(addressesEqual(result.tokenAddress ?? undefined, CommonAddress.Ethereum.USDT)).toBe(
-      true,
-    );
+    expect(result.tokenAddress).toBe(utils.getAddress(CommonAddress.Ethereum.USDT));
     expect(result.blockNum).toBe(USDT0_SEND_BLOCK);
-    expect(utils.isAddress(result.destination ?? '')).toBe(true);
+    expect(result.destination).toBe(USDT0_SEND_DESTINATION);
   });
 });

--- a/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.integration.test.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.integration.test.ts
@@ -1,0 +1,55 @@
+import { utils } from 'ethers';
+import { describe, expect, it } from 'vitest';
+
+import { LayerZeroTransaction } from '../state/app/state';
+import { ChainId } from '../types/ChainId';
+import { addressesEqual } from '../util/AddressUtils';
+import { CommonAddress } from '../util/CommonAddressUtils';
+import { AssetType } from './arbTokenBridge.types';
+import { updateAdditionalLayerZeroData } from './useOftTransactionHistory';
+
+// Runs against a real Ethereum mainnet USDT0 send, so the log lookup is exercised on a
+// real receipt rather than a fixture. The tx carries a LayerZero fee as msg.value, which
+// is what makes EIP-7708 prepend a protocol Transfer log to this receipt after Glamsterdam.
+const USDT0_SEND_TX = '0xb7ccb326d0b383eea44343a60e6f0563c7a7e0a5d3b96696ea39bb7cf76fe3ad';
+const USDT0_SEND_BLOCK = 25799541;
+const USDT_AMOUNT = '2500.0';
+// what the amount would read as if the ETH fee were decoded as USDT instead
+const ETH_FEE_AS_USDT = '37964723.338644';
+
+const transaction = {
+  isOft: true,
+  sender: '0x36d16e71d630ba8c5bfb7ac8a459aebdac1276aa',
+  direction: 'deposit',
+  status: 'success',
+  createdAt: 1,
+  resolvedAt: null,
+  txId: USDT0_SEND_TX,
+  asset: 'USDT',
+  assetType: AssetType.ERC20,
+  value: '0',
+  uniqueId: null,
+  isWithdrawal: false,
+  blockNum: null,
+  tokenAddress: CommonAddress.Ethereum.USDT,
+  childChainId: ChainId.ArbitrumOne,
+  parentChainId: ChainId.Ethereum,
+  sourceChainId: ChainId.Ethereum,
+  destinationChainId: ChainId.ArbitrumOne,
+  destinationTxHash: null,
+} as LayerZeroTransaction;
+
+describe('updateAdditionalLayerZeroData against a real USDT0 transfer', () => {
+  it('resolves the transferred token amount from the live receipt', async () => {
+    const result = await updateAdditionalLayerZeroData(transaction);
+
+    expect(result.value).toBe(USDT_AMOUNT);
+    expect(result.value).not.toBe(ETH_FEE_AS_USDT);
+    expect(result.asset).toBe('USDT');
+    expect(addressesEqual(result.tokenAddress ?? undefined, CommonAddress.Ethereum.USDT)).toBe(
+      true,
+    );
+    expect(result.blockNum).toBe(USDT0_SEND_BLOCK);
+    expect(utils.isAddress(result.destination ?? '')).toBe(true);
+  });
+});

--- a/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.test.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.test.ts
@@ -1,0 +1,129 @@
+import { BigNumber, utils } from 'ethers';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LayerZeroTransaction } from '../state/app/state';
+import { ChainId } from '../types/ChainId';
+import { addressesEqual } from '../util/AddressUtils';
+import { CommonAddress } from '../util/CommonAddressUtils';
+import { AssetType } from './arbTokenBridge.types';
+import { updateAdditionalLayerZeroData } from './useOftTransactionHistory';
+
+// tests in this package run concurrently, so receipts are keyed by tx id rather than
+// swapping a shared mock return value
+const { receipts } = vi.hoisted(() => ({ receipts: new Map<string, unknown>() }));
+
+vi.mock('../token-bridge-sdk/utils', () => ({
+  getProviderForChainId: () => ({
+    getTransactionReceipt: (txId: string) => Promise.resolve(receipts.get(txId)),
+  }),
+}));
+
+vi.mock('../token-bridge-sdk/oftUtils', () => ({
+  getChainIdFromEid: (eid: number) => eid,
+  getOftV2TransferDecodedData: () =>
+    Promise.resolve([
+      [30110, '0x000000000000000000000000deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'],
+    ]),
+}));
+
+vi.mock('../util/TokenUtils', () => ({
+  fetchErc20Data: () => Promise.resolve({ symbol: 'USDT', decimals: 6 }),
+}));
+
+const SYSTEM_ADDRESS = '0xfffffffffffffffffffffffffffffffffffffffe';
+const SENDER = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+const USDT_OFT_ADAPTER = '0x6c96de32cea08842dcc4058c14d3aaad7fa41dee';
+const TRANSFER_TOPIC = utils.id('Transfer(address,address,uint256)');
+
+const TOKEN_AMOUNT = 1_500_000; // 1.5 USDT at 6 decimals
+const ETH_FEE = utils.parseEther('0.0025');
+
+function transferLog({ address, amount }: { address: string; amount: BigNumber | number }) {
+  return {
+    address,
+    topics: [TRANSFER_TOPIC, utils.hexZeroPad(SENDER, 32), utils.hexZeroPad(USDT_OFT_ADAPTER, 32)],
+    data: utils.hexZeroPad(BigNumber.from(amount).toHexString(), 32),
+  };
+}
+
+const protocolEthTransferLog = transferLog({ address: SYSTEM_ADDRESS, amount: ETH_FEE });
+const usdtTransferLog = transferLog({
+  address: CommonAddress.Ethereum.USDT,
+  amount: TOKEN_AMOUNT,
+});
+
+function oftTransaction(
+  txId: string,
+  logs: unknown[],
+  tokenAddress: string = CommonAddress.Ethereum.USDT,
+): LayerZeroTransaction {
+  receipts.set(txId, { blockNumber: 100, logs });
+
+  return {
+    isOft: true,
+    sender: SENDER,
+    direction: 'deposit',
+    status: 'pending',
+    createdAt: 1,
+    resolvedAt: null,
+    txId,
+    asset: 'USDT',
+    assetType: AssetType.ERC20,
+    value: '0',
+    uniqueId: null,
+    isWithdrawal: false,
+    blockNum: null,
+    tokenAddress,
+    childChainId: ChainId.ArbitrumOne,
+    parentChainId: ChainId.Ethereum,
+    sourceChainId: ChainId.Ethereum,
+    destinationChainId: ChainId.ArbitrumOne,
+    destinationTxHash: null,
+  } as LayerZeroTransaction;
+}
+
+describe('updateAdditionalLayerZeroData', () => {
+  it('reads the token transfer when a protocol ETH transfer log is emitted first', async () => {
+    const tx = oftTransaction('0xaa', [protocolEthTransferLog, usdtTransferLog]);
+
+    const result = await updateAdditionalLayerZeroData(tx);
+
+    expect(result.value).toBe('1.5');
+    expect(result.asset).toBe('USDT');
+    expect(addressesEqual(result.tokenAddress ?? undefined, CommonAddress.Ethereum.USDT)).toBe(
+      true,
+    );
+    expect(result.blockNum).toBe(100);
+  });
+
+  it('reads the token transfer when it is the only log in the receipt', async () => {
+    const tx = oftTransaction('0xbb', [usdtTransferLog]);
+
+    const result = await updateAdditionalLayerZeroData(tx);
+
+    expect(result.value).toBe('1.5');
+  });
+
+  it('reads the token transfer on the withdrawal side, where the token is the Arbitrum USDT', async () => {
+    const arbitrumUsdtTransferLog = transferLog({
+      address: CommonAddress.ArbitrumOne.USDT,
+      amount: TOKEN_AMOUNT,
+    });
+    const tx = oftTransaction('0xdd', [arbitrumUsdtTransferLog], CommonAddress.ArbitrumOne.USDT);
+
+    const result = await updateAdditionalLayerZeroData(tx);
+
+    expect(result.value).toBe('1.5');
+    expect(addressesEqual(result.tokenAddress ?? undefined, CommonAddress.ArbitrumOne.USDT)).toBe(
+      true,
+    );
+  });
+
+  it('throws when the receipt has no transfer log for the token', async () => {
+    const tx = oftTransaction('0xcc', [protocolEthTransferLog]);
+
+    await expect(updateAdditionalLayerZeroData(tx)).rejects.toThrow(
+      'No token transfer log found for OFT transaction',
+    );
+  });
+});

--- a/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.test.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { LayerZeroTransaction } from '../state/app/state';
 import { ChainId } from '../types/ChainId';
-import { addressesEqual } from '../util/AddressUtils';
 import { CommonAddress } from '../util/CommonAddressUtils';
 import { AssetType } from './arbTokenBridge.types';
 import { updateAdditionalLayerZeroData } from './useOftTransactionHistory';
@@ -79,7 +78,7 @@ function oftTransaction(
     sourceChainId: ChainId.Ethereum,
     destinationChainId: ChainId.ArbitrumOne,
     destinationTxHash: null,
-  } as LayerZeroTransaction;
+  } satisfies LayerZeroTransaction;
 }
 
 describe('updateAdditionalLayerZeroData', () => {
@@ -90,9 +89,7 @@ describe('updateAdditionalLayerZeroData', () => {
 
     expect(result.value).toBe('1.5');
     expect(result.asset).toBe('USDT');
-    expect(addressesEqual(result.tokenAddress ?? undefined, CommonAddress.Ethereum.USDT)).toBe(
-      true,
-    );
+    expect(result.tokenAddress).toBe(CommonAddress.Ethereum.USDT);
     expect(result.blockNum).toBe(100);
   });
 
@@ -114,9 +111,7 @@ describe('updateAdditionalLayerZeroData', () => {
     const result = await updateAdditionalLayerZeroData(tx);
 
     expect(result.value).toBe('1.5');
-    expect(addressesEqual(result.tokenAddress ?? undefined, CommonAddress.ArbitrumOne.USDT)).toBe(
-      true,
-    );
+    expect(result.tokenAddress).toBe(CommonAddress.ArbitrumOne.USDT);
   });
 
   it('throws when the receipt has no transfer log for the token', async () => {

--- a/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useOftTransactionHistory.ts
@@ -4,6 +4,7 @@ import useSWRImmutable from 'swr/immutable';
 import { LayerZeroTransaction } from '../state/app/state';
 import { getChainIdFromEid, getOftV2TransferDecodedData } from '../token-bridge-sdk/oftUtils';
 import { getProviderForChainId } from '../token-bridge-sdk/utils';
+import { addressesEqual } from '../util/AddressUtils';
 import { CommonAddress } from '../util/CommonAddressUtils';
 import { fetchErc20Data } from '../util/TokenUtils';
 import { isDepositMode } from '../util/isDepositMode';
@@ -224,7 +225,7 @@ function mapLayerZeroMessageToLayerZeroTransaction(
 export async function updateAdditionalLayerZeroData(
   tx: LayerZeroTransaction,
 ): Promise<LayerZeroTransaction> {
-  const { txId } = tx;
+  const { txId, tokenAddress } = tx;
   const updatedTx = { ...tx };
 
   const sourceChainProvider = getProviderForChainId(tx.sourceChainId);
@@ -233,12 +234,26 @@ export async function updateAdditionalLayerZeroData(
   const decodedInputData = await getOftV2TransferDecodedData(txId, sourceChainProvider);
   updatedTx.destination = utils.hexValue(decodedInputData[0][1]);
 
-  // extract token and value
-  const sourceChainTxReceipt = await sourceChainProvider.getTransactionReceipt(txId);
-  const tokenAddress = sourceChainTxReceipt.logs[0]?.address;
-
   if (!tokenAddress) {
     throw new Error('No token address found for OFT transaction');
+  }
+
+  // extract value
+  const sourceChainTxReceipt = await sourceChainProvider.getTransactionReceipt(txId);
+
+  const transferInterface = new ethers.utils.Interface([
+    'event Transfer(address indexed from, address indexed to, uint value)',
+  ]);
+
+  // EIP-7708 makes the protocol emit Transfer logs from the system address, so match on the emitter
+  const transferLog = sourceChainTxReceipt.logs.find(
+    (log) =>
+      log.topics[0] === transferInterface.getEventTopic('Transfer') &&
+      addressesEqual(log.address, tokenAddress),
+  );
+
+  if (!transferLog) {
+    throw new Error('No token transfer log found for OFT transaction');
   }
 
   const { symbol, decimals } = await fetchErc20Data({
@@ -246,16 +261,13 @@ export async function updateAdditionalLayerZeroData(
     provider: sourceChainProvider,
   });
 
-  const transferInterface = new ethers.utils.Interface([
-    'event Transfer(address indexed from, address indexed to, uint value)',
-  ]);
-  const decodedTransferLogs = transferInterface.parseLog(sourceChainTxReceipt.logs[0]!);
+  const decodedTransferLog = transferInterface.parseLog(transferLog);
 
   return {
     ...updatedTx,
     asset: symbol,
-    tokenAddress,
-    value: ethers.utils.formatUnits(decodedTransferLogs.args.value, decimals).toString(),
+    tokenAddress: transferLog.address,
+    value: ethers.utils.formatUnits(decodedTransferLog.args.value, decimals).toString(),
     blockNum: sourceChainTxReceipt.blockNumber,
   };
 }


### PR DESCRIPTION
USDT0 transaction history read `receipt.logs[0]` and assumed it was the token's `Transfer` event. EIP-7708 adds protocol ETH transfer logs ahead of the EVM logs, so that position will point at the wrong entry once Glamsterdam ships. The protocol log has the same shape as an ERC20 `Transfer`, so it decodes fine and silently yields the ETH fee as the transfer amount.

Now matches on the token address and the `Transfer` topic instead of the position.

No behaviour change today. On current receipts the returned values are identical, verified by running the integration test against both the old and new code.

Tests:

- unit test with a protocol ETH transfer log prepended to the receipt (fails on the old code with `2500000000.0` instead of `1.5`)
- integration test against a real mainnet USDT0 send

FS-2552
