### PR TITLE
fix(portal): keep project panel open on deeplink

### DIFF
--- a/packages/portal/components/SidePanel.tsx
+++ b/packages/portal/components/SidePanel.tsx
@@ -17,7 +17,7 @@ export const SidePanel = ({
   panelClassName,
 }: SidePanelProps) => {
   return (
-    <Dialog open={isOpen} onClose={onClose} className="fixed z-[1001]">
+    <Dialog open={isOpen} onClose={onClose} className="fixed inset-0 z-[1001]">
       {/* The backdrop, rendered as a fixed sibling to the panel container */}
       <div className="fixed inset-0 bg-black opacity-80" aria-hidden="true" />
 


### PR DESCRIPTION
Opening a project deeplink like `/projects?project=vault777` showed the panel briefly, then it closed and the `project` param was dropped from the URL.

Headless UI v2 watches the Dialog root element and calls `onClose` when its bounding rect is exactly `0,0,0,0`, assuming the dialog was removed. Our `SidePanel` root is `fixed` with only `fixed` children, so it has no box of its own. On a deeplink it is measured during hydration, before the page has any height, so all four values are zero and the dialog closes itself. Clicking a project works only because by then the portal root sits lower on the page, so `y` is non-zero.

Giving the root `inset-0` fixes it. No visual change since the backdrop and panel container are already full-viewport.

Verified in Chrome against production: with `inset: 0` injected on the dialog root the panel stays open and no navigation fires.