### PR TITLE
ci(monitoring): make monitor runs configurable

### DIFF
--- a/.github/workflows/assertion-monitor.yml
+++ b/.github/workflows/assertion-monitor.yml
@@ -2,12 +2,19 @@ name: Assertion Monitor
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag or SHA to run against'
+        required: false
+        default: master
+        type: string
   schedule:
     - cron: '0 */6 * * *' # Run every 6 hours
 
 jobs:
   run-monitoring:
     name: Assertion Monitor (${{ matrix.chain == 'orbit' && 'Orbit' || matrix.chain == 'core' && 'Core' || matrix.chain == 'enterprise' && 'Enterprise' || matrix.chain }})
+    if: vars.RUN_ASSERTION_MONITOR == 'true'
     strategy:
       matrix:
         chain: [core, orbit, enterprise]
@@ -15,4 +22,5 @@ jobs:
     with:
       chain: ${{ matrix.chain }}
       monitor: assertion
+      ref: ${{ inputs.ref || 'master' }}
     secrets: inherit

--- a/.github/workflows/batch-poster-monitor.yml
+++ b/.github/workflows/batch-poster-monitor.yml
@@ -2,12 +2,19 @@ name: Batch Poster Monitor
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag or SHA to run against'
+        required: false
+        default: master
+        type: string
   schedule:
     - cron: '0 */6 * * *' # Run every 6 hours
 
 jobs:
   run-monitoring:
     name: Batch Poster Monitor (${{ matrix.chain == 'orbit' && 'Orbit' || matrix.chain == 'core' && 'Core' || matrix.chain == 'enterprise' && 'Enterprise' || matrix.chain }})
+    if: vars.RUN_BATCH_POSTER_MONITOR == 'true'
     strategy:
       matrix:
         chain: [core, orbit, enterprise]
@@ -15,4 +22,5 @@ jobs:
     with:
       chain: ${{ matrix.chain }}
       monitor: batch-poster
+      ref: ${{ inputs.ref || 'master' }}
     secrets: inherit

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -9,6 +9,10 @@ on:
       monitor:
         required: true
         type: string
+      ref:
+        required: false
+        type: string
+        default: master
 
 env:
   NEXT_PUBLIC_RPC_PROVIDER: alchemy
@@ -27,6 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: OffchainLabs/arbitrum-portal
+          ref: ${{ inputs.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5
@@ -73,7 +78,7 @@ jobs:
         run: cp ./packages/arb-token-bridge-ui/public/${{ steps.config.outputs.config_file }} ./arbitrum-monitoring/config.json
 
       - name: Run monitoring command
-        run: cd ./arbitrum-monitoring && pnpm ${{ inputs.monitor }}-monitor --enableAlerting --writeToNotion ${{ inputs.chain == 'core' && 'true' || 'false' }} ${{ inputs.monitor == 'retryable' && '--autoRedeem' || '' }}
+        run: cd ./arbitrum-monitoring && pnpm ${{ inputs.monitor }}-monitor --enableAlerting --writeToNotion ${{ (inputs.chain == 'core' || inputs.chain == 'enterprise') && 'true' || 'false' }} ${{ inputs.monitor == 'retryable' && '--autoRedeem' || '' }}
         env:
           RETRYABLE_MONITORING_SLACK_TOKEN: ${{ secrets[steps.config.outputs.slack_token] }}
           RETRYABLE_MONITORING_SLACK_CHANNEL: ${{ secrets[steps.config.outputs.slack_channel] }}

--- a/.github/workflows/retryable-monitor.yml
+++ b/.github/workflows/retryable-monitor.yml
@@ -2,12 +2,19 @@ name: Retryable Monitor
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag or SHA to run against'
+        required: false
+        default: master
+        type: string
   schedule:
     - cron: '3 8 * * *' # Run once a day at 08:03am GMT
 
 jobs:
   run-retryable-monitoring:
     name: Retryable Monitor (${{ matrix.chain == 'orbit' && 'Orbit' || matrix.chain == 'core' && 'Core' || matrix.chain == 'enterprise' && 'Enterprise' || matrix.chain }})
+    if: vars.RUN_RETRYABLE_MONITOR == 'true'
     strategy:
       matrix:
         chain: [core, orbit, enterprise]
@@ -15,4 +22,5 @@ jobs:
     with:
       chain: ${{ matrix.chain }}
       monitor: retryable
+      ref: ${{ inputs.ref || 'master' }}
     secrets: inherit


### PR DESCRIPTION
Small monitoring workflow cleanup:

- Each monitor workflow is now toggled by a repo variable (`RUN_<MONITOR>_MONITOR`), so runs can be enabled or paused without editing the workflow.
- Manual runs accept a `ref` input to point the monitor at a specific branch (defaults to `master`).
- Notion sync is enabled for enterprise chains, matching core.